### PR TITLE
Remove unused `time` import to fix lint warning

### DIFF
--- a/analytics/core/analytics_thread.py
+++ b/analytics/core/analytics_thread.py
@@ -5,7 +5,6 @@ Analytics thread for periodic user tracking pings
 """
 
 import threading
-import time
 from typing import Optional
 
 from config import ANALYTICS_PING_INTERVAL_S, APP_VERSION


### PR DESCRIPTION
## 问题背景

在代码审查中，发现 `analytics/core/analytics_thread.py` 文件导入了 `time` 模块，但该模块未在文件中任何地方使用。这导致 lint 工具（如 flake8 或 pylint）发出未使用导入的警告，影响代码质量和整洁度。

## 修改内容

- 移除了未使用的 `import time` 语句。
- 其他代码保持不变，以确保功能不受影响。

## 验证方式

- 运行 lint 工具（例如，使用 `flake8 analytics/core/analytics_thread.py`）确认未使用导入警告已消除。
- 执行现有测试套件（如果存在）以验证代码行为未发生改变。
- 由于改动最小且仅限于导入清理，预期不会引入任何副作用。