### PR TITLE
small perf improvement

### DIFF
--- a/config.py
+++ b/config.py
@@ -129,6 +129,7 @@ LCU_MONITOR_INTERVAL_INGAME = 3.0  # Seconds between LCU connection checks durin
 # Main loop sleep intervals
 MAIN_LOOP_SLEEP = 0.016     # Main loop iteration sleep time (16ms for 60 FPS responsive chroma UI)
 MAIN_LOOP_IDLE_SLEEP = 0.05  # Idle main loop sleep time (50ms when no active UI/chroma work)
+MAIN_LOOP_INGAME_SLEEP = 0.5  # In-game main loop sleep (500ms during InProgress to avoid stealing CPU from the game)
 
 
 # =============================================================================

--- a/main/runtime/loop.py
+++ b/main/runtime/loop.py
@@ -10,7 +10,13 @@ from typing import Any
 from state import SharedState
 from lcu import LCUSkinScraper
 from utils.core.logging import get_logger, log_section
-from config import MAIN_LOOP_SLEEP, MAIN_LOOP_IDLE_SLEEP, MAIN_LOOP_STALL_THRESHOLD_S, CHROMA_PANEL_PROCESSING_THRESHOLD_S
+from config import (
+    MAIN_LOOP_SLEEP,
+    MAIN_LOOP_IDLE_SLEEP,
+    MAIN_LOOP_INGAME_SLEEP,
+    MAIN_LOOP_STALL_THRESHOLD_S,
+    CHROMA_PANEL_PROCESSING_THRESHOLD_S,
+)
 
 log = get_logger()
 
@@ -60,14 +66,24 @@ def run_main_loop(state: SharedState, skin_scraper: LCUSkinScraper) -> None:
 
 
 def _compute_main_loop_sleep(state: SharedState, ui_activity: bool) -> float:
-    """Return adaptive main-loop sleep based on current activity."""
+    """Return adaptive main-loop sleep based on current activity.
+
+    Three tiers:
+      - fast (16ms)    : active UI / chroma work — responsive loop needed
+      - idle (50ms)    : in client but nothing happening — stay reactive to hovers
+      - in-game (500ms): player is actually playing a match — yield CPU to the game
+    """
     fast_loop = (
         ui_activity
         or state.champion_exchange_triggered
         or state.chroma_panel_open
         or state.pending_chroma_selection
     )
-    return MAIN_LOOP_SLEEP if fast_loop else MAIN_LOOP_IDLE_SLEEP
+    if fast_loop:
+        return MAIN_LOOP_SLEEP
+    if state.phase == "InProgress":
+        return MAIN_LOOP_INGAME_SLEEP
+    return MAIN_LOOP_IDLE_SLEEP
 
 
 def _process_ui_updates(state: SharedState, skin_scraper: LCUSkinScraper) -> bool:

--- a/threads/handlers/champ_thread.py
+++ b/threads/handlers/champ_thread.py
@@ -12,6 +12,11 @@ from utils.core.logging import get_logger
 from ui.chroma.selector import get_chroma_selector
 from config import CHAMP_POLL_INTERVAL
 
+# Long sleep when not in ChampSelect — we only need to react when phase returns.
+# 2s is responsive enough: even if phase flips to ChampSelect right after we sleep,
+# the user has ~10s of hover time before locking, so a 2s wake-up delay is invisible.
+CHAMP_POLL_INTERVAL_IDLE = 2.0
+
 log = get_logger()
 
 
@@ -125,7 +130,9 @@ class ChampThread(threading.Thread):
                 # Reset exchange tracking when exiting ChampSelect
                 if self.state.phase != "ChampSelect":
                     self.last_locked_champion_id = None
-                time.sleep(CHAMP_POLL_INTERVAL)
+                # Sleep longer when we have no work — huge CPU/wakeup savings
+                # during InProgress (40-min match = 4800 fewer wakeups).
+                time.sleep(CHAMP_POLL_INTERVAL_IDLE)
                 continue
             
             cid = self.lcu.hovered_champion_id


### PR DESCRIPTION
During an active match two threads kept waking up with nothing to do:

  - Main loop: 20 Hz via MAIN_LOOP_IDLE_SLEEP (50ms)
  - ChampThread: 4 Hz via CHAMP_POLL_INTERVAL (250ms)

Combined that's ~24 useless wakeups/sec, or ~57,600 forced context switches over a 40-min match

# Honest expectations
CPU time savings are negligible. The real win is scheduler noise reduction, not raw compute. No visible FPS gains but slightly cleaner frame pacing.