### PR TITLE
Add automatic lobby-based Party Mode

### DIFF
--- a/Pengu Loader/plugins/ROSE-PartyMode/index.js
+++ b/Pengu Loader/plugins/ROSE-PartyMode/index.js
@@ -27,6 +27,10 @@
   // Party state
   let partyState = {
     enabled: false,
+    relay_connected: false,
+    auto_reconnect: false,
+    automatic: true,
+    auto_room_active: false,
     my_token: null,
     my_summoner_id: null,
     my_summoner_name: "Unknown",
@@ -683,9 +687,9 @@
         <span class="party-status offline">Offline</span>
       </div>
       <div class="party-content">
-        <div class="party-description">Share your skins with friends in the same lobby. Enable party mode and exchange tokens to connect.</div>
+        <div class="party-description">Automatic mode is always active. Friends using this private Rose build are linked as soon as they are together in the same premade lobby.</div>
 
-        <div class="party-section" id="party-toggle-section">
+        <div class="party-section" id="party-toggle-section" style="display: none;">
           <button class="party-toggle-btn enable" id="party-toggle-btn">
             Enable Party Mode
           </button>
@@ -700,7 +704,7 @@
         </div>
 
         <div class="party-section" id="party-add-section" style="display: none;">
-          <div class="party-section-title">Add Friend</div>
+          <div class="party-section-title">Approve Friend Once</div>
           <div class="add-peer-container">
             <input type="text" class="add-peer-input" id="add-peer-input" placeholder="Paste friend's token here...">
             <button class="add-btn" id="add-peer-btn">Add</button>
@@ -709,7 +713,7 @@
         </div>
 
         <div class="party-section" id="party-peers-section" style="display: none;">
-          <div class="party-section-title">Connected Friends (<span id="peer-count">0</span>)</div>
+          <div class="party-section-title">Approved Friends (<span id="peer-count">0</span> online)</div>
           <div class="peers-list" id="peers-list">
             <div class="no-peers">No friends connected yet</div>
           </div>
@@ -760,6 +764,7 @@
 
     const statusEl = partyPanel.querySelector(".party-status");
     const toggleBtn = document.getElementById("party-toggle-btn");
+    const toggleSection = document.getElementById("party-toggle-section");
     const tokenSection = document.getElementById("party-token-section");
     const addSection = document.getElementById("party-add-section");
     const peersSection = document.getElementById("party-peers-section");
@@ -768,21 +773,31 @@
     const peersList = document.getElementById("peers-list");
 
     if (partyState.enabled) {
-      statusEl.className = "party-status online";
-      statusEl.textContent = "Online";
+      if (partyState.automatic && !partyState.auto_room_active) {
+        statusEl.className = "party-status online";
+        statusEl.textContent = "Waiting for lobby";
+      } else {
+        statusEl.className = partyState.relay_connected
+          ? "party-status online"
+          : "party-status offline";
+        statusEl.textContent = partyState.relay_connected
+          ? (partyState.automatic ? "Lobby linked" : "Online")
+          : "Reconnecting...";
+      }
 
       toggleBtn.className = "party-toggle-btn disable";
       toggleBtn.textContent = "Disable Party Mode";
 
-      tokenSection.style.display = "block";
-      addSection.style.display = "block";
+      toggleSection.style.display = partyState.automatic ? "none" : "block";
+      tokenSection.style.display = partyState.automatic ? "none" : "block";
+      addSection.style.display = partyState.automatic ? "none" : "block";
       peersSection.style.display = "block";
 
       if (partyState.my_token) {
         tokenDisplay.value = partyState.my_token;
       }
 
-      // Update peers list (show all peers, including those still connecting)
+      // Keep approved friends visible even while their Rose is offline.
       const allPeers = partyState.peers || [];
       const connectedPeers = allPeers.filter((p) => p.connected);
       peerCountEl.textContent = connectedPeers.length;
@@ -795,7 +810,7 @@
             const cs = (peer.connection_state || "disconnected").toLowerCase();
             const isWaiting = cs === "connecting" || cs === "handshaking";
             const statusText = isWaiting
-              ? "Waiting for your friend"
+              ? "Saved - reconnects automatically"
               : cs === "connected"
                 ? (peer.in_lobby ? "In lobby" : "Connected")
                 : cs === "handshaking"
@@ -834,6 +849,7 @@
       toggleBtn.className = "party-toggle-btn enable";
       toggleBtn.textContent = "Enable Party Mode";
 
+      toggleSection.style.display = partyState.automatic ? "none" : "block";
       tokenSection.style.display = "none";
       addSection.style.display = "none";
       peersSection.style.display = "none";
@@ -913,6 +929,10 @@
       case "party-state":
         partyState = {
           enabled: data.enabled || false,
+          relay_connected: data.relay_connected || false,
+          auto_reconnect: data.auto_reconnect || false,
+          automatic: data.automatic !== false,
+          auto_room_active: data.auto_room_active || false,
           my_token: data.my_token || null,
           my_summoner_id: data.my_summoner_id || null,
           my_summoner_name: data.my_summoner_name || "Unknown",
@@ -928,6 +948,7 @@
 
         if (data.success) {
           partyState.enabled = true;
+          partyState.auto_reconnect = true;
           partyState.my_token = data.token;
           console.log(`${LOG_PREFIX} Party mode enabled`);
         } else {

--- a/config.py
+++ b/config.py
@@ -23,6 +23,10 @@ log = logging.getLogger(__name__)
 APP_VERSION = "1.2.14"                          # Application version
 APP_USER_AGENT = f"Rose/{APP_VERSION}"  # User-Agent header for HTTP requests
 
+# Automatically discover Party Mode peers from the premade League lobby.
+PARTY_MODE_ALWAYS_ON = True
+PARTY_AUTO_ROOM_MAX_AGE_SECONDS = 6 * 60 * 60
+
 _CONFIG = configparser.ConfigParser()
 _CONFIG_MTIME: float = 0.0  # Last known modification time of config.ini
 

--- a/party/core/__init__.py
+++ b/party/core/__init__.py
@@ -6,5 +6,6 @@ Party Mode Core - Main orchestration
 
 from .party_manager import PartyManager
 from .party_state import PartyState
+from .party_storage import PartyStorage
 
-__all__ = ["PartyManager", "PartyState"]
+__all__ = ["PartyManager", "PartyState", "PartyStorage"]

--- a/party/core/party_manager.py
+++ b/party/core/party_manager.py
@@ -6,10 +6,12 @@ Orchestrator for party mode skin sharing via WebSocket relay.
 """
 
 import asyncio
+import base64
 import secrets
 import time
 from typing import Callable, Dict, List, Optional, Tuple
 
+from config import PARTY_AUTO_ROOM_MAX_AGE_SECONDS, PARTY_MODE_ALWAYS_ON
 from lcu import LCU
 from state import SharedState
 from utils.core.logging import get_logger
@@ -18,29 +20,51 @@ from ..network.ws_relay import PartyRelay, compute_room_key
 from ..protocol.token_codec import PartyToken, create_token
 from ..protocol.message_types import SkinSelection
 from ..discovery.lobby_matcher import LobbyMatcher
+from ..discovery.auto_lobby_room import AutoLobbyRoom
 from ..discovery.skin_collector import SkinCollector, PartySkinData
 from .party_state import PartyState
+from .party_storage import PartyStorage
 
 log = get_logger()
 
 LOBBY_CHECK_INTERVAL = 2.0
 SKIN_BROADCAST_INTERVAL = 1.0
+SKIN_RESYNC_INTERVAL = 10.0
+RECONNECT_MAX_DELAY = 15.0
 
 
 class PartyManager:
     """Main orchestrator for party mode."""
 
-    def __init__(self, lcu: LCU, state: SharedState, injection_manager=None):
+    def __init__(
+        self,
+        lcu: LCU,
+        state: SharedState,
+        injection_manager=None,
+        storage: Optional[PartyStorage] = None,
+    ):
         self.lcu = lcu
         self.state = state
         self.injection_manager = injection_manager
+        self._storage = storage or PartyStorage()
 
         self.party_state = PartyState()
+        self.party_state.automatic = PARTY_MODE_ALWAYS_ON
 
         # Networking
         self._my_key: Optional[bytes] = None
         self._my_token: Optional[PartyToken] = None
         self._relay: Optional[PartyRelay] = None
+        self._active_room_key: Optional[str] = None
+        self._active_room_host_id: Optional[int] = None
+        self._active_room_host_key: Optional[bytes] = None
+        self._personal_room_key: Optional[str] = None
+        self._auto_lobby_room = AutoLobbyRoom()
+        self._ignored_peer_ids = set()
+        self._trusted_peer_names: Dict[int, str] = {}
+        self._relay_lock = asyncio.Lock()
+        self._next_reconnect_at = 0.0
+        self._reconnect_delay = 1.0
 
         # Discovery
         self._lobby_matcher: Optional[LobbyMatcher] = None
@@ -48,6 +72,8 @@ class PartyManager:
 
         # Background tasks
         self._running = False
+        self._restore_attempted = False
+        self._enable_lock = asyncio.Lock()
         self._lobby_check_task: Optional[asyncio.Task] = None
         self._skin_broadcast_task: Optional[asyncio.Task] = None
 
@@ -72,62 +98,211 @@ class PartyManager:
         self._on_peer_update = on_peer_update
 
     async def enable(self) -> str:
-        """Enable party mode: generate token and connect to relay room."""
+        """Enable Party Mode and restore the last approved room."""
+        async with self._enable_lock:
+            if self.party_state.enabled:
+                return self.party_state.my_token or ""
+
+            log.info("[PARTY] Enabling party mode...")
+
+            try:
+                self._lobby_matcher = LobbyMatcher(self.lcu, self.state)
+                self._skin_collector = SkinCollector(self.state)
+
+                my_summoner_id = self._lobby_matcher.get_my_summoner_id()
+                my_summoner_name = self._lobby_matcher.get_my_summoner_name()
+
+                if not my_summoner_id:
+                    raise RuntimeError(
+                        "Failed to get summoner ID - is League client running?"
+                    )
+
+                self.party_state.my_summoner_id = my_summoner_id
+                self.party_state.my_summoner_name = my_summoner_name
+
+                account = self._storage.load_account(my_summoner_id)
+                self._my_key = self._load_or_create_personal_key(account)
+                self.party_state.enabled = True
+                self.party_state.auto_reconnect = True
+                self.party_state.automatic = PARTY_MODE_ALWAYS_ON
+                if PARTY_MODE_ALWAYS_ON:
+                    self._ignored_peer_ids = set()
+                    self._trusted_peer_names = {}
+                else:
+                    self._ignored_peer_ids = {
+                        int(value) for value in account.get(
+                            "ignored_peers", []
+                        )
+                    }
+                    self._trusted_peer_names = {
+                        int(peer_id): peer_data.get(
+                            "summoner_name", "Unknown"
+                        )
+                        for peer_id, peer_data in account.get(
+                            "trusted_peers", {}
+                        ).items()
+                    }
+
+                own_room_key = compute_room_key(my_summoner_id, self._my_key)
+                self._personal_room_key = own_room_key
+
+                if PARTY_MODE_ALWAYS_ON:
+                    updated_at = float(
+                        account.get("auto_room_updated_at") or 0
+                    )
+                    if (
+                        account.get("auto_room_key")
+                        and time.time() - updated_at
+                        <= PARTY_AUTO_ROOM_MAX_AGE_SECONDS
+                    ):
+                        self._auto_lobby_room.restore(
+                            account.get("auto_room_key"),
+                            account.get("auto_lobby_members", []),
+                        )
+
+                    auto_room_key = self._auto_lobby_room.update(
+                        getattr(self.state, "phase", ""),
+                        self._lobby_matcher.get_lobby_summoner_ids(),
+                        my_summoner_id,
+                    )
+                    self._active_room_key = auto_room_key or own_room_key
+                    self._active_room_host_id = my_summoner_id
+                    self._active_room_host_key = self._my_key
+                    self.party_state.auto_room_active = bool(auto_room_key)
+                else:
+                    saved_room_key = account.get("active_room_key")
+                    saved_host_id = int(
+                        account.get("active_room_host_id") or my_summoner_id
+                    )
+                    saved_host_key = self._decode_stored_key(
+                        account.get("active_room_host_key")
+                    )
+                    if (
+                        saved_room_key
+                        and saved_host_key
+                        and compute_room_key(saved_host_id, saved_host_key)
+                        == saved_room_key
+                    ):
+                        self._active_room_key = saved_room_key
+                        self._active_room_host_id = saved_host_id
+                        self._active_room_host_key = saved_host_key
+                    else:
+                        self._active_room_key = own_room_key
+                        self._active_room_host_id = my_summoner_id
+                        self._active_room_host_key = self._my_key
+
+                # The displayed invitation always points at the room we are
+                # actually using. Friends-of-friends therefore join the same
+                # group instead of accidentally creating a split room.
+                self._refresh_group_token()
+                token_str = self.party_state.my_token
+
+                if not PARTY_MODE_ALWAYS_ON:
+                    for peer_id, peer_data in account.get(
+                        "trusted_peers", {}
+                    ).items():
+                        sid = int(peer_id)
+                        if sid in self._ignored_peer_ids:
+                            continue
+                        self.party_state.add_peer(
+                            sid,
+                            summoner_name=peer_data.get(
+                                "summoner_name", "Unknown"
+                            ),
+                            connected=False,
+                            connection_state="connecting",
+                        )
+
+                own_key_b64 = base64.urlsafe_b64encode(self._my_key).decode("ascii")
+                self._storage.update_account(
+                    my_summoner_id,
+                    auto_enable=True,
+                    own_key=own_key_b64,
+                    active_room_key=(
+                        None
+                        if PARTY_MODE_ALWAYS_ON
+                        else (
+                            self._active_room_key
+                            if self._active_room_key != own_room_key
+                            else None
+                        )
+                    ),
+                    active_room_host_id=(
+                        my_summoner_id
+                        if PARTY_MODE_ALWAYS_ON
+                        else self._active_room_host_id
+                    ),
+                    active_room_host_key=(
+                        None
+                        if PARTY_MODE_ALWAYS_ON
+                        or self._active_room_key == own_room_key
+                        else base64.urlsafe_b64encode(
+                            self._active_room_host_key
+                        ).decode("ascii")
+                    ),
+                    auto_room_key=(
+                        self._auto_lobby_room.active_room_key
+                        if PARTY_MODE_ALWAYS_ON
+                        else account.get("auto_room_key")
+                    ),
+                    auto_lobby_members=(
+                        list(self._auto_lobby_room.lobby_members)
+                        if PARTY_MODE_ALWAYS_ON
+                        else account.get("auto_lobby_members", [])
+                    ),
+                    auto_room_updated_at=(
+                        time.time()
+                        if PARTY_MODE_ALWAYS_ON
+                        and self._auto_lobby_room.active_room_key
+                        else account.get("auto_room_updated_at")
+                    ),
+                )
+
+                # A temporary relay outage no longer disables Party Mode. The
+                # background loop keeps retrying until the connection returns.
+                await self._replace_relay(self._active_room_key)
+
+                self._running = True
+                self._lobby_check_task = asyncio.create_task(
+                    self._lobby_check_loop()
+                )
+                self._skin_broadcast_task = asyncio.create_task(
+                    self._skin_broadcast_loop()
+                )
+
+                log.info(
+                    f"[PARTY] Party mode enabled with persistent room "
+                    f"{self._active_room_key[:8]}..."
+                )
+                self._notify_state_change()
+                return token_str
+
+            except Exception as e:
+                log.error(f"[PARTY] Failed to enable party mode: {e}")
+                await self.disable(persist=False)
+                raise RuntimeError(f"Failed to enable party mode: {e}")
+
+    async def restore_if_configured(self) -> bool:
+        """Auto-enable once for the current account when it was enabled before."""
         if self.party_state.enabled:
-            return self.party_state.my_token or ""
+            return True
+        if self._restore_attempted:
+            return False
 
-        log.info("[PARTY] Enabling party mode...")
+        matcher = LobbyMatcher(self.lcu, self.state)
+        summoner_id = matcher.get_my_summoner_id()
+        if not summoner_id:
+            return False
+        self._restore_attempted = True
+        account = self._storage.load_account(summoner_id)
+        if not PARTY_MODE_ALWAYS_ON and not account.get("auto_enable"):
+            return False
 
-        try:
-            self._lobby_matcher = LobbyMatcher(self.lcu, self.state)
-            self._skin_collector = SkinCollector(self.state)
+        log.info("[PARTY] Starting automatic Party Mode session")
+        await self.enable()
+        return True
 
-            my_summoner_id = self._lobby_matcher.get_my_summoner_id()
-            my_summoner_name = self._lobby_matcher.get_my_summoner_name()
-
-            if not my_summoner_id:
-                raise RuntimeError("Failed to get summoner ID - is League client running?")
-
-            self.party_state.my_summoner_id = my_summoner_id
-            self.party_state.my_summoner_name = my_summoner_name
-
-            # Generate key and token
-            self._my_key = secrets.token_bytes(32)
-            self._my_token = create_token(
-                summoner_id=my_summoner_id,
-                encryption_key=self._my_key,
-            )
-
-            token_str = self._my_token.encode()
-            self.party_state.my_token = token_str
-            self.party_state.enabled = True
-
-            # Connect to relay room
-            room_key = compute_room_key(my_summoner_id, self._my_key)
-            self._relay = PartyRelay(room_key)
-            self._relay.set_on_members_changed(self._on_relay_members_changed)
-
-            if await self._relay.connect():
-                await self._relay.join(my_summoner_id, my_summoner_name)
-                log.info(f"[PARTY] Connected to relay room {room_key[:8]}...")
-            else:
-                log.warning("[PARTY] Relay connection failed, party mode limited")
-
-            # Start background tasks
-            self._running = True
-            self._lobby_check_task = asyncio.create_task(self._lobby_check_loop())
-            self._skin_broadcast_task = asyncio.create_task(self._skin_broadcast_loop())
-
-            log.info(f"[PARTY] Party mode enabled. Token: {token_str[:20]}...")
-            self._notify_state_change()
-            return token_str
-
-        except Exception as e:
-            log.error(f"[PARTY] Failed to enable party mode: {e}")
-            await self.disable()
-            raise RuntimeError(f"Failed to enable party mode: {e}")
-
-    async def disable(self):
+    async def disable(self, persist: bool = True):
         """Disable party mode."""
         log.info("[PARTY] Disabling party mode...")
         self._running = False
@@ -147,15 +322,27 @@ class PartyManager:
             await self._relay.disconnect()
             self._relay = None
 
+        if persist and self.party_state.my_summoner_id:
+            self._storage.update_account(
+                self.party_state.my_summoner_id,
+                auto_enable=False,
+            )
+
         self.party_state.clear_all()
         self._my_key = None
         self._my_token = None
+        self._active_room_key = None
+        self._active_room_host_id = None
+        self._active_room_host_key = None
+        self._personal_room_key = None
+        self._auto_lobby_room.clear()
+        self._trusted_peer_names = {}
 
         log.info("[PARTY] Party mode disabled")
         self._notify_state_change()
 
     async def add_peer(self, token_str: str) -> Tuple[bool, Optional[str]]:
-        """Join another player's party room by pasting their token."""
+        """Approve a friend once and persist their shared relay room."""
         if not self.party_state.enabled:
             return False, "Party mode not enabled"
 
@@ -173,30 +360,39 @@ class PartyManager:
                 for member in self._relay.members:
                     if member.get("summoner_id") == token.summoner_id:
                         log.info(f"[PARTY] Peer {token.summoner_id} is already in our room")
+                        self._remember_peer(
+                            token.summoner_id,
+                            member.get("summoner_name", "Unknown"),
+                        )
                         return True, None
 
             # Check if we're already in the target room
             target_room_key = compute_room_key(token.summoner_id, token.encryption_key)
             if self._relay and self._relay.room_key == target_room_key:
-                log.info(f"[PARTY] Already in peer's room")
+                log.info("[PARTY] Already in peer's room")
+                self._remember_peer(token.summoner_id)
                 return True, None
 
-            # Disconnect from current room and join the host's room
-            if self._relay:
-                await self._relay.disconnect()
-
-            self._relay = PartyRelay(target_room_key)
-            self._relay.set_on_members_changed(self._on_relay_members_changed)
-
-            if not await self._relay.connect():
+            # Switch once, then remember the room across Rose restarts.
+            if not await self._replace_relay(target_room_key):
                 return False, "Failed to connect to relay"
 
-            await self._relay.join(
+            self._active_room_key = target_room_key
+            self._active_room_host_id = token.summoner_id
+            self._active_room_host_key = token.encryption_key
+            self._refresh_group_token()
+            self._remember_peer(token.summoner_id)
+            self._storage.update_account(
                 self.party_state.my_summoner_id,
-                self.party_state.my_summoner_name,
+                active_room_key=target_room_key,
+                active_room_host_id=token.summoner_id,
+                active_room_host_key=base64.urlsafe_b64encode(
+                    token.encryption_key
+                ).decode("ascii"),
             )
 
             log.info(f"[PARTY] Joined party room {target_room_key[:8]}...")
+            self._notify_state_change()
             return True, None
 
         except ValueError as e:
@@ -209,12 +405,38 @@ class PartyManager:
             return False, f"Unexpected error: {e}"
 
     async def remove_peer(self, summoner_id: int):
-        """Remove a peer (not really applicable in shared room model, but kept for UI)."""
+        """Forget a persistent friend and stop applying their selections."""
+        my_id = self.party_state.my_summoner_id
+        if my_id:
+            self._storage.forget_peer(my_id, summoner_id)
+        self._ignored_peer_ids.add(int(summoner_id))
+        self._trusted_peer_names.pop(int(summoner_id), None)
         self.party_state.remove_peer(summoner_id)
         if self._skin_collector:
             self._skin_collector.clear_peer(summoner_id)
+
+        # If this friend hosted the saved room, return to our own stable room.
+        if (
+            my_id
+            and self._my_key
+            and self._active_room_host_id == int(summoner_id)
+            and int(summoner_id) != int(my_id)
+        ):
+            own_room_key = compute_room_key(my_id, self._my_key)
+            self._active_room_key = own_room_key
+            self._active_room_host_id = my_id
+            self._active_room_host_key = self._my_key
+            self._refresh_group_token()
+            self._storage.update_account(
+                my_id,
+                active_room_key=None,
+                active_room_host_id=my_id,
+                active_room_host_key=None,
+            )
+            await self._replace_relay(own_room_key)
+
         self._notify_state_change()
-        log.info(f"[PARTY] Removed peer {summoner_id}")
+        log.info(f"[PARTY] Forgot persistent peer {summoner_id}")
 
     async def broadcast_skin_update(self):
         """Broadcast our current skin selection to the relay room."""
@@ -266,17 +488,23 @@ class PartyManager:
     def _on_relay_members_changed(self, members: list):
         """Called by the relay when the member list changes."""
         my_id = self.party_state.my_summoner_id
+        self.party_state.relay_connected = bool(
+            self._relay and self._relay.connected
+        )
+        self._reconnect_delay = 1.0
+        self._next_reconnect_at = 0.0
 
         # Update party state with relay members (exclude ourselves)
         current_peer_ids = set()
         for member in members:
-            sid = member.get("summoner_id", 0)
-            if sid == my_id or not sid:
+            sid = int(member.get("summoner_id", 0) or 0)
+            if sid == my_id or not sid or sid in self._ignored_peer_ids:
                 continue
 
             current_peer_ids.add(sid)
             name = member.get("summoner_name", "Unknown")
             skin = member.get("skin")
+            self._remember_peer(sid, name)
 
             if sid not in self.party_state.peers:
                 self.party_state.add_peer(
@@ -299,42 +527,59 @@ class PartyManager:
                         champion_id=skin.get("champion_id", 0),
                         skin_id=skin.get("skin_id", 0),
                         chroma_id=skin.get("chroma_id"),
+                        custom_mod_hash=skin.get("custom_mod_hash"),
+                        is_custom=bool(skin.get("is_custom")),
                     )
                     self.party_state.update_peer_skin(sid, sel)
                     self._skin_collector.update_from_peer(sel)
                 except Exception as e:
                     log.debug(f"[PARTY] Failed to update peer skin: {e}")
 
-        # Remove peers that are no longer in the room
+        # Keep approved friends visible while offline. They are automatically
+        # marked connected again as soon as their Rose rejoins the room.
         stale = [sid for sid in self.party_state.peers if sid not in current_peer_ids]
         for sid in stale:
-            self.party_state.remove_peer(sid)
+            peer = self.party_state.peers[sid]
+            peer.connected = False
+            peer.connection_state = "connecting"
+            peer.in_lobby = False
             if self._skin_collector:
                 self._skin_collector.clear_peer(sid)
-            log.info(f"[PARTY] Removed peer {sid}")
+            log.info(f"[PARTY] Peer {sid} offline; waiting for automatic reconnect")
 
         self._notify_state_change()
 
     # ─── Background tasks ────────────────────────────────────────────────
 
     async def _lobby_check_loop(self):
-        """Check lobby membership and update peer status."""
+        """Check lobby membership and repair relay connectivity."""
         while self._running:
             try:
                 await asyncio.sleep(LOBBY_CHECK_INTERVAL)
                 if not self._running or not self._lobby_matcher:
                     continue
 
+                if PARTY_MODE_ALWAYS_ON:
+                    await self._sync_auto_lobby_room()
+
+                if not self._relay or not self._relay.connected:
+                    self.party_state.relay_connected = False
+                    await self._ensure_relay_connected()
+
                 lobby_ids = self._lobby_matcher.get_all_summoner_ids()
+                state_changed = False
                 for sid in self.party_state.peers:
                     in_lobby = sid in lobby_ids
                     if self.party_state.peers[sid].in_lobby != in_lobby:
                         self.party_state.update_peer_lobby_status(sid, in_lobby)
+                        state_changed = True
                         name = self.party_state.peers[sid].summoner_name
                         if in_lobby:
                             log.info(f"[PARTY] Peer {name} joined our lobby")
                         else:
                             log.info(f"[PARTY] Peer {name} left our lobby")
+                if state_changed:
+                    self._notify_state_change()
 
             except asyncio.CancelledError:
                 break
@@ -346,6 +591,7 @@ class PartyManager:
         last_skin_id = None
         last_chroma_id = None
         last_custom_mod = None
+        last_broadcast_at = 0.0
 
         while self._running:
             try:
@@ -358,19 +604,168 @@ class PartyManager:
                 current_custom_mod = getattr(self.state, "selected_custom_mod", None)
                 # Track custom mod by its path to detect changes
                 custom_mod_key = current_custom_mod.get("relative_path") if current_custom_mod else None
+                now = time.monotonic()
 
                 if (current_skin_id != last_skin_id or
                     current_chroma_id != last_chroma_id or
-                    custom_mod_key != last_custom_mod):
+                    custom_mod_key != last_custom_mod or
+                    now - last_broadcast_at >= SKIN_RESYNC_INTERVAL):
                     last_skin_id = current_skin_id
                     last_chroma_id = current_chroma_id
                     last_custom_mod = custom_mod_key
                     await self.broadcast_skin_update()
+                    last_broadcast_at = now
+
+                # The invitation displayed in the UI always remains valid.
+                if self._my_token and self._my_token.time_until_expiry() < 300:
+                    self._refresh_group_token()
+                    self._notify_state_change()
 
             except asyncio.CancelledError:
                 break
             except Exception as e:
                 log.info(f"[PARTY] Skin broadcast error: {e}")
+
+    def _load_or_create_personal_key(self, account: dict) -> bytes:
+        key = self._decode_stored_key(account.get("own_key"))
+        if key:
+            return key
+        if account.get("own_key"):
+            log.warning("[PARTY] Stored personal room key is invalid; rotating it")
+        return secrets.token_bytes(32)
+
+    @staticmethod
+    def _decode_stored_key(encoded) -> Optional[bytes]:
+        if not encoded:
+            return None
+        try:
+            key = base64.urlsafe_b64decode(str(encoded).encode("ascii"))
+            return key if len(key) == 32 else None
+        except Exception:
+            return None
+
+    def _refresh_group_token(self):
+        if not self._active_room_host_id or not self._active_room_host_key:
+            return
+        self._my_token = create_token(
+            summoner_id=self._active_room_host_id,
+            encryption_key=self._active_room_host_key,
+        )
+        self.party_state.my_token = self._my_token.encode()
+
+    def _remember_peer(self, summoner_id: int, summoner_name: str = "Unknown"):
+        sid = int(summoner_id)
+        if sid in self._ignored_peer_ids:
+            self._ignored_peer_ids.remove(sid)
+        my_id = self.party_state.my_summoner_id
+        old_name = self._trusted_peer_names.get(sid)
+        resolved_name = (
+            summoner_name
+            if summoner_name and summoner_name != "Unknown"
+            else old_name or "Unknown"
+        )
+        if (
+            my_id
+            and not PARTY_MODE_ALWAYS_ON
+            and old_name != resolved_name
+        ):
+            self._storage.trust_peer(my_id, sid, resolved_name)
+        self._trusted_peer_names[sid] = resolved_name
+        if sid not in self.party_state.peers:
+            self.party_state.add_peer(
+                sid,
+                summoner_name=resolved_name,
+                connected=False,
+                connection_state="connecting",
+            )
+
+    async def _sync_auto_lobby_room(self):
+        """Follow the premade lobby while freezing the room during the game."""
+        if (
+            not self._lobby_matcher
+            or not self._personal_room_key
+            or not self.party_state.my_summoner_id
+        ):
+            return
+
+        auto_room_key = self._auto_lobby_room.update(
+            getattr(self.state, "phase", ""),
+            self._lobby_matcher.get_lobby_summoner_ids(),
+            self.party_state.my_summoner_id,
+        )
+        target_room_key = auto_room_key or self._personal_room_key
+        auto_active = bool(auto_room_key)
+        self.party_state.auto_room_active = auto_active
+
+        if target_room_key == self._active_room_key:
+            return
+
+        old_room_key = self._active_room_key
+        self._active_room_key = target_room_key
+        self.party_state.clear_peers()
+        if self._skin_collector:
+            self._skin_collector.clear_all()
+
+        self._storage.update_account(
+            self.party_state.my_summoner_id,
+            auto_room_key=auto_room_key,
+            auto_lobby_members=list(self._auto_lobby_room.lobby_members),
+            auto_room_updated_at=(time.time() if auto_active else None),
+        )
+
+        log.info(
+            f"[PARTY] Automatic lobby room changed "
+            f"{(old_room_key or 'none')[:8]} -> {target_room_key[:8]}"
+        )
+        await self._replace_relay(target_room_key)
+
+    async def _replace_relay(self, room_key: str) -> bool:
+        """Atomically replace the transport and announce our current identity."""
+        async with self._relay_lock:
+            if self._relay:
+                await self._relay.disconnect()
+
+            relay = PartyRelay(room_key)
+            relay.set_on_members_changed(self._on_relay_members_changed)
+            self._relay = relay
+            self.party_state.relay_connected = False
+
+            if not await relay.connect():
+                self._schedule_reconnect()
+                self._notify_state_change()
+                return False
+
+            await relay.join(
+                self.party_state.my_summoner_id,
+                self.party_state.my_summoner_name,
+            )
+            self.party_state.relay_connected = True
+            self._reconnect_delay = 1.0
+            self._next_reconnect_at = 0.0
+            await self.broadcast_skin_update()
+            self._notify_state_change()
+            return True
+
+    async def _ensure_relay_connected(self) -> bool:
+        if self._relay and self._relay.connected:
+            return True
+        if not self._active_room_key:
+            return False
+        if time.monotonic() < self._next_reconnect_at:
+            return False
+
+        log.info(
+            f"[PARTY] Reconnecting to persistent room "
+            f"{self._active_room_key[:8]}..."
+        )
+        return await self._replace_relay(self._active_room_key)
+
+    def _schedule_reconnect(self):
+        self._next_reconnect_at = time.monotonic() + self._reconnect_delay
+        self._reconnect_delay = min(
+            self._reconnect_delay * 2.0,
+            RECONNECT_MAX_DELAY,
+        )
 
     @staticmethod
     def _hash_custom_mod(mod_path: str) -> Optional[str]:

--- a/party/core/party_state.py
+++ b/party/core/party_state.py
@@ -29,6 +29,10 @@ class PartyState:
 
     # Party mode status
     enabled: bool = False
+    relay_connected: bool = False
+    auto_reconnect: bool = False
+    automatic: bool = False
+    auto_room_active: bool = False
     my_token: Optional[str] = None
     my_summoner_id: Optional[int] = None
     my_summoner_name: str = "Unknown"
@@ -130,10 +134,19 @@ class PartyState:
                 if p.connected and p.skin_selection
             }
 
+    def clear_peers(self):
+        """Clear transient room members without disabling Party Mode."""
+        with self._lock:
+            self.peers.clear()
+            self.party_skins.clear()
+
     def clear_all(self):
         """Clear all party state"""
         with self._lock:
             self.enabled = False
+            self.relay_connected = False
+            self.auto_reconnect = False
+            self.auto_room_active = False
             self.my_token = None
             self.peers.clear()
             self.party_skins.clear()
@@ -143,6 +156,10 @@ class PartyState:
         with self._lock:
             return {
                 "enabled": self.enabled,
+                "relay_connected": self.relay_connected,
+                "auto_reconnect": self.auto_reconnect,
+                "automatic": self.automatic,
+                "auto_room_active": self.auto_room_active,
                 "my_token": self.my_token,
                 "my_summoner_id": self.my_summoner_id,
                 "my_summoner_name": self.my_summoner_name,

--- a/party/core/party_storage.py
+++ b/party/core/party_storage.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Durable, account-scoped settings for Party Mode.
+
+Pairing data lives in Rose's user-data directory so updating or reinstalling
+the application doesn't make users exchange invitations again.
+"""
+
+import json
+import os
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from utils.core.logging import get_logger
+from utils.core.paths import get_state_dir
+
+log = get_logger()
+
+STORAGE_VERSION = 1
+
+
+class PartyStorage:
+    """Small atomic JSON store keyed by League summoner ID."""
+
+    def __init__(self, path: Optional[Path] = None):
+        self.path = path or (get_state_dir() / "party_mode.json")
+
+    @staticmethod
+    def _default_account() -> Dict[str, Any]:
+        return {
+            "auto_enable": False,
+            "own_key": None,
+            "active_room_key": None,
+            "active_room_host_id": None,
+            "active_room_host_key": None,
+            "auto_room_key": None,
+            "auto_lobby_members": [],
+            "auto_room_updated_at": None,
+            "trusted_peers": {},
+            "ignored_peers": [],
+        }
+
+    def load_account(self, summoner_id: int) -> Dict[str, Any]:
+        data = self._read()
+        account = data.get("accounts", {}).get(str(int(summoner_id)), {})
+        result = self._default_account()
+        if isinstance(account, dict):
+            result.update(account)
+        if not isinstance(result.get("trusted_peers"), dict):
+            result["trusted_peers"] = {}
+        if not isinstance(result.get("ignored_peers"), list):
+            result["ignored_peers"] = []
+        return deepcopy(result)
+
+    def update_account(self, summoner_id: int, **changes: Any) -> Dict[str, Any]:
+        data = self._read()
+        accounts = data.setdefault("accounts", {})
+        account = self._default_account()
+        existing = accounts.get(str(int(summoner_id)))
+        if isinstance(existing, dict):
+            account.update(existing)
+        account.update(changes)
+        accounts[str(int(summoner_id))] = account
+        self._write(data)
+        return deepcopy(account)
+
+    def trust_peer(
+        self,
+        summoner_id: int,
+        peer_id: int,
+        summoner_name: str = "Unknown",
+    ) -> None:
+        account = self.load_account(summoner_id)
+        trusted = dict(account["trusted_peers"])
+        trusted[str(int(peer_id))] = {
+            "summoner_name": str(summoner_name or "Unknown"),
+        }
+        ignored = [
+            value
+            for value in account["ignored_peers"]
+            if int(value) != int(peer_id)
+        ]
+        self.update_account(
+            summoner_id,
+            trusted_peers=trusted,
+            ignored_peers=ignored,
+        )
+
+    def forget_peer(self, summoner_id: int, peer_id: int) -> None:
+        account = self.load_account(summoner_id)
+        trusted = dict(account["trusted_peers"])
+        trusted.pop(str(int(peer_id)), None)
+        ignored = {int(value) for value in account["ignored_peers"]}
+        ignored.add(int(peer_id))
+        self.update_account(
+            summoner_id,
+            trusted_peers=trusted,
+            ignored_peers=sorted(ignored),
+        )
+
+    def _read(self) -> Dict[str, Any]:
+        try:
+            with open(self.path, "r", encoding="utf-8") as handle:
+                data = json.load(handle)
+            if not isinstance(data, dict):
+                raise ValueError("Party settings root must be an object")
+            if not isinstance(data.get("accounts"), dict):
+                data["accounts"] = {}
+            data["version"] = STORAGE_VERSION
+            return data
+        except FileNotFoundError:
+            return {"version": STORAGE_VERSION, "accounts": {}}
+        except Exception as exc:
+            log.warning(f"[PARTY] Could not read persistent settings: {exc}")
+            return {"version": STORAGE_VERSION, "accounts": {}}
+
+    def _write(self, data: Dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = self.path.with_suffix(self.path.suffix + ".tmp")
+        try:
+            with open(temp_path, "w", encoding="utf-8") as handle:
+                json.dump(data, handle, indent=2, sort_keys=True)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_path, self.path)
+        finally:
+            try:
+                if temp_path.exists():
+                    temp_path.unlink()
+            except OSError:
+                pass

--- a/party/discovery/__init__.py
+++ b/party/discovery/__init__.py
@@ -8,3 +8,6 @@ from .lobby_matcher import LobbyMatcher
 from .skin_collector import SkinCollector
 
 __all__ = ["LobbyMatcher", "SkinCollector"]
+from .auto_lobby_room import AutoLobbyRoom, compute_auto_room_key
+
+__all__ = ["AutoLobbyRoom", "compute_auto_room_key"]

--- a/party/discovery/auto_lobby_room.py
+++ b/party/discovery/auto_lobby_room.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Stable automatic Party Mode room selection.
+
+The room is derived from the premade lobby members, then frozen across queue,
+ready-check, champion select, and the game. Random matchmade teammates are
+never used to change the room.
+"""
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Iterable, Optional, Tuple
+
+
+AUTO_ROOM_NAMESPACE = "rose-private-auto-party-v1"
+
+DISCOVERY_PHASES = {"Lobby", "Matchmaking", "ReadyCheck"}
+HOLD_PHASES = {
+    "Matchmaking",
+    "ReadyCheck",
+    "ChampSelect",
+    "GameStart",
+    "Reconnect",
+    "InProgress",
+}
+RESET_PHASES = {
+    "PreEndOfGame",
+    "EndOfGame",
+    "WaitingForStats",
+    "TerminatedInError",
+}
+
+
+def normalize_lobby_members(
+    summoner_ids: Iterable[int],
+    my_summoner_id: int,
+) -> Tuple[int, ...]:
+    members = {
+        int(value)
+        for value in summoner_ids
+        if int(value) > 0
+    }
+    if int(my_summoner_id) not in members or len(members) < 2:
+        return ()
+    return tuple(sorted(members))
+
+
+def compute_auto_room_key(members: Iterable[int]) -> str:
+    normalized = tuple(sorted({int(value) for value in members}))
+    payload = (
+        AUTO_ROOM_NAMESPACE
+        + ":"
+        + ",".join(str(value) for value in normalized)
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]
+
+
+@dataclass
+class AutoLobbyRoom:
+    """State machine that prevents room churn during game transitions."""
+
+    active_room_key: Optional[str] = None
+    lobby_members: Tuple[int, ...] = field(default_factory=tuple)
+
+    def restore(
+        self,
+        room_key: Optional[str],
+        lobby_members: Iterable[int],
+    ) -> None:
+        members = tuple(sorted({int(value) for value in lobby_members}))
+        if room_key and len(members) >= 2:
+            self.active_room_key = str(room_key)
+            self.lobby_members = members
+
+    def update(
+        self,
+        phase: str,
+        premade_lobby_ids: Iterable[int],
+        my_summoner_id: int,
+    ) -> Optional[str]:
+        phase = str(phase or "")
+        members = normalize_lobby_members(
+            premade_lobby_ids,
+            my_summoner_id,
+        )
+
+        # Lobby membership is authoritative before matchmaking. If somebody
+        # joins or leaves, every Rose client derives the same replacement room.
+        if phase in DISCOVERY_PHASES and members:
+            room_key = compute_auto_room_key(members)
+            self.active_room_key = room_key
+            self.lobby_members = members
+            return room_key
+
+        # In the plain lobby, a one-person lobby means the premade disbanded.
+        if phase == "Lobby" and not members:
+            self.clear()
+            return None
+
+        # Once matchmaking starts, never derive from champion-select myTeam:
+        # that list contains matchmade strangers and can change visibility.
+        if phase in HOLD_PHASES:
+            return self.active_room_key
+
+        if phase in RESET_PHASES:
+            self.clear()
+            return None
+
+        return self.active_room_key
+
+    def clear(self) -> None:
+        self.active_room_key = None
+        self.lobby_members = ()

--- a/party/integration/ui_bridge.py
+++ b/party/integration/ui_bridge.py
@@ -115,12 +115,12 @@ class PartyUIBridge:
             }
 
         try:
-            success = await self.party_manager.add_peer(token)
+            success, error = await self.party_manager.add_peer(token)
             self._broadcast_state()
             return {
                 "type": "party-peer-added",
                 "success": success,
-                "error": None if success else "Failed to connect to peer",
+                "error": error,
             }
         except Exception as e:
             log.error(f"[PARTY_UI] Failed to add peer: {e}")

--- a/party/network/ws_relay.py
+++ b/party/network/ws_relay.py
@@ -55,7 +55,11 @@ class PartyRelay:
 
     @property
     def connected(self) -> bool:
-        return self._connected and self._ws is not None
+        return (
+            self._connected
+            and self._ws is not None
+            and not bool(getattr(self._ws, "closed", False))
+        )
 
     def set_on_members_changed(self, callback: Callable[[List[dict]], None]):
         """Called whenever the member list changes (join/leave/skin update)."""
@@ -63,6 +67,8 @@ class PartyRelay:
 
     async def connect(self, timeout: float = 15.0) -> bool:
         """Connect to the relay room."""
+        if self.connected:
+            return True
         if not RELAY_URL:
             log.warning("[RELAY] No relay URL configured")
             return False
@@ -81,6 +87,8 @@ class PartyRelay:
             log.info("[RELAY] Connected")
             return True
         except Exception as e:
+            self._connected = False
+            self._ws = None
             log.warning(f"[RELAY] Connection failed: {e}")
             return False
 
@@ -129,8 +137,9 @@ class PartyRelay:
         if self._ws and self._connected:
             try:
                 await self._ws.send(json.dumps(data))
-            except ConnectionClosed:
+            except (ConnectionClosed, OSError) as exc:
                 self._connected = False
+                log.info(f"[RELAY] Send failed; reconnect scheduled: {exc}")
 
     async def _receive_loop(self):
         try:
@@ -144,7 +153,9 @@ class PartyRelay:
                         continue
 
                     if msg.get("type") == "members":
-                        self.members = msg.get("members", [])
+                        self.members = self._deduplicate_members(
+                            msg.get("members", [])
+                        )
                         log.info(f"[RELAY] Members updated: {len(self.members)} in room")
                         if self._on_members_changed:
                             try:
@@ -159,6 +170,26 @@ class PartyRelay:
         except Exception as e:
             log.warning(f"[RELAY] Receive error: {e}")
             self._connected = False
+        finally:
+            if self._ws and bool(getattr(self._ws, "closed", False)):
+                self._connected = False
+
+    @staticmethod
+    def _deduplicate_members(members: list) -> List[dict]:
+        """Collapse stale duplicate sockets after a fast Rose restart."""
+        by_summoner_id: Dict[int, dict] = {}
+        for member in members if isinstance(members, list) else []:
+            if not isinstance(member, dict):
+                continue
+            summoner_id = int(member.get("summoner_id", 0) or 0)
+            if not summoner_id:
+                continue
+            existing = by_summoner_id.get(summoner_id)
+            if existing is None or (
+                not existing.get("skin") and member.get("skin")
+            ):
+                by_summoner_id[summoner_id] = member
+        return list(by_summoner_id.values())
 
     async def _keepalive_loop(self):
         try:
@@ -167,7 +198,9 @@ class PartyRelay:
                 if self._ws and self._connected:
                     try:
                         await self._ws.send("ping")
-                    except Exception:
+                    except Exception as exc:
+                        self._connected = False
+                        log.info(f"[RELAY] Keepalive failed: {exc}")
                         break
         except asyncio.CancelledError:
             return

--- a/party/protocol/message_types.py
+++ b/party/protocol/message_types.py
@@ -84,6 +84,8 @@ class SkinSelection:
     skin_id: int
     chroma_id: Optional[int] = None
     custom_mod_path: Optional[str] = None
+    custom_mod_hash: Optional[str] = None
+    is_custom: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for message payload"""
@@ -99,6 +101,8 @@ class SkinSelection:
             skin_id=data["skin_id"],
             chroma_id=data.get("chroma_id"),
             custom_mod_path=data.get("custom_mod_path"),
+            custom_mod_hash=data.get("custom_mod_hash"),
+            is_custom=bool(data.get("is_custom")),
         )
 
 

--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -2650,31 +2650,41 @@ class MessageHandler:
 
     # ==================== Party Mode Handlers ====================
 
+    def _get_or_create_party_manager(self):
+        """Return the single PartyManager used by UI and auto-restore."""
+        party_manager = getattr(self.shared_state, "party_manager", None)
+        if party_manager:
+            return party_manager
+
+        from party.core.party_manager import PartyManager
+
+        lcu = self.skin_scraper.lcu if self.skin_scraper else None
+        if not lcu:
+            return None
+
+        party_manager = PartyManager(
+            lcu,
+            self.shared_state,
+            self.injection_manager,
+        )
+        self.shared_state.party_manager = party_manager
+        party_manager.set_callbacks(
+            on_state_change=lambda state: self.broadcaster.broadcast_party_state()
+        )
+        return party_manager
+
     def _handle_party_enable(self, payload: dict) -> None:
         """Handle party mode enable request"""
         try:
-            party_manager = getattr(self.shared_state, 'party_manager', None)
+            party_manager = self._get_or_create_party_manager()
             if not party_manager:
-                # Initialize party manager
-                from party.core.party_manager import PartyManager
-                from lcu import LCU
-
-                # Get LCU instance from skin_scraper
-                lcu = self.skin_scraper.lcu if self.skin_scraper else None
-                if not lcu:
-                    response_payload = {
-                        "type": "party-enabled",
-                        "success": False,
-                        "error": "LCU not available - is League client running?",
-                    }
-                    self._send_response(json.dumps(response_payload))
-                    return
-
-                party_manager = PartyManager(lcu, self.shared_state, self.injection_manager)
-                self.shared_state.party_manager = party_manager
-                party_manager.set_callbacks(
-                    on_state_change=lambda state: self.broadcaster.broadcast_party_state()
-                )
+                response_payload = {
+                    "type": "party-enabled",
+                    "success": False,
+                    "error": "LCU not available - is League client running?",
+                }
+                self._send_response(json.dumps(response_payload))
+                return
 
             # Enable party mode (async operation)
             import asyncio
@@ -2843,7 +2853,7 @@ class MessageHandler:
     def _handle_party_get_state(self, payload: dict) -> None:
         """Handle get party state request"""
         try:
-            party_manager = getattr(self.shared_state, 'party_manager', None)
+            party_manager = self._get_or_create_party_manager()
             if not party_manager:
                 response_payload = {
                     "type": "party-state",
@@ -2861,6 +2871,33 @@ class MessageHandler:
                 }
 
             self._send_response(json.dumps(response_payload))
+
+            # The first state request happens when the League-side plugin
+            # connects. Restore the saved room without requiring another click.
+            if (
+                party_manager
+                and not party_manager.enabled
+                and self.websocket_server
+                and self.websocket_server.loop
+            ):
+                import asyncio
+
+                async def do_restore():
+                    try:
+                        restored = await party_manager.restore_if_configured()
+                        if restored:
+                            self.shared_state.party_mode_enabled = True
+                            self.shared_state.party_token = (
+                                party_manager.my_token_str
+                            )
+                            self.broadcaster.broadcast_party_state()
+                    except Exception as e:
+                        log.warning(f"[PARTY] Auto-restore failed: {e}")
+
+                asyncio.run_coroutine_threadsafe(
+                    do_restore(),
+                    self.websocket_server.loop,
+                )
 
         except Exception as e:
             log.error(f"[PARTY] Error getting party state: {e}")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Rose regression tests."""

--- a/tests/test_party_reliability.py
+++ b/tests/test_party_reliability.py
@@ -1,0 +1,430 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from party.core.party_manager import PartyManager
+from party.core.party_storage import PartyStorage
+from party.discovery.auto_lobby_room import AutoLobbyRoom, compute_auto_room_key
+from party.network.ws_relay import PartyRelay, compute_room_key
+from party.protocol.token_codec import PartyToken, create_token
+
+
+class DummyLCU:
+    def __init__(self, summoner_id=101, name="Local"):
+        self.current_summoner = {
+            "summonerId": summoner_id,
+            "displayName": name,
+        }
+        self.session = {
+            "myTeam": [
+                {"summonerId": summoner_id, "championId": 1},
+                {"summonerId": 202, "championId": 2},
+            ]
+        }
+
+    def get(self, path):
+        if path == "/lol-lobby/v2/lobby":
+            return {
+                "members": [
+                    {"summonerId": 101},
+                    {"summonerId": 202},
+                ]
+            }
+        return None
+
+
+class DummyState:
+    phase = "Lobby"
+    locked_champ_id = None
+    hovered_champ_id = None
+    last_hovered_skin_id = None
+    selected_chroma_id = None
+    selected_custom_mod = None
+
+
+class FakeRelay:
+    connect_results = []
+    instances = []
+
+    def __init__(self, room_key):
+        self.room_key = room_key
+        self.connected = False
+        self.members = []
+        self.callback = None
+        self.joined = None
+        self.sent_skins = []
+        type(self).instances.append(self)
+
+    def set_on_members_changed(self, callback):
+        self.callback = callback
+
+    async def connect(self, timeout=15.0):
+        result = (
+            type(self).connect_results.pop(0)
+            if type(self).connect_results
+            else True
+        )
+        self.connected = result
+        return result
+
+    async def join(self, summoner_id, summoner_name):
+        self.joined = (summoner_id, summoner_name)
+
+    async def send_skin(self, skin):
+        self.sent_skins.append(skin)
+
+    async def disconnect(self):
+        self.connected = False
+        self.members = []
+
+
+class PartyReliabilityTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.storage = PartyStorage(
+            Path(self.temp_dir.name) / "party_mode.json"
+        )
+        FakeRelay.connect_results = []
+        FakeRelay.instances = []
+        self.relay_patch = patch(
+            "party.core.party_manager.PartyRelay",
+            FakeRelay,
+        )
+        self.relay_patch.start()
+        self.always_on_patch = patch(
+            "party.core.party_manager.PARTY_MODE_ALWAYS_ON",
+            False,
+        )
+        self.always_on_patch.start()
+
+    def tearDown(self):
+        self.always_on_patch.stop()
+        self.relay_patch.stop()
+        self.temp_dir.cleanup()
+
+    async def test_pair_once_restores_same_room_after_restart(self):
+        first = PartyManager(
+            DummyLCU(),
+            DummyState(),
+            storage=self.storage,
+        )
+        await first.enable()
+
+        friend_key = b"f" * 32
+        friend_token = create_token(202, friend_key).encode()
+        success, error = await first.add_peer(friend_token)
+        self.assertTrue(success)
+        self.assertIsNone(error)
+        expected_room = compute_room_key(202, friend_key)
+        self.assertEqual(first._active_room_key, expected_room)
+        await first.disable(persist=False)
+
+        restarted = PartyManager(
+            DummyLCU(),
+            DummyState(),
+            storage=self.storage,
+        )
+        restored = await restarted.restore_if_configured()
+        self.assertTrue(restored)
+        self.assertTrue(restarted.enabled)
+        self.assertEqual(restarted._active_room_key, expected_room)
+        self.assertEqual(restarted._relay.room_key, expected_room)
+        self.assertIn(202, restarted.party_state.peers)
+        await restarted.disable(persist=False)
+
+    async def test_personal_invitation_keeps_same_room_key(self):
+        first = PartyManager(
+            DummyLCU(),
+            DummyState(),
+            storage=self.storage,
+        )
+        token_one = PartyToken.decode(await first.enable())
+        room_one = compute_room_key(token_one.summoner_id, token_one.encryption_key)
+        await first.disable(persist=False)
+
+        second = PartyManager(
+            DummyLCU(),
+            DummyState(),
+            storage=self.storage,
+        )
+        token_two = PartyToken.decode(await second.enable())
+        room_two = compute_room_key(token_two.summoner_id, token_two.encryption_key)
+        self.assertEqual(token_one.encryption_key, token_two.encryption_key)
+        self.assertEqual(room_one, room_two)
+        await second.disable(persist=False)
+
+    async def test_group_invitation_keeps_friends_of_friends_in_same_room(self):
+        host = PartyManager(
+            DummyLCU(101, "Host"),
+            DummyState(),
+            storage=self.storage,
+        )
+        host_token = await host.enable()
+        host_invitation = PartyToken.decode(host_token)
+        group_room = compute_room_key(
+            host_invitation.summoner_id,
+            host_invitation.encryption_key,
+        )
+
+        friend = PartyManager(
+            DummyLCU(202, "Friend"),
+            DummyState(),
+            storage=self.storage,
+        )
+        await friend.enable()
+        success, _ = await friend.add_peer(host_token)
+        self.assertTrue(success)
+        forwarded = PartyToken.decode(friend.my_token_str)
+        self.assertEqual(
+            compute_room_key(
+                forwarded.summoner_id,
+                forwarded.encryption_key,
+            ),
+            group_room,
+        )
+
+        third = PartyManager(
+            DummyLCU(303, "Third"),
+            DummyState(),
+            storage=self.storage,
+        )
+        await third.enable()
+        success, _ = await third.add_peer(friend.my_token_str)
+        self.assertTrue(success)
+        self.assertEqual(third._active_room_key, group_room)
+
+        await host.disable(persist=False)
+        await friend.disable(persist=False)
+        await third.disable(persist=False)
+
+    async def test_relay_failure_reconnects_without_disabling_party(self):
+        FakeRelay.connect_results = [False, True]
+        manager = PartyManager(
+            DummyLCU(),
+            DummyState(),
+            storage=self.storage,
+        )
+        await manager.enable()
+        self.assertTrue(manager.enabled)
+        self.assertFalse(manager.party_state.relay_connected)
+
+        manager._next_reconnect_at = 0.0
+        connected = await manager._ensure_relay_connected()
+        self.assertTrue(connected)
+        self.assertTrue(manager.party_state.relay_connected)
+        self.assertEqual(FakeRelay.instances[-1].joined, (101, "Local"))
+        await manager.disable(persist=False)
+
+    async def test_forgetting_host_returns_to_personal_room(self):
+        manager = PartyManager(
+            DummyLCU(),
+            DummyState(),
+            storage=self.storage,
+        )
+        own_token = PartyToken.decode(await manager.enable())
+        own_room = compute_room_key(101, own_token.encryption_key)
+
+        friend_token = create_token(202, b"x" * 32).encode()
+        success, _ = await manager.add_peer(friend_token)
+        self.assertTrue(success)
+        await manager.remove_peer(202)
+
+        self.assertEqual(manager._active_room_key, own_room)
+        account = self.storage.load_account(101)
+        self.assertNotIn("202", account["trusted_peers"])
+        self.assertIn(202, account["ignored_peers"])
+        await manager.disable(persist=False)
+
+    async def test_common_custom_mod_metadata_survives_relay_update(self):
+        manager = PartyManager(
+            DummyLCU(),
+            DummyState(),
+            storage=self.storage,
+        )
+        await manager.enable()
+        member = {
+            "summoner_id": 202,
+            "summoner_name": "Friend",
+            "skin": {
+                "champion_id": 2,
+                "skin_id": 2001,
+                "custom_mod_hash": "abcdef0123456789",
+                "is_custom": True,
+            },
+        }
+        manager._relay.members = [member]
+        manager._on_relay_members_changed([member])
+        selection = manager.party_state.peers[202].skin_selection
+        self.assertEqual(selection.custom_mod_hash, "abcdef0123456789")
+        self.assertTrue(selection.is_custom)
+
+        with patch.object(
+            PartyManager,
+            "find_local_mod_by_hash",
+            return_value="skins/2/shared.fantome",
+        ):
+            skins = manager.get_party_skins()
+        self.assertEqual(len(skins), 1)
+        self.assertEqual(
+            skins[0].custom_mod_path,
+            "skins/2/shared.fantome",
+        )
+        await manager.disable(persist=False)
+
+
+class AutomaticLobbyRoomTests(unittest.TestCase):
+    def test_same_premade_members_always_derive_same_room(self):
+        expected = compute_auto_room_key([303, 101, 202])
+        self.assertEqual(expected, compute_auto_room_key([202, 303, 101]))
+        self.assertEqual(expected, compute_auto_room_key([101, 202, 303, 202]))
+
+    def test_room_is_frozen_across_matchmaking_and_champion_select(self):
+        room = AutoLobbyRoom()
+        lobby_room = room.update("Lobby", [101, 202], 101)
+        self.assertIsNotNone(lobby_room)
+
+        # myTeam can contain matchmade strangers, but is intentionally never
+        # used to replace the premade room during these phases.
+        self.assertEqual(room.update("Matchmaking", [], 101), lobby_room)
+        self.assertEqual(
+            room.update("ChampSelect", [101, 202, 303, 404, 505], 101),
+            lobby_room,
+        )
+        self.assertEqual(room.update("InProgress", [], 101), lobby_room)
+
+    def test_lobby_membership_change_moves_everyone_to_new_room(self):
+        room = AutoLobbyRoom()
+        first = room.update("Lobby", [101, 202], 101)
+        second = room.update("Lobby", [101, 202, 303], 101)
+        self.assertNotEqual(first, second)
+        self.assertEqual(second, compute_auto_room_key([101, 202, 303]))
+
+    def test_solo_lobby_and_end_of_game_clear_automatic_room(self):
+        room = AutoLobbyRoom()
+        room.update("Lobby", [101, 202], 101)
+        self.assertIsNone(room.update("EndOfGame", [], 101))
+        self.assertIsNone(room.update("Lobby", [101], 101))
+
+    def test_saved_room_can_be_restored_mid_champion_select(self):
+        room = AutoLobbyRoom()
+        expected = compute_auto_room_key([101, 202])
+        room.restore(expected, [101, 202])
+        self.assertEqual(room.update("ChampSelect", [], 101), expected)
+
+    def test_duplicate_restart_socket_prefers_member_with_skin(self):
+        members = PartyRelay._deduplicate_members([
+            {"summoner_id": 101, "summoner_name": "Old"},
+            {
+                "summoner_id": 101,
+                "summoner_name": "New",
+                "skin": {"champion_id": 1, "skin_id": 1001},
+            },
+            {"summoner_id": 202, "summoner_name": "Friend"},
+        ])
+        self.assertEqual(len(members), 2)
+        local = next(m for m in members if m["summoner_id"] == 101)
+        self.assertEqual(local["skin"]["skin_id"], 1001)
+
+
+class MutableLobbyLCU(DummyLCU):
+    def __init__(self, summoner_id=101, name="Local", lobby_ids=None):
+        super().__init__(summoner_id, name)
+        self.lobby_ids = list(lobby_ids or [summoner_id])
+
+    def get(self, path):
+        if path == "/lol-lobby/v2/lobby":
+            return {
+                "members": [
+                    {"summonerId": value}
+                    for value in self.lobby_ids
+                ]
+            }
+        return None
+
+
+class AutomaticPartyManagerTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.storage = PartyStorage(
+            Path(self.temp_dir.name) / "party_mode.json"
+        )
+        FakeRelay.connect_results = []
+        FakeRelay.instances = []
+        self.relay_patch = patch(
+            "party.core.party_manager.PartyRelay",
+            FakeRelay,
+        )
+        self.relay_patch.start()
+
+    def tearDown(self):
+        self.relay_patch.stop()
+        self.temp_dir.cleanup()
+
+    async def test_always_on_starts_without_saved_setting_or_token_action(self):
+        lcu = MutableLobbyLCU(101, "Local", [101, 202])
+        manager = PartyManager(lcu, DummyState(), storage=self.storage)
+        restored = await manager.restore_if_configured()
+        self.assertTrue(restored)
+        self.assertTrue(manager.enabled)
+        self.assertTrue(manager.party_state.automatic)
+        self.assertTrue(manager.party_state.auto_room_active)
+        self.assertEqual(
+            manager._active_room_key,
+            compute_auto_room_key([101, 202]),
+        )
+        await manager.disable(persist=False)
+
+    async def test_two_clients_in_same_lobby_choose_identical_room(self):
+        first = PartyManager(
+            MutableLobbyLCU(101, "First", [101, 202]),
+            DummyState(),
+            storage=self.storage,
+        )
+        second = PartyManager(
+            MutableLobbyLCU(202, "Second", [202, 101]),
+            DummyState(),
+            storage=self.storage,
+        )
+        await first.enable()
+        await second.enable()
+        self.assertEqual(first._active_room_key, second._active_room_key)
+        self.assertEqual(
+            first._active_room_key,
+            compute_auto_room_key([101, 202]),
+        )
+        await first.disable(persist=False)
+        await second.disable(persist=False)
+
+    async def test_room_does_not_change_when_premade_endpoint_disappears(self):
+        state = DummyState()
+        state.phase = "Lobby"
+        lcu = MutableLobbyLCU(101, "Local", [101, 202])
+        manager = PartyManager(lcu, state, storage=self.storage)
+        await manager.enable()
+        expected = manager._active_room_key
+
+        state.phase = "ChampSelect"
+        lcu.lobby_ids = []
+        await manager._sync_auto_lobby_room()
+        self.assertEqual(manager._active_room_key, expected)
+        await manager.disable(persist=False)
+
+    async def test_return_to_solo_lobby_leaves_shared_room(self):
+        state = DummyState()
+        state.phase = "Lobby"
+        lcu = MutableLobbyLCU(101, "Local", [101, 202])
+        manager = PartyManager(lcu, state, storage=self.storage)
+        await manager.enable()
+        shared_room = manager._active_room_key
+
+        lcu.lobby_ids = [101]
+        await manager._sync_auto_lobby_room()
+        self.assertNotEqual(manager._active_room_key, shared_room)
+        self.assertEqual(manager._active_room_key, manager._personal_room_key)
+        self.assertFalse(manager.party_state.auto_room_active)
+        await manager.disable(persist=False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- automatically join Rose users from the same premade lobby in one relay room
- keep the room stable through champion select/game and reconnect/resync after interruptions
- keep custom mod files local; only selection metadata is shared

`PARTY_MODE_ALWAYS_ON` controls the automatic flow; the manual token path remains available when it is disabled.

## Test
`python -m unittest tests.test_party_reliability -v` — 16 passed