### PR TITLE
Fix chroma wheel startup race condition when Rose attaches in champ select

### DIFF
--- a/Pengu Loader/plugins/ROSE-ChromaWheel/index.js
+++ b/Pengu Loader/plugins/ROSE-ChromaWheel/index.js
@@ -29,7 +29,8 @@
   // Track selected chroma for button color update (controlled by Python)
   let selectedChromaData = null; // { id, primaryColor, colors, name }
   let pythonChromaState = null; // { selectedChromaId, chromaColor, chromaColors, currentSkinId }
-  let championLocked = false; // Track if a champion is locked
+  let championLocked = false; // Track if a champion is locked 
+  let currentPhase = null; // Track the last observed phase so startup replays do not look like a new session
 
   /**
    * Escape HTML special characters to prevent XSS (CWE-79)
@@ -789,18 +790,43 @@
     updateChromaButtonColor();
   }
 
+  function resetFrontendSessionState(reason) {
+    // Clear transient frontend state only when a Champ Select session really starts/ends.
+    skinMonitorState = null;
+    pythonChromaState = null;
+    selectedChromaData = null;
+    championLocked = false;
+
+    // Remove stale UI that may still be attached from the previous session.
+    const existingPanel = document.getElementById(PANEL_ID);
+    if (existingPanel) {
+      existingPanel.remove();
+    }
+
+    document.querySelectorAll(BUTTON_SELECTOR).forEach((button) => {
+      button.remove();
+    });
+
+    emitBridgeLog("session_state_reset", { reason });
+  }
+
   function handlePhaseChangeFromPython(data) {
     // Use Python-detected game mode to drive ARAM detection for the JS panel
     try {
       const phase = data.phase;
       const gameMode = data.gameMode;
       const mapId = data.mapId;
+      // Late startup can replay "ChampSelect" after skin-state is already current.
+      // Keep the last seen phase so we only reset on real phase transitions.
+      const previousPhase = currentPhase;
+      currentPhase = phase;
 
       if (phase === "ChampSelect") {
-        // Reset stale skin state from previous game so the chroma button
-        // doesn't briefly show the old champion's data at lock-in
-        skinMonitorState = null;
-        pythonChromaState = null;
+        // Only reset on a real transition into a new Champ Select session.
+        // Startup replays can arrive after a valid skin-state payload.
+        if (previousPhase && previousPhase !== "ChampSelect") {
+          resetFrontendSessionState("phase-entry");
+        }
 
         const isAram =
           mapId === 12 ||
@@ -815,6 +841,12 @@
         isAramFromPython = Boolean(isAram);
       } else {
         // Leaving champ select / finalization – clear flag
+        if (
+          previousPhase === "ChampSelect" ||
+          previousPhase === "FINALIZATION"
+        ) {
+          resetFrontendSessionState("phase-exit");
+        }
         isAramFromPython = false;
       }
     } catch (e) {
@@ -1779,6 +1811,33 @@
     return button.closest(".skin-selection-item, .thumbnail-wrapper");
   }
 
+  function hasConfirmedLockedSkinState(state = skinMonitorState) {
+    return Boolean(
+      state &&
+      Number.isFinite(state.skinId) &&
+      state.skinId > 0 &&
+      Number.isFinite(state.championId) &&
+      state.championId > 0
+    );
+  }
+
+  function maybeInferChampionLockedFromSkinState(state = skinMonitorState) {
+    if (championLocked || !hasConfirmedLockedSkinState(state)) {
+      return;
+    }
+
+    championLocked = true;
+    log.info(
+      `[ChromaWheel] Inferred champion lock from skin state (champion=${state.championId}, skin=${state.skinId})`
+    );
+
+    setTimeout(() => {
+      if (typeof scanSkinSelection === "function") {
+        scanSkinSelection();
+      }
+    }, 0);
+  }
+
   function handleChampionLocked(data) {
     const wasLocked = championLocked;
     championLocked = data.locked === true;
@@ -1814,7 +1873,8 @@
     const isSwiftplay =
       skinItem.classList.contains("thumbnail-wrapper") &&
       skinItem.classList.contains("active-skin");
-    if (!championLocked && !isSwiftplay) {
+    const lockConfirmed = championLocked || hasConfirmedLockedSkinState();
+    if (!lockConfirmed && !isSwiftplay) {
       // Remove existing button if champion is not locked (and not Swiftplay)
       const existingButton = skinItem.querySelector(BUTTON_SELECTOR);
       if (existingButton) {
@@ -3682,6 +3742,7 @@
 
     if (window.__roseSkinState) {
       skinMonitorState = window.__roseSkinState;
+      maybeInferChampionLockedFromSkinState(skinMonitorState);
 
       // Warm champion data up front so button visibility can recover even if
       // the first skin-state payload reports hasChromas=false before caches settle.
@@ -3731,6 +3792,7 @@
       emitBridgeLog("skin_state_update", detail || {});
       const prevState = skinMonitorState;
       skinMonitorState = detail || null;
+      maybeInferChampionLockedFromSkinState(skinMonitorState);
 
       // Reset selected chroma data when skin changes (not just chroma selection)
       if (prevState && prevState.skinId !== detail?.skinId) {

--- a/Pengu Loader/plugins/ROSE-FormsWheel/index.js
+++ b/Pengu Loader/plugins/ROSE-FormsWheel/index.js
@@ -169,6 +169,8 @@
   let selectedChromaData = null; // { id, primaryColor, colors, name }
   let pythonChromaState = null; // { selectedChromaId, chromaColor, chromaColors, currentSkinId }
   let championLocked = false; // Track if a champion is locked
+  // Track the last observed phase so startup replays do not look like a new session.
+  let currentPhase = null;
 
   // Asset paths for custom hover button
   const HOVER_BUTTON_ASSET = "hol-button.png";
@@ -1359,18 +1361,43 @@
     updateChromaButtonColor();
   }
 
+  function resetFrontendSessionState(reason) {
+    // Clear transient frontend state only when a Champ Select session really starts/ends.
+    skinMonitorState = null;
+    pythonChromaState = null;
+    selectedChromaData = null;
+    championLocked = false;
+
+    // Remove stale UI that may still be attached from the previous session.
+    const existingPanel = document.getElementById(PANEL_ID);
+    if (existingPanel) {
+      existingPanel.remove();
+    }
+
+    document.querySelectorAll(BUTTON_SELECTOR).forEach((button) => {
+      button.remove();
+    });
+
+    emitBridgeLog("session_state_reset", { reason });
+  }
+
   function handlePhaseChangeFromPython(data) {
     // Use Python-detected game mode to drive ARAM detection for the JS panel
     try {
       const phase = data.phase;
       const gameMode = data.gameMode;
       const mapId = data.mapId;
+      // Late startup can replay "ChampSelect" after skin-state is already current.
+      // Keep the last seen phase so we only reset on real phase transitions.
+      const previousPhase = currentPhase;
+      currentPhase = phase;
 
       if (phase === "ChampSelect") {
-        // Reset stale skin state from previous game so the chroma button
-        // doesn't briefly show the old champion's data at lock-in
-        skinMonitorState = null;
-        pythonChromaState = null;
+        // Only reset on a real transition into a new Champ Select session.
+        // Startup replays can arrive after a valid skin-state payload.
+        if (previousPhase && previousPhase !== "ChampSelect") {
+          resetFrontendSessionState("phase-entry");
+        }
 
         const isAram =
           mapId === 12 ||
@@ -1385,6 +1412,12 @@
         isAramFromPython = Boolean(isAram);
       } else {
         // Leaving champ select / finalization â€" clear flag
+        if (
+          previousPhase === "ChampSelect" ||
+          previousPhase === "FINALIZATION"
+        ) {
+          resetFrontendSessionState("phase-exit");
+        }
         isAramFromPython = false;
       }
     } catch (e) {

--- a/pengu/processing/flow_controller.py
+++ b/pengu/processing/flow_controller.py
@@ -54,6 +54,14 @@ class FlowController:
         
         if getattr(self.shared_state, "own_champion_locked", False):
             return True
+
+        # Late reconnects can briefly restore the locked champion ID before the
+        # full lock pipeline flips own_champion_locked. Accept the cached skin
+        # snapshot in that window so chroma initialization is not missed.
+        if current_phase == "ChampSelect" and getattr(
+            self.shared_state, "locked_champ_id", None
+        ) is not None:
+            return True
         
         if getattr(self.shared_state, "phase", None) == "FINALIZATION":
             return True

--- a/threads/core/lcu_monitor_thread.py
+++ b/threads/core/lcu_monitor_thread.py
@@ -4,6 +4,7 @@
 LCU connection monitoring thread for language detection
 """
 
+import json
 import time
 import threading
 from typing import Callable, Optional
@@ -99,9 +100,12 @@ class LCUMonitorThread(threading.Thread):
                 elif not current_lcu_ok and self.waiting_for_connection:
                     # Refresh connection periodically
                     self.lcu.refresh_if_needed()
-                
+
+                if current_lcu_ok and current_ws_connected:
+                    self._maybe_recover_locked_champ_select_state()
+                 
                 self.last_lcu_ok = current_lcu_ok
-                
+                 
             except Exception as e:
                 log.debug(f"LCU monitor error: {e}")
             
@@ -188,6 +192,7 @@ class LCUMonitorThread(threading.Thread):
             my_cell = sess.get("localPlayerCellId")
             if my_cell is None:
                 return
+            self.state.local_cell_id = my_cell
             
             # Check if there are any locked champions
             locked_champions = compute_locked(sess)
@@ -196,48 +201,132 @@ class LCUMonitorThread(threading.Thread):
             if my_cell in locked_champions:
                 locked_champ_id = locked_champions[my_cell]
                 
-                # Only update if not already set (avoid duplicate processing)
-                if self.state.locked_champ_id != locked_champ_id:
-                    champ_name = f"champ_{locked_champ_id}"  # Use ID since we don't have database
-                    
-                    log_status(log, "Initial state: Champion already locked", f"{champ_name} (ID: {locked_champ_id})", "")
-                    
-                    # Set the locked champion state
-                    self.state.locked_champ_id = locked_champ_id
-                    self.state.locked_champ_timestamp = time.time()
-                    
-                    # Reset historic mode state for new champion lock (always deactivate before checking)
-                    self.state.historic_mode_active = False
-                    self.state.historic_skin_id = None
-                    self.state.historic_first_detection_done = False
-                    log.debug(f"[init-state] Reset historic mode state for initial champion lock")
-                    
-                    # Broadcast deactivated state to JavaScript (hide flag)
-                    try:
-                        if self.state and hasattr(self.state, 'ui_skin_thread') and self.state.ui_skin_thread:
-                            self.state.ui_skin_thread._broadcast_historic_state()
-                    except Exception as e:
-                        log.debug(f"[init-state] Failed to broadcast historic state reset: {e}")
-                    
-                    # Scrape skins for this champion from LCU
-                    if self.skin_scraper:
-                        try:
-                            self.skin_scraper.scrape_champion_skins(locked_champ_id)
-                        except Exception as e:
-                            log.debug(f"[init-state] Failed to scrape champion skins: {e}")
-                    
-                    # English skin names are now loaded by LCU skin scraper
-                    
-                    # Notify injection manager of champion lock
-                    if self.injection_manager:
-                        try:
-                            self.injection_manager.on_champion_locked(champ_name, locked_champ_id, self.state.owned_skin_ids)
-                        except Exception as e:
-                            log.debug(f"[init-state] Failed to notify injection manager: {e}")
-                    
-                    log.info(f"[init-state] App will start after initialization (champion: {champ_name})")
+                if self._needs_late_lock_bootstrap(locked_champ_id):
+                    self._bootstrap_late_locked_champion(
+                        locked_champ_id=locked_champ_id,
+                        locked_champions=locked_champions,
+                    )
         except Exception as e:
             log.debug(f"Error checking initial champion state: {e}")
+
+    def _maybe_recover_locked_champ_select_state(self) -> None:
+        """Retry late-lock recovery while a locked Champ Select session is active."""
+        try:
+            if getattr(self.state, "phase", None) != "ChampSelect":
+                return
+
+            if self.state.own_champion_locked and self.state.locked_champ_id is not None:
+                return
+
+            self._check_initial_champion_state()
+        except Exception as e:
+            log.debug(f"[init-state] Error retrying late lock recovery: {e}")
+
+    def _needs_late_lock_bootstrap(self, locked_champ_id: int) -> bool:
+        """Return True when late-start lock recovery still needs to run."""
+        return (
+            self.state.locked_champ_id != locked_champ_id
+            or not self.state.own_champion_locked
+        )
+
+    def _bootstrap_late_locked_champion(self, locked_champ_id: int, locked_champions: dict) -> None:
+        """Restore the same state a normal champion-lock event would set up."""
+        champ_name = f"champ_{locked_champ_id}"
+        log_status(
+            log,
+            "Initial state: Champion already locked",
+            f"{champ_name} (ID: {locked_champ_id})",
+            "",
+        )
+
+        self.state.phase = "ChampSelect"
+        self.state.locked_champ_id = locked_champ_id
+        self.state.locked_champ_timestamp = time.time()
+        self.state.own_champion_locked = True
+        self.state.locks_by_cell = dict(locked_champions)
+
+        self.state.historic_mode_active = False
+        self.state.historic_skin_id = None
+        self.state.historic_first_detection_done = False
+        log.debug("[init-state] Reset historic mode state for initial champion lock")
+
+        self._broadcast_historic_reset()
+        self._scrape_locked_champion_skins(locked_champ_id)
+        self._notify_injection_manager(champ_name, locked_champ_id)
+        self._sync_ui_for_late_lock()
+
+        log.info(
+            f"[init-state] App will start after initialization (champion: {champ_name})"
+        )
+
+    def _broadcast_historic_reset(self) -> None:
+        """Hide historic-mode UI after late-start lock recovery."""
+        ui_thread = getattr(self.state, "ui_skin_thread", None)
+        if not ui_thread:
+            return
+        try:
+            ui_thread._broadcast_historic_state()
+        except Exception as e:
+            log.debug(f"[init-state] Failed to broadcast historic state reset: {e}")
+
+    def _scrape_locked_champion_skins(self, locked_champ_id: int) -> None:
+        """Warm the skin scraper for the locked champion."""
+        if not self.skin_scraper:
+            return
+        try:
+            self.skin_scraper.scrape_champion_skins(locked_champ_id)
+        except Exception as e:
+            log.debug(f"[init-state] Failed to scrape champion skins: {e}")
+
+    def _notify_injection_manager(self, champ_name: str, locked_champ_id: int) -> None:
+        """Backfill the injection manager with the locked champion."""
+        if not self.injection_manager:
+            return
+        try:
+            self.injection_manager.on_champion_locked(
+                champ_name,
+                locked_champ_id,
+                self.state.owned_skin_ids,
+            )
+        except Exception as e:
+            log.debug(f"[init-state] Failed to notify injection manager: {e}")
+
+    def _sync_ui_for_late_lock(self) -> None:
+        """Broadcast late lock state to JS and replay any cached skin name."""
+        ui_thread = getattr(self.state, "ui_skin_thread", None)
+        if not ui_thread:
+            return
+
+        try:
+            ui_thread._broadcast_phase_change("ChampSelect")
+        except Exception as e:
+            log.debug(f"[init-state] Failed to broadcast ChampSelect phase: {e}")
+
+        try:
+            ui_thread._broadcast_champion_locked(True)
+        except Exception as e:
+            log.debug(f"[init-state] Failed to broadcast champion lock state: {e}")
+
+        self._replay_cached_skin_name(ui_thread)
+
+    def _replay_cached_skin_name(self, ui_thread) -> None:
+        """Replay the cached skin name if the first sync was ignored before lock state existed."""
+        cached_skin_name = (getattr(self.state, "ui_last_text", "") or "").strip()
+        if not cached_skin_name:
+            return
+
+        try:
+            log.info(
+                "[init-state] Replaying cached skin after late lock bootstrap: '%s'",
+                cached_skin_name,
+            )
+            ui_thread.message_handler.handle_message(json.dumps({
+                "skin": cached_skin_name,
+                "originalName": cached_skin_name,
+                "timestamp": int(time.time() * 1000),
+            }))
+        except Exception as e:
+            log.debug(f"[init-state] Failed to replay cached skin state: {e}")
     
     def _is_ws_connected(self) -> bool:
         """Check if WebSocket is connected"""


### PR DESCRIPTION
## Problem
Rose doesn't launch the chroma wheel if it started during Champ Select after the player had already locked his champion

If Rose start before Champ Select = works
If Rose start during Champ Select BEFORE player locks in champion = works
If Rose starts during Champ Select AFTER player locks in champion = BROKEN

## Root Cause

There were two races happening together:

1. When Rose attached after player had locked his champ, backend lock state and skin state could be missing or arrive late
2. After that state was recovered, the frontend could still clear it again when it received a replayed ChampSelect phase event during startup

So the wheel sometimes had either:
- no recovered lock/skin state or
- valid state that got wiped before the button scan used it



## Fix:

- restore locked Champ Select state when Rose connects after lock-in
- allow skin payloads during the brief recovery window as soon as locked_champ_id is known
- replay cached skin state after late lock recovery
- stop the wheel plugins from clearing recovered skin state on replayed startup ChampSelect events
- only reset frontend wheel state on real phase transitions into or out of Champ Select