### PR TITLE
feat: add "Open Mods Folder" entry to system tray context menu

### DIFF
--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -20,7 +20,7 @@ from urllib.parse import quote
 
 from config import get_config_float, get_config_option, set_config_option
 from injection.mods.storage import ModStorageService
-from utils.core.paths import get_user_data_dir, get_asset_path, get_injection_dir
+from utils.core.paths import get_user_data_dir, get_asset_path, get_injection_dir, open_folder_in_explorer
 from utils.core.issue_reporter import clear_issues, read_issues_tail
 from utils.core.junction import is_junction, safe_remove_entry, link_or_extract
 from utils.system.admin_utils import (
@@ -764,12 +764,7 @@ class MessageHandler:
         """Handle open mods folder request"""
         try:
             mods_folder = get_user_data_dir() / "mods"
-            mods_folder.mkdir(parents=True, exist_ok=True)
-            
-            if sys.platform == "win32":
-                os.startfile(str(mods_folder))
-            else:
-                subprocess.Popen(["xdg-open" if os.name != "nt" else "explorer", str(mods_folder)])
+            open_folder_in_explorer(mods_folder)
             log.info(f"[SkinMonitor] Opened mods folder: {mods_folder}")
         except Exception as e:
             log.error(f"[SkinMonitor] Failed to open mods folder: {e}")

--- a/utils/core/paths.py
+++ b/utils/core/paths.py
@@ -6,6 +6,7 @@ Handles user data directories and permissions
 """
 
 import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Optional, Tuple
@@ -235,6 +236,18 @@ def get_injection_dir() -> Path:
     injection_dir = get_user_data_dir() / "injection"
     injection_dir.mkdir(parents=True, exist_ok=True)
     return injection_dir
+
+
+def open_folder_in_explorer(folder: Path) -> None:
+    """
+    Create `folder` if missing and reveal it in the OS file explorer.
+    Raises on failure — callers handle logging/error reporting.
+    """
+    folder.mkdir(parents=True, exist_ok=True)
+    if sys.platform == "win32":
+        os.startfile(str(folder))
+    else:
+        subprocess.Popen(["xdg-open", str(folder)])
 
 
 def get_app_dir() -> Path:

--- a/utils/integration/tray_manager.py
+++ b/utils/integration/tray_manager.py
@@ -10,6 +10,7 @@ from typing import Optional, Callable
 import pystray
 from PIL import Image, ImageDraw
 from utils.core.logging import get_logger
+from utils.core.paths import get_user_data_dir, open_folder_in_explorer
 from config import (
     APP_VERSION,
     TRAY_READY_MAX_WAIT_S, TRAY_READY_CHECK_INTERVAL_S,
@@ -191,13 +192,23 @@ class TrayManager:
                 )
             except Exception:
                 log.debug("Unable to show error message box for settings dialog failure")
-    
+
+    def _on_open_mods(self, icon, item):
+        """Open the user mods folder in the file explorer."""
+        log.info("Open Mods Folder requested from system tray")
+        try:
+            open_folder_in_explorer(get_user_data_dir() / "mods")
+        except Exception as e:
+            log.error(f"Failed to open mods folder: {e}")
+
     def _create_menu(self) -> pystray.Menu:
         """Create the context menu for the tray icon"""
         return pystray.Menu(
             pystray.MenuItem(f"Rose v{APP_VERSION}", None, enabled=False),
             pystray.Menu.SEPARATOR,
-            pystray.MenuItem("Quit", self._on_quit)
+            pystray.MenuItem("Open Mods Folder", self._on_open_mods),
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem("Quit", self._on_quit),
         )
     
     def _run_tray(self):


### PR DESCRIPTION
## Summary
- Adds an `Open Mods Folder` entry between the version label and `Quit` in the system tray context menu, exposing the same action that's already available from the WebSocket UI.
- Extracts the shared open-folder logic into `utils.core.paths.open_folder_in_explorer`; both the tray callback and the existing `_handle_open_mods_folder` WebSocket handler now go through it.
- The buggy unreachable ternary in the original handler (`"xdg-open" if os.name != "nt" else "explorer"`, sitting inside the non-Windows branch) is dropped by virtue of routing through the util — no other behaviour change at the WebSocket call site.

## Test plan
- [ ] Right-click the tray icon — menu shows `Rose v…` (disabled), separator, `Open Mods Folder`, separator, `Quit`.
- [ ] Click `Open Mods Folder` — Explorer opens at `%LOCALAPPDATA%\Rose\mods`; log shows `Open Mods Folder requested from system tray`.
- [ ] Delete `%LOCALAPPDATA%\Rose\mods` and click again — folder is recreated and opens.
- [ ] Trigger the existing WebSocket "open mods folder" UI action — Explorer still opens at the same path; `[SkinMonitor] Opened mods folder:` still logs.
- [ ] `Quit` still works.