### PR TITLE
Clear historic entry when default skin is played

### DIFF
--- a/threads/handlers/injection_trigger.py
+++ b/threads/handlers/injection_trigger.py
@@ -511,11 +511,17 @@ class InjectionTrigger:
                 self._inject_custom_mod(dummy_custom_mod, base_skin_name=base_skin_name_for_injection, champion_name=cname)
                 return
             
-            # Skip injection for base skins (only if no mods are selected)
-            if ui_skin_id == 0:
-                log.info("[INJECT] skipping base skin injection (skinId=0) - no mods-only flow available")
+            # Skip injection for base/default skins (only if no mods are selected)
+            from utils.core.utilities import is_default_skin
+            if ui_skin_id is not None and is_default_skin(ui_skin_id):
+                log.info(f"[INJECT] skipping injection for default skin (skinId={ui_skin_id}) - no mods selected")
                 if self.injection_manager:
                     self.injection_manager.resume_if_suspended()
+                champ_id = self.state.locked_champ_id or self.state.hovered_champ_id
+                if champ_id:
+                    from utils.core.historic import clear_historic_entry
+                    clear_historic_entry(int(champ_id))
+                    log.info(f"[HISTORIC] Cleared historic entry for champion {champ_id} (default skin played)")
 
             # Force owned skins/chromas via LCU
             # Use effective_skin_id which includes the selected chroma if applicable

--- a/threads/handlers/injection_trigger.py
+++ b/threads/handlers/injection_trigger.py
@@ -511,9 +511,12 @@ class InjectionTrigger:
                 self._inject_custom_mod(dummy_custom_mod, base_skin_name=base_skin_name_for_injection, champion_name=cname)
                 return
             
-            # Skip injection for base/default skins (only if no mods are selected)
+            # Skip injection for base/default skins (only if no mods are selected and
+            # historic mode is not active — if historic is active, the skin resolver
+            # already overrides to the saved skin and injection should proceed normally)
             from utils.core.utilities import is_default_skin
-            if ui_skin_id is not None and is_default_skin(ui_skin_id):
+            historic_active = getattr(self.state, 'historic_mode_active', False)
+            if ui_skin_id is not None and is_default_skin(ui_skin_id) and not historic_active:
                 log.info(f"[INJECT] skipping injection for default skin (skinId={ui_skin_id}) - no mods selected")
                 if self.injection_manager:
                     self.injection_manager.resume_if_suspended()


### PR DESCRIPTION
  When a champion is played on the default skin, the historic entry was
  never cleared from historic.json, causing the custom skin popup to
  reappear on the next champion select even though the user's last
  choice was the default skin.

  Extended the default skin check from ui_skin_id == 0 to
  is_default_skin(ui_skin_id) to catch the actual base skin ID
  (champion_id * 1000), and call clear_historic_entry() so the file
  reflects the user's last real choice.