### PR TITLE
fix: report low disk space on failed injections

### DIFF
--- a/Pengu Loader/plugins/ROSE-SettingsPanel/index.js
+++ b/Pengu Loader/plugins/ROSE-SettingsPanel/index.js
@@ -990,6 +990,7 @@
   }
 
   function _diagnosticsCategory(e) {
+    if (e?.code === 'LOW_DISK_SPACE') return 'disk_space';
     const raw = String(e?.text || e?.msg || "").trim();
     const code = String(e?.code || "").trim();
 
@@ -3307,6 +3308,18 @@
               timeoutAtMax
                 ? `Fix: you're already at the maximum Monitor Auto-Resume Timeout. This usually means the injection is extremely slow. Try lighter mods, close heavy apps, move League/mods to an SSD, and consider adding antivirus exclusions for the League and Rose folders. Then retry.`
                 : `Fix: increase "Monitor Auto-Resume Timeout (seconds)" and click Save. If the warning is still there, increase it again and Save again. Once the warning is gone, try again.`,
+            ],
+          };
+        }
+
+        const isLowDiskSpace =
+          code === 'LOW_DISK_SPACE' || /Low Disk Space/i.test(raw) || /not enough disk space/i.test(raw);
+        if (isLowDiskSpace) {
+          return {
+            title: 'Not enough disk space for injection',
+            details: [
+              'What it means: Rose could not create the overlay for the selected skin.',
+              'Fix: free up space on the drive containing Rose injection files, then retry. Map mods can require several GB.',
             ],
           };
         }

--- a/injection/overlay/overlay_manager.py
+++ b/injection/overlay/overlay_manager.py
@@ -11,6 +11,7 @@ Security Notes:
     - Commands only execute mod-tools.exe from the verified tools directory
 """
 
+import shutil
 import subprocess
 import threading
 import time
@@ -36,6 +37,21 @@ from config import (
 
 log = get_logger()
 
+# mkoverlay needs free space for the generated WAD overlay in addition to the
+# extracted mod files. A gigabyte is a conservative lower bound for a normal
+# skin, while the extracted mod size catches larger map/voiceover mods.
+MIN_FREE_SPACE_BYTES = 1 * 1024 * 1024 * 1024
+DISK_SPACE_HEADROOM_BYTES = 512 * 1024 * 1024
+DISK_SPACE_ERROR_MARKERS = (
+    'not enough space',
+    'not enough disk space',
+    'insufficient disk space',
+    'disk full',
+    'no space left',
+    'error 112',
+    'errno 28',
+)
+
 
 class OverlayManager:
     """Manages overlay creation and execution"""
@@ -57,6 +73,81 @@ class OverlayManager:
         """Set current overlay process on process manager"""
         if self.process_manager:
             self.process_manager.current_overlay_process = value
+
+    @staticmethod
+    def _directory_size(directory: Path) -> int:
+        '''Return the best-effort size of files below *directory*.'''
+        total = 0
+        try:
+            for path in directory.rglob('*'):
+                try:
+                    if path.is_file():
+                        total += path.stat().st_size
+                except OSError:
+                    continue
+        except OSError:
+            return 0
+        return total
+
+    @staticmethod
+    def _format_bytes(size: int) -> str:
+        '''Format a byte count for log and diagnostics messages.'''
+        value = float(max(0, size))
+        for unit in ('B', 'KB', 'MB', 'GB', 'TB'):
+            if value < 1024 or unit == 'TB':
+                return f'{value:.1f} {unit}'
+            value /= 1024
+        return f'{value:.1f} TB'
+
+    def _report_low_disk_space_failure(
+        self,
+        output_lines: Optional[List[str]] = None,
+        mod_names: Optional[List[str]] = None,
+        result_code: Optional[int] = None,
+    ) -> bool:
+        '''Report a failed overlay when its output drive is out of space.'''
+        output = ' '.join(output_lines or ()).lower()
+        tool_reported_disk_error = (
+            any(marker in output for marker in DISK_SPACE_ERROR_MARKERS)
+            or result_code in (28, 112)
+        )
+
+        free_bytes = None
+        required_bytes = max(MIN_FREE_SPACE_BYTES, DISK_SPACE_HEADROOM_BYTES)
+        try:
+            usage = shutil.disk_usage(self.mods_dir.parent)
+            free_bytes = usage.free
+            extracted_bytes = self._directory_size(self.mods_dir)
+            required_bytes = max(
+                MIN_FREE_SPACE_BYTES,
+                extracted_bytes + DISK_SPACE_HEADROOM_BYTES,
+            )
+        except (OSError, ValueError) as exc:
+            log.debug(f'[INJECT] Could not inspect free disk space after injection failure: {exc}')
+
+        low_disk_space = free_bytes is not None and free_bytes < required_bytes
+        if not low_disk_space and not tool_reported_disk_error:
+            return False
+
+        free_text = self._format_bytes(free_bytes) if free_bytes is not None else 'an unknown amount'
+        required_text = self._format_bytes(required_bytes)
+        log.error(
+            '[INJECT] Injection failed because disk space is too low '
+            f'({free_text} free; approximately {required_text} recommended on {self.mods_dir.parent})'
+        )
+        report_issue(
+            'LOW_DISK_SPACE',
+            'error',
+            f'Injection failed: not enough disk space for the overlay ({free_text} free).',
+            details={
+                'free_bytes': free_bytes,
+                'required_bytes': required_bytes,
+                'overlay_path': str(self.mods_dir.parent),
+                'mods': '/'.join(mod_names or ()),
+            },
+            hint='Free up disk space on the drive containing Rose injection files, then retry the skin.',
+        )
+        return True
     
     def mk_run_overlay(self, mod_names: List[str], timeout: int = 120, stop_callback: Optional[Callable] = None, injection_manager=None) -> int:
         """Create and run overlay
@@ -98,6 +189,8 @@ class OverlayManager:
         
         log.debug(f"[INJECT] Creating overlay: {' '.join(cmd)}")
         mkoverlay_start = time.time()
+        output_lines = []
+        error_lines = []
         try:
             # Hide console window on Windows
             import sys
@@ -119,9 +212,6 @@ class OverlayManager:
             
             # Wait for process to complete with timeout
             # Read both stdout and stderr in separate threads to see what mkoverlay is doing
-            output_lines = []
-            error_lines = []
-            
             def read_output(pipe, lines_list, prefix):
                 try:
                     for line in pipe:
@@ -157,6 +247,11 @@ class OverlayManager:
             mkoverlay_duration = time.time() - mkoverlay_start
             
             if proc.returncode != 0:
+                self._report_low_disk_space_failure(
+                    output_lines + error_lines,
+                    mod_names,
+                    result_code=proc.returncode,
+                )
                 log.error(f"[INJECT] mkoverlay failed with return code: {proc.returncode}")
                 return proc.returncode
             else:
@@ -185,6 +280,7 @@ class OverlayManager:
                 details={"timeout_s": timeout},
                 hint="Try increasing Monitor Auto-Resume Timeout and/or using smaller mods.",
             )
+            self._report_low_disk_space_failure(output_lines + error_lines, mod_names)
             return 124
         except Exception as e:
             log.error(f"[INJECT] mkoverlay error: {e} - monitor will auto-resume if needed")
@@ -195,6 +291,7 @@ class OverlayManager:
                 details={"error": str(e)},
                 hint="Check Rose logs for details, then retry.",
             )
+            self._report_low_disk_space_failure(output_lines + error_lines, mod_names)
             return 1
 
         # Run overlay
@@ -256,6 +353,10 @@ class OverlayManager:
             self.current_overlay_process = None
             self._wipe_overlay_dir(overlay_dir)
             if proc.returncode != 0:
+                self._report_low_disk_space_failure(
+                    mod_names=mod_names,
+                    result_code=proc.returncode,
+                )
                 log.error(f"[INJECT] runoverlay failed with return code: {proc.returncode}")
                 return proc.returncode
             else:
@@ -346,6 +447,10 @@ class OverlayManager:
                 mkoverlay_duration = time.time() - mkoverlay_start
                 
                 if proc.returncode != 0:
+                    self._report_low_disk_space_failure(
+                        mod_names=mod_names,
+                        result_code=proc.returncode,
+                    )
                     log.error(f"[INJECT] mkoverlay failed with return code: {proc.returncode}")
                     return proc.returncode
                 else:
@@ -359,8 +464,10 @@ class OverlayManager:
             except subprocess.TimeoutExpired:
                 log.error(f"[INJECT] mkoverlay timed out after {timeout}s")
                 proc.kill()
+                self._report_low_disk_space_failure(mod_names=mod_names)
                 return -1
             except Exception as e:
+                self._report_low_disk_space_failure(mod_names=mod_names)
                 log.error(f"[INJECT] mkoverlay failed with exception: {e}")
                 return -1
                 

--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -411,6 +411,7 @@ class MessageHandler:
         Categories:
           - injection_threshold
           - monitor_timeout
+          - disk_space
         """
         try:
             cats = payload.get("categories") or []
@@ -423,6 +424,9 @@ class MessageHandler:
             for c in cats:
                 cl = str(c or "").strip().lower()
                 if not cl:
+                    continue
+                if cl in ('disk_space', 'low_disk_space'):
+                    norm.add('disk_space')
                     continue
                 if cl in ("injection_threshold", "threshold", "injection"):
                     norm.add("injection_threshold")
@@ -526,6 +530,8 @@ class MessageHandler:
                 ml = (msg_line or "").lower()
                 fl = (fix_line or "").lower()
                 # Match the same categories we summarize
+                if 'not enough disk space' in ml or ('disk space' in ml and 'injection failed' in ml):
+                    return 'disk_space'
                 if "auto-resume safety" in ml or "monitor auto-resume timeout" in fl:
                     return "monitor_timeout"
                 if "base skin forcing took longer" in ml or "injection threshold" in ml or "injection threshold" in fl or "base skin force time" in fl or "base skin confirmation" in fl or "verification failed" in ml:
@@ -711,6 +717,13 @@ class MessageHandler:
                     if tracker_samples is not None:
                         result["trackerSamples"] = tracker_samples
                     return result
+
+                # Category: Low disk space during overlay creation
+                if 'not enough disk space' in ml or ('disk space' in ml and 'injection failed' in ml):
+                    return {
+                        'code': 'LOW_DISK_SPACE',
+                        'text': 'Low Disk Space -> free up space',
+                    }
 
                 # Fallback: keep it short
                 short = msg.strip()

--- a/test_overlay_disk_space.py
+++ b/test_overlay_disk_space.py
@@ -1,0 +1,59 @@
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from injection.overlay.overlay_manager import OverlayManager
+
+
+class OverlayDiskSpaceTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.manager = OverlayManager(
+            tools_dir=Path(self.temp_dir.name) / 'tools',
+            mods_dir=Path(self.temp_dir.name) / 'mods',
+            game_dir=Path(self.temp_dir.name) / 'game',
+        )
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    @patch('injection.overlay.overlay_manager.report_issue')
+    @patch('injection.overlay.overlay_manager.shutil.disk_usage')
+    def test_reports_when_free_space_is_below_safe_minimum(self, disk_usage, report_issue):
+        disk_usage.return_value = SimpleNamespace(free=512 * 1024 * 1024)
+
+        result = self.manager._report_low_disk_space_failure(mod_names=['skin', 'map'])
+
+        self.assertTrue(result)
+        report_issue.assert_called_once()
+        self.assertEqual(report_issue.call_args.args[0], 'LOW_DISK_SPACE')
+
+    @patch('injection.overlay.overlay_manager.report_issue')
+    @patch('injection.overlay.overlay_manager.shutil.disk_usage')
+    def test_reports_explicit_disk_full_tool_error(self, disk_usage, report_issue):
+        disk_usage.return_value = SimpleNamespace(free=100 * 1024 * 1024 * 1024)
+
+        result = self.manager._report_low_disk_space_failure(
+            output_lines=['mkoverlay failed: no space left on device'],
+        )
+
+        self.assertTrue(result)
+        report_issue.assert_called_once()
+
+    @patch('injection.overlay.overlay_manager.report_issue')
+    @patch('injection.overlay.overlay_manager.shutil.disk_usage')
+    def test_does_not_report_normal_injection_failure(self, disk_usage, report_issue):
+        disk_usage.return_value = SimpleNamespace(free=100 * 1024 * 1024 * 1024)
+
+        result = self.manager._report_low_disk_space_failure(
+            output_lines=['mkoverlay failed: conflicting files'],
+        )
+
+        self.assertFalse(result)
+        report_issue.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/core/issue_reporter.py
+++ b/utils/core/issue_reporter.py
@@ -20,12 +20,14 @@ from utils.core.paths import get_user_data_dir
 _LOCK = threading.Lock()
 _LAST: Dict[str, float] = {}  # naive dedupe: key -> last timestamp
 
-# Keep rose_diagnostics.txt focused on the two settings-related tuning problems that commonly
-# confuse users. Everything else should go to the normal logs.
+# Keep rose_diagnostics.txt focused on actionable tuning problems and critical
+# resource failures that commonly confuse users. Everything else should go to
+# the normal logs.
 _ALLOWED_CODES = {
     'AUTO_RESUME_TRIGGERED',  # Suggest increasing Monitor Auto-Resume Timeout
     'BASE_SKIN_FORCE_SLOW',   # Suggest increasing Injection Threshold
     'BASE_SKIN_VERIFY_FAILED',  # Base skin verification mismatch (often causes skin not to show)
+    'LOW_DISK_SPACE',         # Injection could not build an overlay with available disk space
 }
 
 


### PR DESCRIPTION
## Summary

- Detect insufficient disk space after failed overlay injection attempts, including large map-mod cases.
- Record a `LOW_DISK_SPACE` diagnostic and show actionable guidance in the Settings diagnostics panel.
- Add mocked tests so the behavior can be verified without filling a real disk.

## Root cause

`mkoverlay` can fail when the overlay drive does not have enough free space, but the resulting failure was previously indistinguishable from other injection errors.

## Validation

- `python -m unittest -v test_overlay_disk_space.py`
- `python -m compileall -q injection utils pengu threads test_overlay_disk_space.py`
- `node --check "Pengu Loader\\plugins\\ROSE-SettingsPanel\\index.js"`
- `git diff --check`