### PR TITLE
Fix localhost bridge cross-origin file read and WebSocket hijack

### DIFF
--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -14,8 +14,9 @@ import subprocess
 import sys
 import time
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Optional
+from urllib.parse import quote
 
 from config import get_config_float, get_config_option, set_config_option
 from injection.mods.storage import ModStorageService
@@ -30,6 +31,28 @@ from utils.system.admin_utils import (
 )
 
 log = logging.getLogger(__name__)
+
+
+def _is_unc_path(path_value: str) -> bool:
+    """Return True for UNC/device paths that can trigger network auth/probing."""
+    stripped = path_value.strip()
+    return stripped.startswith(("\\\\", "//"))
+
+
+def _is_safe_relative_path(path_value: str) -> bool:
+    """Validate a client-supplied path is relative and cannot traverse upward."""
+    if not isinstance(path_value, str):
+        return False
+
+    cleaned = path_value.strip().replace("/", "\\")
+    if not cleaned:
+        return False
+
+    candidate = PureWindowsPath(cleaned)
+    if candidate.is_absolute() or candidate.drive or _is_unc_path(cleaned):
+        return False
+
+    return all(part not in {"", ".", ".."} for part in candidate.parts)
 
 
 class MessageHandler:
@@ -69,6 +92,28 @@ class MessageHandler:
         self.port = port
         self.mod_storage = mod_storage or ModStorageService()
         self.injection_manager = injection_manager
+
+    def _is_valid_local_league_path(self, game_path: str) -> bool:
+        """Validate a League install path without touching UNC/network paths."""
+        if not isinstance(game_path, str):
+            return False
+
+        cleaned = game_path.strip()
+        if not cleaned or _is_unc_path(cleaned):
+            return False
+
+        game_dir = Path(cleaned)
+        if not game_dir.is_absolute():
+            return False
+
+        try:
+            if game_dir.exists() and game_dir.is_dir():
+                league_exe = game_dir / "League of Legends.exe"
+                return league_exe.exists() and league_exe.is_file()
+        except Exception:
+            return False
+
+        return False
     
     def handle_message(self, message: str) -> None:
         """Handle incoming WebSocket message
@@ -221,7 +266,8 @@ class MessageHandler:
                 asset_file = get_asset_path(asset_path)
                 
                 if asset_file and asset_file.exists():
-                    http_url = f"http://localhost:{self.port}/asset/{asset_path.replace(chr(92), '/')}"
+                    encoded_asset_path = quote(asset_path.replace(chr(92), "/"), safe="/")
+                    http_url = f"http://localhost:{self.port}/asset/{encoded_asset_path}"
                     log.debug(f"[SkinMonitor] Local asset found: {asset_file} -> {http_url}")
                     
                     response_payload = {
@@ -323,13 +369,7 @@ class MessageHandler:
             
             path_valid = False
             if game_path:
-                try:
-                    game_dir = Path(game_path.strip())
-                    if game_dir.exists() and game_dir.is_dir():
-                        league_exe = game_dir / "League of Legends.exe"
-                        path_valid = league_exe.exists() and league_exe.is_file()
-                except Exception:
-                    path_valid = False
+                path_valid = self._is_valid_local_league_path(game_path)
             
             from config import APP_VERSION
             response_payload = {
@@ -707,13 +747,7 @@ class MessageHandler:
             path_valid = False
             
             if game_path and game_path.strip():
-                try:
-                    game_dir = Path(game_path.strip())
-                    if game_dir.exists() and game_dir.is_dir():
-                        league_exe = game_dir / "League of Legends.exe"
-                        path_valid = league_exe.exists() and league_exe.is_file()
-                except Exception:
-                    path_valid = False
+                path_valid = self._is_valid_local_league_path(game_path)
             
             validation_payload = {
                 "type": "path-validation-result",
@@ -1539,6 +1573,9 @@ class MessageHandler:
             if not rel_path:
                 log.warning("[SkinMonitor] Other mod selection missing path/id")
                 return
+            if not _is_safe_relative_path(str(rel_path)):
+                log.warning("[SkinMonitor] Blocked unsafe other mod path: %s", rel_path)
+                return
 
             mod_path = self.mod_storage.mods_root / str(rel_path).replace("/", "\\")
             selected_mod = type("ModEntry", (), {
@@ -1724,6 +1761,9 @@ class MessageHandler:
             log.info(f"[SkinMonitor] Monitor auto-resume timeout updated to {monitor_auto_resume_timeout}s")
             
             if game_path and game_path.strip():
+                if not self._is_valid_local_league_path(game_path):
+                    self._send_settings_save_error("League path must be a valid local League of Legends folder.")
+                    return
                 set_config_option("General", "leaguePath", game_path.strip())
                 # Try to infer and save client path
                 from injection.config.config_manager import ConfigManager
@@ -2135,6 +2175,14 @@ class MessageHandler:
                         "type": "folder-opened-response",
                         "success": False,
                         "error": "Champion ID and Skin ID are required",
+                    }
+                    self._send_response(json.dumps(response_payload))
+                    return
+                if not str(champion_id).isdigit() or not str(skin_id).isdigit():
+                    response_payload = {
+                        "type": "folder-opened-response",
+                        "success": False,
+                        "error": "Champion ID and Skin ID must be numeric",
                     }
                     self._send_response(json.dumps(response_payload))
                     return

--- a/pengu/core/http_handler.py
+++ b/pengu/core/http_handler.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from urllib.parse import urlparse, unquote
 
 from utils.core.paths import get_skins_dir, get_asset_path, get_state_dir
+from utils.core.security import cors_headers_for_origin, is_loopback_origin
 
 log = logging.getLogger(__name__)
 
@@ -19,9 +20,8 @@ class HTTPHandler:
     """Handles HTTP requests for file serving
 
     Security Note:
-        - CORS is set to wildcard (*) but server binds ONLY to localhost (127.0.0.1)
-        - This is safe because external hosts cannot reach localhost
-        - All file paths are validated with _is_safe_path() to prevent path traversal
+        - Browser requests with an Origin header are only allowed from loopback origins.
+        - File-serving routes resolve paths under explicit Rose-owned directories.
     """
 
     def __init__(self, port: int):
@@ -45,11 +45,22 @@ class HTTPHandler:
             True if path is safe, False if it escapes base_dir
         """
         try:
-            base_resolved = base_dir.resolve()
             target_resolved = requested_path.resolve()
-            return str(target_resolved).startswith(str(base_resolved))
+            target_resolved.relative_to(base_dir.resolve())
+            return True
         except (OSError, ValueError):
             return False
+
+    def _get_origin(self, request_headers: dict) -> Optional[str]:
+        """Read Origin from a dict-like headers object."""
+        try:
+            return request_headers.get("Origin") or request_headers.get("origin")
+        except AttributeError:
+            return None
+
+    def _forbidden(self) -> tuple:
+        """Return a generic forbidden response."""
+        return (403, {"Content-Type": "text/plain"}, b"Forbidden")
     
     def handle_request(self, path: str, request_headers: dict) -> Optional[tuple]:
         """Process HTTP requests
@@ -65,6 +76,12 @@ class HTTPHandler:
         try:
             parsed_path = urlparse(path)
             path_clean = unquote(parsed_path.path)
+            origin = self._get_origin(request_headers)
+            if origin and not is_loopback_origin(origin):
+                log.warning("[SkinMonitor] Blocked HTTP request from origin: %s", origin)
+                return self._forbidden()
+
+            cors_headers = cors_headers_for_origin(origin)
             
             log.debug(f"[SkinMonitor] HTTP request: {path_clean}")
             
@@ -72,7 +89,7 @@ class HTTPHandler:
             if path_clean == "/port":
                 return (
                     200,
-                    {"Content-Type": "text/plain", "Access-Control-Allow-Origin": "*"},
+                    {"Content-Type": "text/plain", **cors_headers},
                     str(self.port).encode('utf-8')
                 )
             
@@ -84,7 +101,7 @@ class HTTPHandler:
                         port = port_file.read_text(encoding='utf-8').strip()
                         return (
                             200,
-                            {"Content-Type": "text/plain", "Access-Control-Allow-Origin": "*"},
+                            {"Content-Type": "text/plain", **cors_headers},
                             port.encode('utf-8')
                         )
                     except Exception as e:
@@ -92,21 +109,21 @@ class HTTPHandler:
                 # Fallback to current port if file doesn't exist
                 return (
                     200,
-                    {"Content-Type": "text/plain", "Access-Control-Allow-Origin": "*"},
+                    {"Content-Type": "text/plain", **cors_headers},
                     str(self.port).encode('utf-8')
                 )
             
             # Handle preview requests
             if path_clean.startswith("/preview/"):
-                return self._handle_preview_request(path_clean)
+                return self._handle_preview_request(path_clean, cors_headers)
             
             # Handle asset requests
             elif path_clean.startswith("/asset/"):
-                return self._handle_asset_request(path_clean)
+                return self._handle_asset_request(path_clean, cors_headers)
             
             # Handle plugin file requests
             elif path_clean.startswith("/plugin/"):
-                return self._handle_plugin_request(path_clean)
+                return self._handle_plugin_request(path_clean, cors_headers)
             
             # Return None to let WebSocket handshake proceed
             return None
@@ -114,11 +131,11 @@ class HTTPHandler:
             log.warning(f"[SkinMonitor] HTTP request error: {e}", exc_info=True)
             return (
                 500,
-                {"Access-Control-Allow-Origin": "*"},
+                {"Content-Type": "text/plain"},
                 b"Internal Server Error"
             )
     
-    def _handle_preview_request(self, path_clean: str) -> Optional[tuple]:
+    def _handle_preview_request(self, path_clean: str, cors_headers: dict[str, str]) -> Optional[tuple]:
         """Handle preview image requests"""
         parts = path_clean.replace("/preview/", "").split("/")
         if len(parts) >= 4:
@@ -138,7 +155,7 @@ class HTTPHandler:
             # Security: Validate path doesn't escape skins directory
             if not self._is_safe_path(skins_dir, file_path):
                 log.warning(f"[SkinMonitor] Blocked path traversal attempt: {path_clean}")
-                return (403, {"Access-Control-Allow-Origin": "*"}, b"Forbidden")
+                return self._forbidden()
 
             if file_path.exists():
                 log.debug(f"[SkinMonitor] Serving preview: {file_path}")
@@ -148,14 +165,14 @@ class HTTPHandler:
                     200,
                     {
                         "Content-Type": "image/png",
-                        "Access-Control-Allow-Origin": "*",
+                        **cors_headers,
                         "Cache-Control": "public, max-age=3600"
                     },
                     file_data
                 )
         return None
     
-    def _handle_asset_request(self, path_clean: str) -> Optional[tuple]:
+    def _handle_asset_request(self, path_clean: str, cors_headers: dict[str, str]) -> Optional[tuple]:
         """Handle asset file requests"""
         asset_path = path_clean.replace("/asset/", "")
         asset_file = get_asset_path(asset_path)
@@ -170,14 +187,14 @@ class HTTPHandler:
                 200,
                 {
                     "Content-Type": content_type,
-                    "Access-Control-Allow-Origin": "*",
+                    **cors_headers,
                     "Cache-Control": "public, max-age=3600"
                 },
                 file_data
             )
         return None
     
-    def _handle_plugin_request(self, path_clean: str) -> Optional[tuple]:
+    def _handle_plugin_request(self, path_clean: str, cors_headers: dict[str, str]) -> Optional[tuple]:
         """Handle plugin file requests"""
         plugin_path = path_clean.replace("/plugin/", "")
         parts = plugin_path.split("/", 1)
@@ -196,7 +213,7 @@ class HTTPHandler:
                     # Security: Validate path doesn't escape plugins directory
                     if not self._is_safe_path(plugins_dir, file_path):
                         log.warning(f"[SkinMonitor] Blocked path traversal attempt: {path_clean}")
-                        return (403, {"Access-Control-Allow-Origin": "*"}, b"Forbidden")
+                        return self._forbidden()
 
                     if file_path.exists():
                         log.debug(f"[SkinMonitor] Serving plugin file: {file_path}")
@@ -208,7 +225,7 @@ class HTTPHandler:
                             200,
                             {
                                 "Content-Type": content_type,
-                                "Access-Control-Allow-Origin": "*",
+                                **cors_headers,
                                 "Cache-Control": "public, max-age=3600"
                             },
                             file_data

--- a/pengu/core/websocket_server.py
+++ b/pengu/core/websocket_server.py
@@ -11,6 +11,7 @@ import threading
 from typing import Optional, Set, Callable
 from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 from websockets.server import WebSocketServerProtocol, serve
+from utils.core.security import is_loopback_origin
 
 log = logging.getLogger(__name__)
 
@@ -139,6 +140,12 @@ class WebSocketServer:
     
     async def _process_http_request(self, path: str, request_headers) -> Optional[tuple]:
         """Process HTTP requests (delegates to http_handler)"""
+        origin = request_headers.get("Origin")
+        upgrade = (request_headers.get("Upgrade") or "").lower()
+        if upgrade == "websocket" and origin and not is_loopback_origin(origin):
+            log.warning("[SkinMonitor] Blocked WebSocket request from origin: %s", origin)
+            return (403, {"Content-Type": "text/plain"}, b"Forbidden")
+
         if self.http_handler:
             return self.http_handler(path, request_headers)
         return None

--- a/utils/core/paths.py
+++ b/utils/core/paths.py
@@ -251,16 +251,9 @@ def get_app_dir() -> Path:
         return Path(__file__).parent.parent.parent
 
 
-def get_asset_path(asset_name: str) -> Path:
+def get_assets_dir() -> Path:
     """
-    Get the path to an asset file (icons, images, etc.)
-    Works in both development and frozen (PyInstaller) environments.
-
-    Args:
-        asset_name: Name of the asset file (e.g., "champ-select-flyout-background-sr.jpg")
-
-    Returns:
-        Path to the asset file
+    Get the base assets directory.
     """
     if getattr(sys, 'frozen', False):
         # Running as compiled executable
@@ -271,11 +264,49 @@ def get_asset_path(asset_name: str) -> Path:
         else:
             # One-dir mode: use _internal folder
             base_path = Path(sys.executable).parent / "_internal"
-        return base_path / "assets" / asset_name
+        return base_path / "assets"
     else:
         # Running as script
         app_dir = get_app_dir()
-        return app_dir / "assets" / asset_name
+        return app_dir / "assets"
+
+
+def get_asset_path(asset_name: str) -> Path:
+    """
+    Get the path to an asset file (icons, images, etc.)
+    Works in both development and frozen (PyInstaller) environments.
+
+    Args:
+        asset_name: Name of the asset file (e.g., "champ-select-flyout-background-sr.jpg")
+
+    Returns:
+        Path to the asset file, or to a guaranteed-missing asset for invalid input.
+    """
+    assets_dir = get_assets_dir()
+    invalid_asset = assets_dir / "__invalid_asset_path__"
+
+    if not isinstance(asset_name, str):
+        return invalid_asset
+
+    cleaned_name = asset_name.replace("\\", "/").lstrip("/")
+    candidate = Path(cleaned_name)
+
+    if (
+        not cleaned_name
+        or candidate.is_absolute()
+        or candidate.drive
+        or any(part in {"", ".", ".."} for part in candidate.parts)
+        or ":" in cleaned_name
+    ):
+        return invalid_asset
+
+    asset_path = assets_dir / candidate
+    try:
+        asset_path.resolve(strict=False).relative_to(assets_dir.resolve(strict=False))
+    except (OSError, ValueError):
+        return invalid_asset
+
+    return asset_path
 
 
 def ensure_write_permissions(path: Path) -> bool:

--- a/utils/core/security.py
+++ b/utils/core/security.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Security helpers for Rose's localhost bridge.
+"""
+
+from urllib.parse import urlparse
+
+
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
+
+
+def is_loopback_origin(origin: str | None) -> bool:
+    """Return True only for browser origins hosted on the local machine."""
+    if not origin:
+        return False
+
+    try:
+        parsed = urlparse(origin)
+    except ValueError:
+        return False
+
+    if parsed.scheme not in {"http", "https"}:
+        return False
+
+    host = parsed.hostname
+    if not host:
+        return False
+
+    return host.lower() in _LOOPBACK_HOSTS
+
+
+def cors_headers_for_origin(origin: str | None) -> dict[str, str]:
+    """Build CORS headers for an allowed loopback origin."""
+    if not is_loopback_origin(origin):
+        return {}
+
+    return {
+        "Access-Control-Allow-Origin": origin,
+        "Vary": "Origin",
+    }


### PR DESCRIPTION

## Summary

Fixes a localhost bridge security issue where arbitrary websites could interact with Rose's local HTTP/WebSocket server while Rose was running.

This patch:

- rejects non-loopback browser `Origin` headers for HTTP bridge requests
- rejects non-loopback browser `Origin` headers during WebSocket upgrade
- removes wildcard CORS responses from localhost bridge endpoints
- restricts `/asset/` resolution to files inside Rose's bundled `assets` directory
- rejects unsafe absolute, UNC, drive-letter, and traversal paths in bridge-controlled flows


## Security impact

Before this change, a page such as `https://attacker.example` could read local files through:

```text
http://127.0.0.1:50000/asset/C:/Users/<user>/...
```

and could also open a WebSocket to Rose's local bridge and send unauthenticated commands.

After this change, those cross-origin browser requests are rejected.

#### Also, you should double check if nothing got broken since I can't compile the binary on my end