### PR TITLE
Add isolated Classic Mode support (🐑)

### DIFF
--- a/Pengu Loader/plugins/ROSE-ChromaWheel/index.js
+++ b/Pengu Loader/plugins/ROSE-ChromaWheel/index.js
@@ -816,10 +816,21 @@
       const phase = data.phase;
       const gameMode = data.gameMode;
       const mapId = data.mapId;
+      const classicMode =
+        mapId === 453 ||
+        data.queueId === 3260 ||
+        (typeof gameMode === "string" && gameMode.toUpperCase() === "JADE");
       // Late startup can replay "ChampSelect" after skin-state is already current.
       // Keep the last seen phase so we only reset on real phase transitions.
       const previousPhase = currentPhase;
       currentPhase = phase;
+
+      if (classicMode) {
+        resetFrontendSessionState("classic-plugin-isolation");
+        stopObserver();
+        isAramFromPython = false;
+        return;
+      }
 
       if (phase === "ChampSelect") {
         // Only reset on a real transition into a new Champ Select session.

--- a/Pengu Loader/plugins/ROSE-ClassicChroma/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicChroma/index.js
@@ -51,10 +51,10 @@
 
   function currentSelection() {
     const selection = api()?.currentSelection?.();
-    if (!selection?.parentEntry || !selection?.rawSkinId) return null;
+    if (!selection?.parentEntry || !selection?.lcuSkinId) return null;
     return {
       parent: selection.parentEntry,
-      rawId: Number(selection.rawSkinId),
+      rawId: Number(selection.lcuSkinId),
     };
   }
 
@@ -85,7 +85,7 @@
       skin?.chromaPreviewPath || skin?.imagePath || skin?.chromaPath || skin?.tilePath;
     if (directPath) return String(directPath);
 
-    const resourceId = api()?.resourceSkinId?.(rawIdOf(skin)) || 0;
+    const resourceId = api()?.skinIdFromLcu?.(rawIdOf(skin)) || 0;
     const resourceChampionId = Math.floor(resourceId / 1000);
     if (resourceChampionId > 0 && resourceId > 0) {
       return `/lol-game-data/assets/v1/champion-chroma-images/${resourceChampionId}/${resourceId}.png`;
@@ -188,7 +188,7 @@
       .map((skin, index) => ({
         skin,
         rawId: rawIdOf(skin),
-        resourceId: api().resourceSkinId(rawIdOf(skin)),
+        resourceId: api().skinIdFromLcu(rawIdOf(skin)),
         name: String(skin?.name || parent?.name || "Chroma"),
         colors: colorsOf(skin),
         primaryColor: primaryColorOf(skin),
@@ -285,20 +285,19 @@
         const resourceId = choice.resourceId;
         const rawId = choice.rawId;
         log("info", "Chroma selection submitted", {
-          rawSkinId: rawId,
-          resourceSkinId: resourceId,
+          lcuSkinId: rawId,
+          skinId: resourceId,
           isBase: choice.isBase,
           parentRawSkinId: rawIdOf(parent),
         });
         api().projectResourceSelection(resourceId, "chroma-state");
         bridge?.send({
           type: "chroma-selection",
-          skinId: choice.isBase ? 0 : choice.resourceId,
           chromaId: choice.isBase ? 0 : choice.resourceId,
           chromaName: choice.name,
           championId: api().state().championId,
-          baseSkinId: api().resourceSkinId(rawIdOf(parent)),
-          rawSkinId: rawId,
+          baseSkinId: api().skinIdFromLcu(rawIdOf(parent)),
+          skinId: resourceId,
           source: "classic-chroma",
           primaryColor: choice.primaryColor || null,
           colors: choice.colors,

--- a/Pengu Loader/plugins/ROSE-ClassicChroma/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicChroma/index.js
@@ -20,7 +20,7 @@
   let outsideClickHandler = null;
 
   function api() {
-    return window.__roseJadeWheelDebug;
+    return window.__roseClassicWheelApi;
   }
 
   function rawIdOf(skin) {
@@ -42,20 +42,12 @@
   }
 
   function currentSelection() {
-    const jade = api();
-    const state = jade?.state?.();
-    if (state?.active !== true) return null;
-    const rawId = Number(
-      state.projectedVariantRawSkinId || state.desiredVisualRawSkinId || state.selectedRawSkinId
-    );
-    const parents = jade.catalogData?.() || [];
-    for (const parent of parents) {
-      if (rawIdOf(parent) === rawId) return { parent, rawId };
-      if (variantsOf(parent).some((child) => rawIdOf(child) === rawId)) {
-        return { parent, rawId };
-      }
-    }
-    return null;
+    const selection = api()?.currentSelection?.();
+    if (!selection?.parentEntry || !selection?.rawSkinId) return null;
+    return {
+      parent: selection.parentEntry,
+      rawId: Number(selection.rawSkinId),
+    };
   }
 
   function colorsOf(skin) {
@@ -293,6 +285,7 @@
           championId: api().state().championId,
           baseSkinId: api().resourceSkinId(rawIdOf(parent)),
           rawSkinId: rawId,
+          source: "classic-chroma",
           primaryColor: choice.primaryColor || null,
           colors: choice.colors,
           timestamp: Date.now(),
@@ -323,7 +316,9 @@
   function handlePhaseChange(data) {
     const phase = String(data?.phase || "");
     const classicMode =
-      Number(data?.mapId) === 453 || String(data?.gameMode || "").toUpperCase() === "JADE";
+      Number(data?.mapId) === 453 ||
+      Number(data?.queueId) === 3260 ||
+      String(data?.gameMode || "").toUpperCase() === "JADE";
     isInJadeChampSelect =
       classicMode && (phase === "ChampSelect" || phase === "FINALIZATION");
     if (!isInJadeChampSelect) championLocked = false;
@@ -482,6 +477,8 @@
     bridge.subscribe("phase-change", handlePhaseChange);
     bridge.subscribe("champion-locked", handleChampionLocked);
     bridge.subscribe("chroma-state", render);
+    const classicState = api()?.state?.();
+    if (classicState) handlePhaseChange(classicState);
     window.addEventListener("rose-jade-wheel-layout", handleWheelLayout);
     new MutationObserver(render).observe(document.body, { childList: true, subtree: true });
     setInterval(render, 500);

--- a/Pengu Loader/plugins/ROSE-ClassicChroma/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicChroma/index.js
@@ -316,6 +316,16 @@
       choiceButton.addEventListener("click", (event) => {
         event.preventDefault();
         event.stopPropagation();
+        const latest = currentSelection();
+        if (!latest || rawIdOf(latest.parent) !== rawIdOf(parent)) {
+          log("warn", "Ignored stale chroma panel selection", {
+            panelParentRawSkinId: rawIdOf(parent),
+            currentParentRawSkinId: rawIdOf(latest?.parent),
+          });
+          closePanel();
+          render();
+          return;
+        }
         playChromaClickSound();
         const resourceId = choice.resourceId;
         const rawId = choice.rawId;

--- a/Pengu Loader/plugins/ROSE-ClassicChroma/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicChroma/index.js
@@ -19,6 +19,14 @@
   let panelParentRawId = 0;
   let outsideClickHandler = null;
 
+  function log(level, message, data = null) {
+    const method = level === "error" ? "error" : level === "warn" ? "warn" : "log";
+    console[method](`[ClassicChroma] ${message}`, data || "");
+    try {
+      bridge?.send({ type: "plugin-log", source: "ClassicChroma", level, message, data, timestamp: Date.now() });
+    } catch (_) {}
+  }
+
   function api() {
     return window.__roseClassicWheelApi;
   }
@@ -276,6 +284,12 @@
         event.stopPropagation();
         const resourceId = choice.resourceId;
         const rawId = choice.rawId;
+        log("info", "Chroma selection submitted", {
+          rawSkinId: rawId,
+          resourceSkinId: resourceId,
+          isBase: choice.isBase,
+          parentRawSkinId: rawIdOf(parent),
+        });
         api().projectResourceSelection(resourceId, "chroma-state");
         bridge?.send({
           type: "chroma-selection",
@@ -322,6 +336,7 @@
     isInJadeChampSelect =
       classicMode && (phase === "ChampSelect" || phase === "FINALIZATION");
     if (!isInJadeChampSelect) championLocked = false;
+    log("debug", "Phase state updated", { phase, active: isInJadeChampSelect, championLocked });
     render();
   }
 
@@ -477,6 +492,7 @@
     bridge.subscribe("phase-change", handlePhaseChange);
     bridge.subscribe("champion-locked", handleChampionLocked);
     bridge.subscribe("chroma-state", render);
+    log("info", "Classic chroma plugin initialized");
     const classicState = api()?.state?.();
     if (classicState) handlePhaseChange(classicState);
     window.addEventListener("rose-jade-wheel-layout", handleWheelLayout);

--- a/Pengu Loader/plugins/ROSE-ClassicChroma/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicChroma/index.js
@@ -18,6 +18,11 @@
   let championLocked = false;
   let panelParentRawId = 0;
   let outsideClickHandler = null;
+  let previewGeneration = 0;
+
+  const CHROMA_CLICK_SOUND_URL =
+    "https://127.0.0.1:65236/fe/lol-champ-select/sounds/sfx-cs-button-chromas-click.ogg";
+  let chromaClickAudio = null;
 
   function log(level, message, data = null) {
     const method = level === "error" ? "error" : level === "warn" ? "warn" : "log";
@@ -29,6 +34,14 @@
 
   function api() {
     return window.__roseClassicWheelApi;
+  }
+
+  function playChromaClickSound() {
+    try {
+      chromaClickAudio ||= new Audio(CHROMA_CLICK_SOUND_URL);
+      chromaClickAudio.currentTime = 0;
+      chromaClickAudio.play().catch(() => {});
+    } catch (_) {}
   }
 
   function rawIdOf(skin) {
@@ -240,9 +253,27 @@
 
     const updatePreview = (choice) => {
       name.textContent = choice.name;
-      preview.style.backgroundImage = choice.visualPath
-        ? `url('${choice.visualPath}')`
-        : "none";
+      const candidates = [...new Set([choice.visualPath, visualPathOf(parent, parent)])]
+        .filter(Boolean);
+      const generation = ++previewGeneration;
+      const apply = (index) => {
+        if (generation !== previewGeneration) return;
+        const path = candidates[index];
+        if (!path) {
+          preview.style.backgroundImage = "none";
+          return;
+        }
+        const image = new Image();
+        image.onload = () => {
+          if (generation === previewGeneration) {
+            preview.style.backgroundImage = `url('${path}')`;
+          }
+        };
+        image.onerror = () => apply(index + 1);
+        image.src = path;
+      };
+      preview.style.backgroundImage = "none";
+      apply(0);
     };
     updatePreview(selectedChoice);
 
@@ -282,6 +313,7 @@
       choiceButton.addEventListener("click", (event) => {
         event.preventDefault();
         event.stopPropagation();
+        playChromaClickSound();
         const resourceId = choice.resourceId;
         const rawId = choice.rawId;
         log("info", "Chroma selection submitted", {
@@ -305,6 +337,12 @@
         });
         closePanel();
         render();
+      });
+      choiceButton.addEventListener("keydown", (event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        event.stopPropagation();
+        choiceButton.click();
       });
     }
 

--- a/Pengu Loader/plugins/ROSE-ClassicChroma/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicChroma/index.js
@@ -19,6 +19,8 @@
   let panelParentRawId = 0;
   let outsideClickHandler = null;
   let previewGeneration = 0;
+  let observer = null;
+  let pollTimer = null;
 
   const CHROMA_CLICK_SOUND_URL =
     "https://127.0.0.1:65236/fe/lol-champ-select/sounds/sfx-cs-button-chromas-click.ogg";
@@ -133,6 +135,7 @@
   }
 
   function closePanel() {
+    previewGeneration += 1;
     document.getElementById(PANEL_ID)?.remove();
     panelParentRawId = 0;
     if (outsideClickHandler) {
@@ -322,7 +325,14 @@
           isBase: choice.isBase,
           parentRawSkinId: rawIdOf(parent),
         });
-        api().projectResourceSelection(resourceId, "chroma-state");
+        if (api()?.projectResourceSelection?.(resourceId, "chroma-state") !== true) {
+          log("warn", "Chroma selection rejected by ClassicWheel", {
+            lcuSkinId: rawId,
+            skinId: resourceId,
+            parentRawSkinId: rawIdOf(parent),
+          });
+          return;
+        }
         bridge?.send({
           type: "chroma-selection",
           chromaId: choice.isBase ? 0 : choice.resourceId,
@@ -374,7 +384,8 @@
       classicMode && (phase === "ChampSelect" || phase === "FINALIZATION");
     if (!isInJadeChampSelect) championLocked = false;
     log("debug", "Phase state updated", { phase, active: isInJadeChampSelect, championLocked });
-    render();
+    if (isInJadeChampSelect) startRendering();
+    else stopRendering();
   }
 
   function handleChampionLocked(data) {
@@ -384,10 +395,30 @@
 
   function handleWheelLayout(event) {
     if (event?.detail?.active === false) {
-      remove();
+      stopRendering();
       return;
     }
+    if (isInJadeChampSelect) startRendering();
+  }
+
+  function startRendering() {
+    if (observer || !document.body) {
+      render();
+      return;
+    }
+    observer = new MutationObserver(render);
+    observer.observe(document.body, { childList: true, subtree: true });
+    pollTimer = setInterval(render, 500);
+    log("debug", "Classic chroma rendering enabled");
     render();
+  }
+
+  function stopRendering() {
+    observer?.disconnect();
+    observer = null;
+    if (pollTimer) clearInterval(pollTimer);
+    pollTimer = null;
+    remove();
   }
 
   function positionPanel(panel, button) {
@@ -533,8 +564,6 @@
     const classicState = api()?.state?.();
     if (classicState) handlePhaseChange(classicState);
     window.addEventListener("rose-jade-wheel-layout", handleWheelLayout);
-    new MutationObserver(render).observe(document.body, { childList: true, subtree: true });
-    setInterval(render, 500);
   }
 
   start();

--- a/Pengu Loader/plugins/ROSE-ClassicChroma/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicChroma/index.js
@@ -1,0 +1,491 @@
+/**
+ * @name ROSE-ClassicChroma
+ * @description JADE-only chroma selector using the regular client presentation.
+ */
+(function initJadeChroma() {
+  "use strict";
+
+  const BUTTON_ID = "rose-jade-chroma-button";
+  const PANEL_ID = "rose-jade-chroma-panel";
+  const STYLE_ID = "rose-jade-chroma-style";
+  const PANEL_WIDTH = 305;
+  const PANEL_MAX_HEIGHT = 420;
+  const PANEL_SCALE = 0.9;
+  const CLASSIC_BACKGROUND =
+    "/lol-game-data/assets/content/src/LeagueClient/GameModeAssets/Classic_SRU/img/champ-select-flyout-background.jpg";
+  let bridge = null;
+  let isInJadeChampSelect = false;
+  let championLocked = false;
+  let panelParentRawId = 0;
+  let outsideClickHandler = null;
+
+  function api() {
+    return window.__roseJadeWheelDebug;
+  }
+
+  function rawIdOf(skin) {
+    return Number(skin?.id ?? skin?.skinId) || 0;
+  }
+
+  function variantsOf(skin) {
+    const variants = [
+      ...(Array.isArray(skin?.childSkins) ? skin.childSkins : []),
+      ...(Array.isArray(skin?.chromas) ? skin.chromas : []),
+    ];
+    const seen = new Set();
+    return variants.filter((variant) => {
+      const id = rawIdOf(variant);
+      if (!id || seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+  }
+
+  function currentSelection() {
+    const jade = api();
+    const state = jade?.state?.();
+    if (state?.active !== true) return null;
+    const rawId = Number(
+      state.projectedVariantRawSkinId || state.desiredVisualRawSkinId || state.selectedRawSkinId
+    );
+    const parents = jade.catalogData?.() || [];
+    for (const parent of parents) {
+      if (rawIdOf(parent) === rawId) return { parent, rawId };
+      if (variantsOf(parent).some((child) => rawIdOf(child) === rawId)) {
+        return { parent, rawId };
+      }
+    }
+    return null;
+  }
+
+  function colorsOf(skin) {
+    const colors = Array.isArray(skin?.colors) ? skin.colors.filter(Boolean) : [];
+    if (!colors.length && skin?.primaryColor) colors.push(skin.primaryColor);
+    return colors.map((color) =>
+      String(color).startsWith("#") ? String(color) : `#${color}`
+    );
+  }
+
+  function primaryColorOf(skin) {
+    const colors = colorsOf(skin);
+    const value = skin?.primaryColor || colors[1] || colors[0] || "";
+    if (!value) return "";
+    return String(value).startsWith("#") ? String(value) : `#${value}`;
+  }
+
+  function swatch(skin, isBase = false) {
+    if (isBase) {
+      return "linear-gradient(135deg, #f0e6d2, #f0e6d2 48%, #be1e37 0, #be1e37 52%, #f0e6d2 0, #f0e6d2)";
+    }
+    return primaryColorOf(skin) || "#c8aa6e";
+  }
+
+  function visualPathOf(skin, parent) {
+    const directPath =
+      skin?.chromaPreviewPath || skin?.imagePath || skin?.chromaPath || skin?.tilePath;
+    if (directPath) return String(directPath);
+
+    const resourceId = api()?.resourceSkinId?.(rawIdOf(skin)) || 0;
+    const resourceChampionId = Math.floor(resourceId / 1000);
+    if (resourceChampionId > 0 && resourceId > 0) {
+      return `/lol-game-data/assets/v1/champion-chroma-images/${resourceChampionId}/${resourceId}.png`;
+    }
+
+    return String(
+      parent?.chromaPreviewPath ||
+      parent?.imagePath ||
+      parent?.chromaPath ||
+      parent?.tilePath ||
+      ""
+    );
+  }
+
+  function createChromaButtonFrame(id, className) {
+    const button = document.createElement("button");
+    button.id = id;
+    button.type = "button";
+    button.className = className;
+    const outerMask = document.createElement("span");
+    outerMask.className = "outer-mask interactive";
+    const frameColor = document.createElement("span");
+    frameColor.className = "frame-color";
+    const content = document.createElement("span");
+    content.className = "content";
+    const innerMask = document.createElement("span");
+    innerMask.className = "inner-mask inner-shadow";
+    frameColor.append(content, innerMask);
+    outerMask.appendChild(frameColor);
+    button.appendChild(outerMask);
+    return button;
+  }
+
+  function closePanel() {
+    document.getElementById(PANEL_ID)?.remove();
+    panelParentRawId = 0;
+    if (outsideClickHandler) {
+      document.removeEventListener("click", outsideClickHandler, true);
+      outsideClickHandler = null;
+    }
+  }
+
+  function remove() {
+    document.getElementById(BUTTON_ID)?.remove();
+    closePanel();
+  }
+
+  function setMainButtonColor(button, selection) {
+    const selected = variantsOf(selection.parent).find(
+      (child) => rawIdOf(child) === selection.rawId
+    );
+    const content = button.querySelector(".content");
+    if (!content) return;
+    if (selected) {
+      content.style.background = swatch(selected);
+      content.style.backgroundImage = "none";
+    } else {
+      content.style.background =
+        "url(/fe/lol-champ-select/images/config/button-chroma.png) center / contain no-repeat";
+    }
+  }
+
+  function render() {
+    if (!isInJadeChampSelect || !championLocked) {
+      remove();
+      return;
+    }
+    const selection = currentSelection();
+    if (!selection || !variantsOf(selection.parent).length) {
+      remove();
+      return;
+    }
+    if (panelParentRawId && panelParentRawId !== rawIdOf(selection.parent)) closePanel();
+    const card = document.querySelector(
+      ".rose-jade-native-card.rose-jade-native-card--selected:not(.skins-pane__skin-card--placeholder)"
+    );
+    if (!card) return;
+    let button = document.getElementById(BUTTON_ID);
+    if (!button) {
+      button = createChromaButtonFrame(BUTTON_ID, "lu-chroma-button rose-jade-chroma-button");
+      button.title = "Select chroma";
+      button.addEventListener("mousedown", (event) => event.stopPropagation());
+      button.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const latest = currentSelection();
+        if (document.getElementById(PANEL_ID)) {
+          closePanel();
+          return;
+        }
+        if (latest) renderPanel(latest.parent, latest.rawId);
+      });
+    }
+    if (button.parentElement !== card) card.appendChild(button);
+    setMainButtonColor(button, selection);
+  }
+
+  function choiceData(parent, selectedRawId) {
+    return [parent, ...variantsOf(parent)]
+      .map((skin, index) => ({
+        skin,
+        rawId: rawIdOf(skin),
+        resourceId: api().resourceSkinId(rawIdOf(skin)),
+        name: String(skin?.name || parent?.name || "Chroma"),
+        colors: colorsOf(skin),
+        primaryColor: primaryColorOf(skin),
+        visualPath: visualPathOf(skin, parent),
+        selected: rawIdOf(skin) === selectedRawId,
+        isBase: index === 0,
+      }))
+      .filter((choice) => choice.rawId > 0);
+  }
+
+  function renderPanel(parent, selectedRawId) {
+    closePanel();
+    const button = document.getElementById(BUTTON_ID);
+    if (!button) return;
+    const choices = choiceData(parent, selectedRawId);
+    if (!choices.length) return;
+    panelParentRawId = rawIdOf(parent);
+    const selectedChoice = choices.find((choice) => choice.selected) || choices[0];
+
+    const panel = document.createElement("div");
+    panel.id = PANEL_ID;
+    panel.className = "rose-jade-chroma-panel";
+
+    const flyout = document.createElement("lol-uikit-flyout-frame");
+    flyout.className = "flyout";
+    flyout.setAttribute("orientation", "top");
+    flyout.setAttribute("animated", "false");
+    flyout.setAttribute("caretoffset", "undefined");
+    flyout.setAttribute("borderless", "undefined");
+    flyout.setAttribute("caretless", "undefined");
+    flyout.setAttribute("show", "true");
+
+    const flyoutContent = document.createElement("lc-flyout-content");
+    flyoutContent.className = "lc-flyout-content";
+    const modal = document.createElement("div");
+    modal.className = "champ-select-chroma-modal chroma-view ember-view";
+    modal.classList.add("rose-jade-chroma-modal");
+    const border = document.createElement("div");
+    border.className = "border";
+
+    const information = document.createElement("div");
+    information.className = "chroma-information";
+    information.style.backgroundImage = `url('${CLASSIC_BACKGROUND}')`;
+    const preview = document.createElement("div");
+    preview.className = "chroma-information-image";
+    const name = document.createElement("div");
+    name.className = "child-skin-name";
+    information.append(preview, name);
+
+    const updatePreview = (choice) => {
+      name.textContent = choice.name;
+      preview.style.backgroundImage = choice.visualPath
+        ? `url('${choice.visualPath}')`
+        : "none";
+    };
+    updatePreview(selectedChoice);
+
+    const scrollable = document.createElement("lol-uikit-scrollable");
+    scrollable.className = "chroma-selection";
+    scrollable.setAttribute("overflow-masks", "enabled");
+    const list = document.createElement("ul");
+    let hoveredChoice = null;
+
+    for (const choice of choices) {
+      const listItem = document.createElement("li");
+      const emberView = document.createElement("div");
+      emberView.className = "ember-view";
+      const choiceButton = document.createElement("div");
+      choiceButton.setAttribute("role", "button");
+      choiceButton.tabIndex = 0;
+      choiceButton.className = `chroma-skin-button${choice.selected ? " selected" : ""}`;
+      choiceButton.title = choice.name;
+      const contents = document.createElement("div");
+      contents.className = "contents";
+      contents.style.background = swatch(choice, choice.isBase);
+      choiceButton.appendChild(contents);
+      emberView.appendChild(choiceButton);
+      listItem.appendChild(emberView);
+      list.appendChild(listItem);
+
+      choiceButton.addEventListener("mouseenter", () => {
+        hoveredChoice = choice;
+        updatePreview(choice);
+      });
+      choiceButton.addEventListener("mouseleave", () => {
+        hoveredChoice = null;
+        setTimeout(() => {
+          if (!hoveredChoice) updatePreview(selectedChoice);
+        }, 0);
+      });
+      choiceButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const resourceId = choice.resourceId;
+        const rawId = choice.rawId;
+        api().projectResourceSelection(resourceId, "chroma-state");
+        bridge?.send({
+          type: "chroma-selection",
+          skinId: choice.isBase ? 0 : choice.resourceId,
+          chromaId: choice.isBase ? 0 : choice.resourceId,
+          chromaName: choice.name,
+          championId: api().state().championId,
+          baseSkinId: api().resourceSkinId(rawIdOf(parent)),
+          rawSkinId: rawId,
+          primaryColor: choice.primaryColor || null,
+          colors: choice.colors,
+          timestamp: Date.now(),
+        });
+        closePanel();
+        render();
+      });
+    }
+
+    scrollable.appendChild(list);
+    modal.append(border, information, scrollable);
+    flyoutContent.appendChild(modal);
+    flyout.appendChild(flyoutContent);
+    panel.appendChild(flyout);
+    document.body.appendChild(panel);
+    positionPanel(panel, button);
+    requestAnimationFrame(() => positionPanel(panel, button));
+
+    outsideClickHandler = (event) => {
+      if (panel.contains(event.target) || button.contains(event.target)) return;
+      closePanel();
+    };
+    setTimeout(() => {
+      if (outsideClickHandler) document.addEventListener("click", outsideClickHandler, true);
+    }, 0);
+  }
+
+  function handlePhaseChange(data) {
+    const phase = String(data?.phase || "");
+    const classicMode =
+      Number(data?.mapId) === 453 || String(data?.gameMode || "").toUpperCase() === "JADE";
+    isInJadeChampSelect =
+      classicMode && (phase === "ChampSelect" || phase === "FINALIZATION");
+    if (!isInJadeChampSelect) championLocked = false;
+    render();
+  }
+
+  function handleChampionLocked(data) {
+    championLocked = data?.locked === true;
+    render();
+  }
+
+  function handleWheelLayout(event) {
+    if (event?.detail?.active === false) {
+      remove();
+      return;
+    }
+    render();
+  }
+
+  function positionPanel(panel, button) {
+    const flyout = panel?.querySelector(".flyout");
+    if (!flyout || !button) return;
+    const buttonRect = button.getBoundingClientRect();
+    const panelRect = flyout.getBoundingClientRect();
+    const width = panelRect.width || PANEL_WIDTH * PANEL_SCALE;
+    const height = panelRect.height || PANEL_MAX_HEIGHT * PANEL_SCALE;
+    const left = Math.max(
+      10,
+      Math.min(buttonRect.left + buttonRect.width / 2 - width / 2, window.innerWidth - width - 10)
+    );
+    flyout.style.left = `${left}px`;
+    flyout.style.top = `${Math.max(10, buttonRect.top - height - 15)}px`;
+  }
+
+  function injectStyles() {
+    if (document.getElementById(STYLE_ID)) return;
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = `
+      #${BUTTON_ID} {
+        position: absolute; pointer-events: auto; border: 0; padding: 0; background: transparent;
+        width: 25px; height: 25px; cursor: pointer; direction: ltr;
+        -webkit-user-select: none; list-style-type: none;
+      }
+      #${BUTTON_ID} .outer-mask {
+        display: block; width: 100%; height: 100%; overflow: hidden;
+        position: relative; border-radius: 50%; box-shadow: 0 0 4px 1px rgba(1,10,19,.25);
+      }
+      #${BUTTON_ID} .frame-color {
+        display: flex; align-items: center; justify-content: center; width: 100%; height: 100%;
+        padding: 2px; box-sizing: border-box; overflow: hidden;
+        background-image: linear-gradient(0deg,#695625 0,#a9852d 23%,#b88d35 93%,#c8aa6e);
+      }
+      #${BUTTON_ID} .content {
+        display: block; width: 20px; height: 20px; box-sizing: border-box;
+        border: 2px solid #010a13; border-radius: 50%;
+        background: url(/fe/lol-champ-select/images/config/button-chroma.png) center / contain no-repeat;
+      }
+      #${BUTTON_ID} .inner-mask {
+        position: absolute; left: 2px; top: 2px; width: calc(100% - 4px); height: calc(100% - 4px);
+        border-radius: 50%; box-shadow: inset 0 0 4px 4px rgba(0,0,0,.75); pointer-events: none;
+      }
+      #${PANEL_ID} { position: fixed; inset: 0; z-index: 10000; pointer-events: none; }
+      #${PANEL_ID} .flyout {
+        position: absolute; overflow: visible; pointer-events: all; -webkit-user-select: none;
+        transform: scale(${PANEL_SCALE}) !important; transform-origin: top left !important;
+      }
+      #${PANEL_ID} .lc-flyout-content { position: relative; }
+      #${PANEL_ID} .rose-jade-chroma-modal {
+        position: relative !important; display: flex !important; flex-direction: column !important;
+        width: ${PANEL_WIDTH}px !important; min-width: ${PANEL_WIDTH}px !important;
+        max-width: ${PANEL_WIDTH}px !important; min-height: 355px !important;
+        max-height: ${PANEL_MAX_HEIGHT}px !important; background: #000 !important;
+        box-sizing: border-box !important; z-index: 0;
+      }
+      #${PANEL_ID} .border {
+        position: absolute; inset: 0; box-sizing: border-box; z-index: 2; pointer-events: none;
+        box-shadow: 0 0 0 1px rgba(1,10,19,.48);
+        border: 2px solid transparent; border-bottom: 0;
+        border-image: linear-gradient(to top,#785a28 0,#463714 50%,#463714 100%) 1 stretch;
+      }
+      #${PANEL_ID} .chroma-information {
+        position: relative !important; width: 100% !important; height: 315px !important;
+        background-size: cover !important; border-bottom: thin solid #463714;
+        flex-grow: 1 !important; z-index: 1;
+      }
+      #${PANEL_ID} .chroma-information-image {
+        position: absolute; inset: 0; background-position: center;
+        background-size: contain; background-repeat: no-repeat;
+      }
+      #${PANEL_ID} .child-skin-name {
+        position: absolute !important; left: 0 !important; right: 0 !important;
+        bottom: 10px !important; width: 100% !important; color: #f7f0de !important;
+        font-family: "LoL Display","Times New Roman",Times,Baskerville,Georgia,serif !important;
+        font-size: 24px !important; font-weight: 700 !important; text-align: center !important;
+      }
+      #${PANEL_ID} .chroma-selection {
+        min-height: 40px !important; max-height: 92px !important; height: 100% !important;
+        width: 100% !important; padding: 7px 0 !important;
+        overflow: auto !important; transform: translateZ(0) !important; pointer-events: all;
+        display: flex !important; flex-flow: row wrap !important; flex-grow: 0 !important;
+        align-items: center !important; justify-content: center !important;
+        position: relative; z-index: 1;
+        -webkit-mask-box-image-source: url("/fe/lol-static-assets/images/uikit/scrollable/scrollable-content-gradient-mask-bottom.png");
+        -webkit-mask-box-image-slice: 0 8 18 0 fill;
+      }
+      #${PANEL_ID} .chroma-selection ul {
+        display: flex !important; align-items: center !important; justify-content: center !important;
+        flex-flow: row wrap !important; gap: 0 !important; width: 100% !important;
+        margin: 0 !important; padding: 0 !important; list-style: none !important;
+      }
+      #${PANEL_ID} .chroma-selection li {
+        display: flex !important; align-items: center !important; justify-content: center !important;
+        margin: 2px 4px !important; padding: 0 !important; list-style: none !important;
+      }
+      #${PANEL_ID} .chroma-selection li > .ember-view {
+        display: flex !important; align-items: center !important; justify-content: center !important;
+        flex: 0 0 26px !important; width: 26px !important; height: 26px !important;
+        min-width: 26px !important; min-height: 26px !important;
+        max-width: 26px !important; max-height: 26px !important;
+        margin: 0 !important; padding: 0 !important; transform: none !important;
+      }
+      #${PANEL_ID} .chroma-skin-button {
+        display: flex !important; align-items: center !important; justify-content: center !important;
+        flex: 0 0 26px !important; width: 26px !important; height: 26px !important;
+        min-width: 26px !important; min-height: 26px !important;
+        max-width: 26px !important; max-height: 26px !important; aspect-ratio: 1 / 1 !important;
+        margin: 0 !important; padding: 0 !important; border: 0 !important;
+        border-radius: 50% !important; box-sizing: border-box !important;
+        background: transparent !important; box-shadow: 0 0 2px #010a13;
+        cursor: pointer; opacity: 1 !important; transform: scale(1) !important;
+      }
+      #${PANEL_ID} .chroma-skin-button .contents {
+        display: flex !important; align-items: center !important; justify-content: center !important;
+        width: 18px !important; height: 18px !important;
+        min-width: 18px !important; min-height: 18px !important;
+        max-width: 18px !important; max-height: 18px !important; aspect-ratio: 1 / 1 !important;
+        border: 2px solid #010a13 !important; border-radius: 50% !important;
+        box-shadow: 0 0 0 2px transparent; box-sizing: border-box !important;
+        opacity: 1 !important; transform: scale(1) !important;
+      }
+      #${PANEL_ID} .chroma-skin-button.selected .contents,
+      #${PANEL_ID} .chroma-skin-button:hover .contents {
+        box-shadow: 0 0 0 2px #c89b3c !important; transform: scale(1) !important;
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  async function start() {
+    while (!window.__roseBridge) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    bridge = window.__roseBridge;
+    injectStyles();
+    bridge.subscribe("phase-change", handlePhaseChange);
+    bridge.subscribe("champion-locked", handleChampionLocked);
+    bridge.subscribe("chroma-state", render);
+    window.addEventListener("rose-jade-wheel-layout", handleWheelLayout);
+    new MutationObserver(render).observe(document.body, { childList: true, subtree: true });
+    setInterval(render, 500);
+  }
+
+  start();
+})();

--- a/Pengu Loader/plugins/ROSE-ClassicHistoric/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicHistoric/index.js
@@ -18,7 +18,7 @@
   let presentationReady = false;
 
   function jadeActive() {
-    return window.__roseJadeWheelDebug?.state?.().active === true;
+    return window.__roseClassicWheelApi?.state?.().active === true;
   }
 
   function cleanup() {
@@ -186,7 +186,9 @@
   function handlePhaseChange(data) {
     const phase = String(data?.phase || "");
     const classicMode =
-      Number(data?.mapId) === 453 || String(data?.gameMode || "").toUpperCase() === "JADE";
+      Number(data?.mapId) === 453 ||
+      Number(data?.queueId) === 3260 ||
+      String(data?.gameMode || "").toUpperCase() === "JADE";
     isInJadeChampSelect =
       classicMode && (phase === "ChampSelect" || phase === "FINALIZATION");
     if (!isInJadeChampSelect) {
@@ -238,6 +240,8 @@
       render();
     });
     bridge.subscribe("phase-change", handlePhaseChange);
+    const classicState = window.__roseClassicWheelApi?.state?.();
+    if (classicState) handlePhaseChange(classicState);
     window.addEventListener("rose-jade-wheel-layout", handleWheelLayout);
     bridge.onReady(() => bridge.send({ type: "request-local-asset", assetPath: ASSET }));
     bridge.send({ type: "request-local-asset", assetPath: ASSET });

--- a/Pengu Loader/plugins/ROSE-ClassicHistoric/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicHistoric/index.js
@@ -17,6 +17,14 @@
   let randomModeActive = false;
   let presentationReady = false;
 
+  function log(level, message, data = null) {
+    const method = level === "error" ? "error" : level === "warn" ? "warn" : "log";
+    console[method](`[ClassicHistoric] ${message}`, data || "");
+    try {
+      bridge?.send({ type: "plugin-log", source: "ClassicHistoric", level, message, data, timestamp: Date.now() });
+    } catch (_) {}
+  }
+
   function jadeActive() {
     return window.__roseClassicWheelApi?.state?.().active === true;
   }
@@ -219,10 +227,12 @@
       if (!nextActive || nextSkinName !== skinName) presentationReady = false;
       active = nextActive;
       skinName = nextSkinName;
+      log("info", "Historic state updated", { active, skinName, randomModeActive });
       render();
     });
     bridge.subscribe("random-mode-state", (data) => {
       randomModeActive = data?.active === true;
+      log("info", "Random state observed", { active: randomModeActive });
       render();
     });
     bridge.subscribe("local-asset-url", (data) => {
@@ -245,6 +255,7 @@
     window.addEventListener("rose-jade-wheel-layout", handleWheelLayout);
     bridge.onReady(() => bridge.send({ type: "request-local-asset", assetPath: ASSET }));
     bridge.send({ type: "request-local-asset", assetPath: ASSET });
+    log("info", "Classic historic plugin initialized");
     new MutationObserver(render).observe(document.body, { childList: true, subtree: true });
   }
 

--- a/Pengu Loader/plugins/ROSE-ClassicHistoric/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicHistoric/index.js
@@ -16,6 +16,9 @@
   let isInJadeChampSelect = false;
   let randomModeActive = false;
   let presentationReady = false;
+  let customModActive = false;
+  let customModName = "";
+  let customModTargetSkinIds = new Set();
 
   function log(level, message, data = null) {
     const method = level === "error" ? "error" : level === "warn" ? "warn" : "log";
@@ -32,6 +35,15 @@
   function cleanup() {
     document.getElementById(MARK_ID)?.remove();
     document.getElementById(TOAST_ID)?.remove();
+  }
+
+  function currentSkinId() {
+    return Number(window.__roseClassicWheelApi?.currentSelection?.()?.skinId) || 0;
+  }
+
+  function customModApplies() {
+    const skinId = currentSkinId();
+    return customModActive && skinId > 0 && customModTargetSkinIds.has(skinId);
   }
 
   function renderMarker() {
@@ -79,9 +91,11 @@
     close.addEventListener("click", (event) => {
       event.preventDefault();
       event.stopPropagation();
-      active = false;
+      const dismissType = customModApplies() ? "dismiss-custom-mod" : "dismiss-historic";
+      if (dismissType === "dismiss-custom-mod") customModActive = false;
+      else active = false;
       cleanup();
-      bridge?.send({ type: "dismiss-historic", timestamp: Date.now() });
+      bridge?.send({ type: dismissType, timestamp: Date.now() });
     });
 
     content.appendChild(text);
@@ -92,8 +106,8 @@
     return toast;
   }
 
-  function renderToast() {
-    if (!skinName) {
+  function renderToast(displayName) {
+    if (!displayName) {
       document.getElementById(TOAST_ID)?.remove();
       return;
     }
@@ -103,19 +117,19 @@
       document.body.appendChild(toast);
     }
     const text = toast.querySelector(".rose-jade-historic-text");
-    if (text && text.textContent !== skinName) text.textContent = skinName;
+    if (text && text.textContent !== displayName) text.textContent = displayName;
   }
 
   function render() {
-    if (
-      !isInJadeChampSelect || !jadeActive() || !active ||
-      randomModeActive || !presentationReady
-    ) {
+    const showHistoric = active && !randomModeActive && presentationReady;
+    const showCustomMod = customModApplies();
+    if (!isInJadeChampSelect || !jadeActive() || (!showHistoric && !showCustomMod)) {
       cleanup();
       return;
     }
-    renderMarker();
-    renderToast();
+    if (showHistoric) renderMarker();
+    else document.getElementById(MARK_ID)?.remove();
+    renderToast(showCustomMod ? customModName : skinName);
   }
 
   function injectStyles() {
@@ -235,6 +249,20 @@
       log("info", "Random state observed", { active: randomModeActive });
       render();
     });
+    bridge.subscribe("custom-mod-state", (data) => {
+      customModActive = data?.active === true;
+      customModName = customModActive ? String(data?.modName || "") : "";
+      customModTargetSkinIds = new Set(
+        (Array.isArray(data?.targetSkinIds) ? data.targetSkinIds : [])
+          .map(Number)
+          .filter((value) => Number.isFinite(value) && value > 0)
+      );
+      const directSkinId = Number(data?.skinId);
+      if (Number.isFinite(directSkinId) && directSkinId > 0) {
+        customModTargetSkinIds.add(directSkinId);
+      }
+      render();
+    });
     bridge.subscribe("local-asset-url", (data) => {
       if (data?.assetPath !== ASSET) return;
       imageUrl = String(data.url || "").replace("localhost", "127.0.0.1");
@@ -249,6 +277,7 @@
       presentationReady = event?.detail?.ready === true;
       render();
     });
+    window.addEventListener("rose-classic-selection-change", render);
     bridge.subscribe("phase-change", handlePhaseChange);
     const classicState = window.__roseClassicWheelApi?.state?.();
     if (classicState) handlePhaseChange(classicState);

--- a/Pengu Loader/plugins/ROSE-ClassicHistoric/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicHistoric/index.js
@@ -1,0 +1,248 @@
+/**
+ * @name ROSE-ClassicHistoric
+ * @description JADE-only history marker and standard history toast.
+ */
+(function initJadeHistoric() {
+  "use strict";
+
+  const MARK_ID = "rose-jade-historic-mark";
+  const TOAST_ID = "rose-jade-historic-toast";
+  const STYLE_ID = "rose-jade-historic-style";
+  const ASSET = "historic_flag.png";
+  let bridge = null;
+  let active = false;
+  let skinName = "";
+  let imageUrl = "";
+  let isInJadeChampSelect = false;
+  let randomModeActive = false;
+  let presentationReady = false;
+
+  function jadeActive() {
+    return window.__roseJadeWheelDebug?.state?.().active === true;
+  }
+
+  function cleanup() {
+    document.getElementById(MARK_ID)?.remove();
+    document.getElementById(TOAST_ID)?.remove();
+  }
+
+  function renderMarker() {
+    const anchor = document.querySelector(
+      ".rose-jade-native-card.rose-jade-native-card--selected:not(.skins-pane__skin-card--placeholder) > .rose-jade-history-anchor"
+    );
+    if (!anchor) {
+      document.getElementById(MARK_ID)?.remove();
+      return;
+    }
+    let mark = document.getElementById(MARK_ID);
+    if (!mark) {
+      mark = document.createElement("div");
+      mark.id = MARK_ID;
+      mark.setAttribute("aria-label", "Historic skin");
+    }
+    mark.title = "Historic skin";
+    if (imageUrl) mark.style.backgroundImage = `url("${imageUrl}")`;
+    if (mark.parentElement !== anchor) anchor.appendChild(mark);
+  }
+
+  function createToast() {
+    const toast = document.createElement("div");
+    toast.id = TOAST_ID;
+
+    const toastBody = document.createElement("div");
+    toastBody.className = "toast-body";
+
+    const toastContent = document.createElement("div");
+    toastContent.className = "toast-content";
+    const frame = document.createElement("lol-uikit-dialog-frame");
+    frame.className = "lol-uikit-dialog-frame top dismissable-icon";
+    const content = document.createElement("lol-uikit-content-block");
+    content.className = "lol-ready-check-notification-party-dodge";
+    content.setAttribute("type", "notification");
+    const text = document.createElement("p");
+    text.className = "rose-jade-historic-text";
+    const subBorder = document.createElement("div");
+    subBorder.className = "lol-uikit-dialog-frame-sub-border";
+    const close = document.createElement("div");
+    close.className = "lol-uikit-dialog-frame-toast-close-button";
+    close.setAttribute("role", "button");
+    close.tabIndex = 0;
+    close.title = "Close";
+    close.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      active = false;
+      cleanup();
+      bridge?.send({ type: "dismiss-historic", timestamp: Date.now() });
+    });
+
+    content.appendChild(text);
+    frame.append(content, subBorder, close);
+    toastContent.appendChild(frame);
+    toastBody.appendChild(toastContent);
+    toast.appendChild(toastBody);
+    return toast;
+  }
+
+  function renderToast() {
+    if (!skinName) {
+      document.getElementById(TOAST_ID)?.remove();
+      return;
+    }
+    let toast = document.getElementById(TOAST_ID);
+    if (!toast) {
+      toast = createToast();
+      document.body.appendChild(toast);
+    }
+    const text = toast.querySelector(".rose-jade-historic-text");
+    if (text && text.textContent !== skinName) text.textContent = skinName;
+  }
+
+  function render() {
+    if (
+      !isInJadeChampSelect || !jadeActive() || !active ||
+      randomModeActive || !presentationReady
+    ) {
+      cleanup();
+      return;
+    }
+    renderMarker();
+    renderToast();
+  }
+
+  function injectStyles() {
+    if (document.getElementById(STYLE_ID)) return;
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = `
+      #${MARK_ID} {
+        position: absolute; inset: 0; width: 100%; height: 100%;
+        z-index: 24; pointer-events: none; background: center / contain no-repeat;
+      }
+      #${TOAST_ID} {
+        position: fixed; left: 50%; bottom: calc(10% + 215px);
+        transform: translateX(-50%); z-index: 10000; display: flex;
+        align-items: center; justify-content: center; width: auto; max-width: 300px;
+        margin: 0; padding: 0; box-sizing: border-box;
+        color: #b2a580; font-size: 14px; line-height: 1.4; pointer-events: none;
+      }
+      #${TOAST_ID} .toast-body {
+        position: relative; display: flex; flex-direction: column;
+        justify-content: space-between; box-sizing: border-box; width: auto; margin: 0 auto;
+      }
+      #${TOAST_ID} .toast-content {
+        display: flex; align-items: center; justify-content: center; width: 100%;
+      }
+      #${TOAST_ID} .lol-uikit-dialog-frame {
+        position: relative; display: inline-block; border: none;
+        background: #010a13; box-shadow: 0 0 0 1px rgba(1,10,19,.48);
+      }
+      #${TOAST_ID} .lol-uikit-dialog-frame::before {
+        content: ""; position: absolute; width: calc(100% + 4px); height: calc(100% + 4px);
+        top: -2px; left: -2px; box-shadow: 0 0 10px 1px rgba(0,0,0,.5);
+        pointer-events: none;
+      }
+      #${TOAST_ID} lol-uikit-content-block {
+        display: inline-block; position: relative; box-sizing: border-box;
+        width: auto; padding-left: 25px; padding-right: 25px;
+        background: transparent; text-align: center;
+        font-family: "LoL Body",Arial,"Helvetica Neue",Helvetica,sans-serif;
+      }
+      #${TOAST_ID} .rose-jade-historic-text {
+        margin: 0; color: #b2a580; font-size: 14px; line-height: 1.4;
+        letter-spacing: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+      }
+      #${TOAST_ID} .lol-uikit-dialog-frame-sub-border::before,
+      #${TOAST_ID} .lol-uikit-dialog-frame-sub-border::after {
+        content: ""; position: absolute; display: flex; box-sizing: border-box;
+        left: 12px; width: calc(100% - 24px); height: 0;
+        border-width: 4px 4px 0 4px; border-image-width: 4px 4px 0 4px;
+        border-image-slice: 4 4 0 4; border-image-repeat: stretch; border-style: solid;
+      }
+      #${TOAST_ID} .lol-uikit-dialog-frame-sub-border::before {
+        top: -6px; border-image-source: url("/fe/lol-uikit/images/sub-border-primary-horizontal.png");
+        transform: rotate(180deg);
+      }
+      #${TOAST_ID} .lol-uikit-dialog-frame-sub-border::after {
+        bottom: -6px; border-image-source: url("/fe/lol-uikit/images/sub-border-secondary-horizontal.png");
+        transform: rotate(180deg);
+      }
+      #${TOAST_ID} .lol-uikit-dialog-frame-toast-close-button {
+        position: absolute; top: 2px; right: 2px; width: 16px; height: 16px;
+        padding: 0; border: 0; border-radius: 50%; cursor: pointer; pointer-events: auto;
+        background: url("/fe/lol-uikit/images/close.png"), rgba(0,0,0,.7);
+        background-size: 70% 70%, 100% 100%; background-position: center;
+        background-repeat: no-repeat; z-index: 10;
+      }
+      #${TOAST_ID} .lol-uikit-dialog-frame-toast-close-button:hover {
+        background: url("/fe/lol-uikit/images/close.png"), rgba(200,50,50,.8);
+        background-size: 70% 70%, 100% 100%; background-position: center;
+        background-repeat: no-repeat;
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  function handlePhaseChange(data) {
+    const phase = String(data?.phase || "");
+    const classicMode =
+      Number(data?.mapId) === 453 || String(data?.gameMode || "").toUpperCase() === "JADE";
+    isInJadeChampSelect =
+      classicMode && (phase === "ChampSelect" || phase === "FINALIZATION");
+    if (!isInJadeChampSelect) {
+      presentationReady = false;
+      cleanup();
+    }
+    else render();
+  }
+
+  function handleWheelLayout(event) {
+    if (event?.detail?.active === false) {
+      presentationReady = false;
+      cleanup();
+      return;
+    }
+    render();
+  }
+
+  async function start() {
+    while (!window.__roseBridge) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    bridge = window.__roseBridge;
+    injectStyles();
+    bridge.subscribe("historic-state", (data) => {
+      const nextActive = data?.active === true;
+      const nextSkinName = String(data?.historicSkinName || "");
+      if (!nextActive || nextSkinName !== skinName) presentationReady = false;
+      active = nextActive;
+      skinName = nextSkinName;
+      render();
+    });
+    bridge.subscribe("random-mode-state", (data) => {
+      randomModeActive = data?.active === true;
+      render();
+    });
+    bridge.subscribe("local-asset-url", (data) => {
+      if (data?.assetPath !== ASSET) return;
+      imageUrl = String(data.url || "").replace("localhost", "127.0.0.1");
+      render();
+    });
+    window.addEventListener("rose-jade-historic-presentation", (event) => {
+      skinName = String(event?.detail?.skinName || skinName);
+      presentationReady = true;
+      render();
+    });
+    window.addEventListener("rose-jade-historic-presentation-state", (event) => {
+      presentationReady = event?.detail?.ready === true;
+      render();
+    });
+    bridge.subscribe("phase-change", handlePhaseChange);
+    window.addEventListener("rose-jade-wheel-layout", handleWheelLayout);
+    bridge.onReady(() => bridge.send({ type: "request-local-asset", assetPath: ASSET }));
+    bridge.send({ type: "request-local-asset", assetPath: ASSET });
+    new MutationObserver(render).observe(document.body, { childList: true, subtree: true });
+  }
+
+  start();
+})();

--- a/Pengu Loader/plugins/ROSE-ClassicMods/index.js_
+++ b/Pengu Loader/plugins/ROSE-ClassicMods/index.js_
@@ -1,23 +1,21 @@
 /**
- * @name ROSE-CustomWheel
+ * @name ROSE-ClassicMods
  * @author Rose Team
- * @description Custom mod wheel for Pengu Loader - displays installed mods for hovered skins
- * @link https://github.com/Alban1911/ROSE-CustomWheel
+ * @description Classic-mode Mod selector derived from ROSE-CustomWheel.
  */
-(function createCustomWheel() {
-  const LOG_PREFIX = "[ROSE-CustomWheel]";
-  console.log(`${LOG_PREFIX} JS Loaded`);
-  // Keep the custom wheel fully namespaced. The official chroma wheel uses
-  // the lu-chroma-* selectors, and sharing them makes the two panels style
-  // and interfere with one another.
-  const BUTTON_CLASS = "rose-custom-wheel-button";
+(function createClassicMods() {
+  const LOG_PREFIX = "[ROSE-ClassicMods]";
+  // Keep the Classic selector independent from the regular Mod wheel.
+  const BUTTON_CLASS = "rose-classic-mods-button";
   const BUTTON_SELECTOR = `.${BUTTON_CLASS}`;
-  const PANEL_CLASS = "rose-custom-wheel-panel";
-  const PANEL_ID = "rose-custom-wheel-panel-container";
+  const PANEL_CLASS = "rose-classic-mods-panel";
+  const PANEL_ID = "rose-classic-mods-panel-container";
   const REQUEST_TYPE = "request-skin-mods";
   const EVENT_SKIN_STATE = "lu-skin-monitor-state";
+  const EVENT_CLASSIC_SELECTION = "rose-classic-selection-change";
 
   let isOpen = false;
+  let bridge = null;
   let panel = null;
   let button = null;
   let championSelectRoot = null;
@@ -44,29 +42,29 @@
   // These are first-class categories in the UI; they just share the same list rendering logic.
   let selectedCategoryIds = Object.create(null);
 
+  function log(level, message, data = null) {
+    const method = level === "error" ? "error" : level === "warn" ? "warn" : "log";
+    console[method](`${LOG_PREFIX} ${message}`, data || "");
+    try {
+      bridge?.send({
+        type: "plugin-log",
+        source: "ClassicMods",
+        level,
+        message,
+        data,
+        timestamp: Date.now(),
+      });
+    } catch (_) {}
+  }
+
+  log("info", "Classic Mods script loaded");
+
   function getCurrentSkinContext() {
-    const state = window.__roseSkinState || {};
-    const championId = Number(state.championId);
-    let skinId = Number(state.skinId);
-    const selectedChromaId = Number(pythonChromaState?.selectedChromaId);
-    const currentSkinId = Number(pythonChromaState?.currentSkinId);
-
-    const chromaBelongsToChampion =
-      Number.isFinite(selectedChromaId) &&
-      selectedChromaId > 0 &&
-      Number.isFinite(championId) &&
-      championId > 0 &&
-      Math.floor(selectedChromaId / 1000) === championId;
-    const chromaContextMatches =
-      !Number.isFinite(currentSkinId) ||
-      currentSkinId <= 0 ||
-      Math.floor(currentSkinId / 1000) === championId;
-
-    if (chromaBelongsToChampion && chromaContextMatches) {
-      skinId = selectedChromaId;
-    }
-
-    return { championId, skinId };
+    const selection = window.__roseClassicWheelApi?.currentSelection?.();
+    return {
+      championId: Number(selection?.championId) || 0,
+      skinId: Number(selection?.skinId) || 0,
+    };
   }
 
   function isSelectedModForSkin(skinId = getCurrentSkinContext().skinId) {
@@ -106,6 +104,12 @@
     pythonChromaState = null;
     selectedModId = null;
     selectedModSkinId = null;
+    selectedMapId = null;
+    selectedFontId = null;
+    selectedAnnouncerId = null;
+    clearAllCategorySelections();
+    lastCategoryModsById = {};
+    emittedHistoricSelectionKeys.clear();
     pendingSelectionRequest = null;
     latestSkinModsRequestId = null;
     currentSkinMods = [];
@@ -113,33 +117,43 @@
 
   function handlePhaseChange(data) {
     const phase = String(data?.phase || "");
-    const previousPhase = currentPhase;
+    const wasActive = classicModeActive;
     currentPhase = phase;
-    classicModeActive =
+    const classicContext =
       data?.mapId === 453 ||
       data?.queueId === 3260 ||
       (typeof data?.gameMode === "string" && data.gameMode.toUpperCase() === "JADE");
+    classicModeActive =
+      classicContext && (phase === "ChampSelect" || phase === "FINALIZATION");
 
-    if (classicModeActive) {
-      resetCustomSkinSessionState();
+    if (wasActive !== classicModeActive) {
+      log("info", classicModeActive ? "Classic Mods mode activated" : "Classic Mods mode deactivated", {
+        phase,
+        mapId: data?.mapId,
+        queueId: data?.queueId,
+      });
+    }
+
+    if (!classicModeActive) {
+      if (wasActive) resetCustomSkinSessionState();
       closePanel();
       detachFromChampionSelect();
       championSelectRoot = null;
       return;
     }
 
-    if (
-      phase === "ChampSelect" &&
-      previousPhase &&
-      previousPhase !== "ChampSelect"
-    ) {
+    if (!wasActive) {
       resetCustomSkinSessionState();
-    } else if (
-      phase !== "ChampSelect" &&
-      previousPhase === "ChampSelect"
-    ) {
-      resetCustomSkinSessionState();
+      requestGlobalMods();
     }
+    updateChampionSelectTarget();
+    setTimeout(requestModsForCurrentSkin, 0);
+  }
+
+  function requestGlobalMods() {
+    requestFonts();
+    requestAnnouncers();
+    for (const tab of OTHER_CATEGORY_TABS) requestCategoryMods(tab.id);
   }
   let lastChampionSelectSession = null; // Track current champ select session
   let isFirstOpenInSession = true; // Track if this is first open in current session
@@ -178,6 +192,9 @@
     { id: "announcers", label: "Announcers" },
     ...OTHER_CATEGORY_TABS.map((t) => ({ id: t.id, label: t.label })),
   ];
+  const DISABLED_CLASSIC_TABS = new Map([
+    ["maps", "Classic map Mod compatibility has not been verified for map 453."],
+  ]);
 
   const SUMMARY_ICONS = {
     skins: '<svg viewBox="0 0 24 24"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>',
@@ -212,6 +229,7 @@
   }
 
   function getSelectedSummaryForTab(tabId) {
+    if (DISABLED_CLASSIC_TABS.has(tabId)) return "Unavailable";
     if (tabId === "skins") {
       if (!championLocked) return "Waiting for champ lock…";
       return isSelectedModForSkin() ? String(selectedModId) : "None";
@@ -249,13 +267,15 @@
     for (const tab of SUMMARY_TABS) {
       const el = panel._summaryValuesByTab[tab.id];
       const raw = getSelectedSummaryForTab(tab.id);
-      if (el) {
-        el.textContent = (raw !== "None" && raw !== "Waiting for champ lock…") ? cleanModName(raw) : raw;
-      }
+      const hasSelection =
+        raw !== "None" &&
+        raw !== "Unavailable" &&
+        raw !== "Waiting for champ lock…";
+      if (el) el.textContent = hasSelection ? cleanModName(raw) : raw;
       // Toggle active class on the row
       const row = panel._summaryRowsByTab && panel._summaryRowsByTab[tab.id];
       if (row) {
-        if (raw !== "None" && raw !== "Waiting for champ lock…") {
+        if (hasSelection) {
           row.classList.add("active");
         } else {
           row.classList.remove("active");
@@ -283,7 +303,7 @@
     if (panel._rightTitle) {
       if (mode === "picker") {
         const icon = SUMMARY_ICONS[activeTab] || "";
-        panel._rightTitle.innerHTML = `<span class="rose-wheel-title-icon">${icon}</span> Choose \u2022 ${escapeHtml(getTabLabel(activeTab))}`;
+        panel._rightTitle.innerHTML = `<span class="rose-classic-mods-title-icon">${icon}</span> Choose \u2022 ${escapeHtml(getTabLabel(activeTab))}`;
       } else {
         panel._rightTitle.textContent = "Custom Mods";
       }
@@ -291,8 +311,6 @@
   }
 
   // Shared bridge API (provided by ROSE-SkinMonitor)
-  let bridge = null;
-
   function waitForBridge() {
     return new Promise((resolve, reject) => {
       const timeout = 10000;
@@ -336,23 +354,23 @@
     }
 
     /* Button and Badge Styles */
-    lol-uikit-flat-button.rose-custom-wheel-button,
-    .rose-custom-wheel-button {
+    lol-uikit-flat-button.rose-classic-mods-button,
+    .rose-classic-mods-button {
       display: inline-block !important;
       white-space: nowrap !important;
       /* Keep badge stacking self-contained (prevents weird overlap with other UI) */
       isolation: isolate !important;
     }
 
-    .rose-custom-wheel-button .count-badge.social-count-badge,
-    lol-uikit-flat-button.rose-custom-wheel-button .count-badge.social-count-badge,
-    .rose-custom-wheel-button > .count-badge.social-count-badge,
-    lol-uikit-flat-button.rose-custom-wheel-button > .count-badge.social-count-badge {
+    .rose-classic-mods-button .count-badge.social-count-badge,
+    lol-uikit-flat-button.rose-classic-mods-button .count-badge.social-count-badge,
+    .rose-classic-mods-button > .count-badge.social-count-badge,
+    lol-uikit-flat-button.rose-classic-mods-button > .count-badge.social-count-badge {
       position: absolute !important;
       /* Positioning: edit these via CSS variables on the element (DevTools-friendly) */
-      top: var(--rose-badge-top, -4px) !important;
-      right: var(--rose-badge-right, -17px) !important;
-      left: var(--rose-badge-left, auto) !important;
+      top: var(--rose-classic-mods-badge-top, -4px) !important;
+      right: var(--rose-classic-mods-badge-right, -17px) !important;
+      left: var(--rose-classic-mods-badge-left, auto) !important;
       min-width: 18px !important;
       height: 18px !important;
       padding: 0 5px !important;
@@ -370,8 +388,8 @@
       /* Above button contents, but not globally "high" */
       z-index: 1 !important;
       transform: translate(
-        var(--rose-badge-translate-x, 60%),
-        var(--rose-badge-translate-y, -60%)
+        var(--rose-classic-mods-badge-translate-x, 60%),
+        var(--rose-classic-mods-badge-translate-y, -60%)
       ) !important;
       margin: 0 !important;
       bottom: auto !important;
@@ -403,7 +421,7 @@
       background-color: transparent !important;
       border: none !important;
     }
-    
+
     .${BUTTON_CLASS} .button-image.default {
       background-color: transparent;
       border: none;
@@ -451,8 +469,8 @@
       min-height: 420px !important;
       max-height: calc(100vh - 120px) !important;
     }
-    
-    .${PANEL_CLASS} .chroma-modal.rose-custom-wheel-modal {
+
+    .${PANEL_CLASS} .chroma-modal.rose-classic-mods-modal {
       /* Height handled in base class to ensure consistency */
       overflow: hidden;
     }
@@ -466,7 +484,7 @@
       width: auto !important;
       filter: drop-shadow(0 0 10px rgba(0,0,0,0.5));
     }
-    
+
     .${PANEL_CLASS} .flyout .caret,
     .${PANEL_CLASS} .flyout [class*="caret"],
     .${PANEL_CLASS} lol-uikit-flyout-frame .caret,
@@ -493,7 +511,7 @@
     /* Tab Navigation */
     /* ===== Unified Summary rows (category + status + change in one row) ===== */
 
-    .${PANEL_CLASS} .rose-wheel-right-header {
+    .${PANEL_CLASS} .rose-classic-mods-right-header {
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -504,7 +522,7 @@
       flex-shrink: 0;
     }
 
-    .${PANEL_CLASS} .rose-wheel-right-title {
+    .${PANEL_CLASS} .rose-classic-mods-right-title {
       font-weight: 700;
       color: #f0e6d2;
       font-size: 13px;
@@ -516,13 +534,13 @@
       gap: 6px;
     }
 
-    .${PANEL_CLASS} .rose-wheel-right-title .rose-wheel-title-icon {
+    .${PANEL_CLASS} .rose-classic-mods-right-title .rose-classic-mods-title-icon {
       width: 18px;
       height: 18px;
       flex-shrink: 0;
     }
 
-    .${PANEL_CLASS} .rose-wheel-right-title .rose-wheel-title-icon svg {
+    .${PANEL_CLASS} .rose-classic-mods-right-title .rose-classic-mods-title-icon svg {
       width: 18px;
       height: 18px;
       fill: none;
@@ -532,7 +550,7 @@
       stroke-linejoin: round;
     }
 
-    .${PANEL_CLASS} .rose-wheel-summary {
+    .${PANEL_CLASS} .rose-classic-mods-summary {
       flex: 1;
       min-height: 0;
       display: flex;
@@ -543,11 +561,11 @@
       overflow-y: auto;
     }
 
-    .${PANEL_CLASS} .rose-wheel-summary::-webkit-scrollbar { width: 6px; }
-    .${PANEL_CLASS} .rose-wheel-summary::-webkit-scrollbar-track { background: rgba(0,0,0,0.3); }
-    .${PANEL_CLASS} .rose-wheel-summary::-webkit-scrollbar-thumb { background: #5b5a56; border-radius: 3px; }
+    .${PANEL_CLASS} .rose-classic-mods-summary::-webkit-scrollbar { width: 6px; }
+    .${PANEL_CLASS} .rose-classic-mods-summary::-webkit-scrollbar-track { background: rgba(0,0,0,0.3); }
+    .${PANEL_CLASS} .rose-classic-mods-summary::-webkit-scrollbar-thumb { background: #5b5a56; border-radius: 3px; }
 
-    .${PANEL_CLASS} .rose-wheel-summary-row {
+    .${PANEL_CLASS} .rose-classic-mods-summary-row {
       display: grid;
       grid-template-columns: 1fr auto;
       align-items: center;
@@ -560,27 +578,33 @@
       transition: all 0.2s ease;
     }
 
-    .${PANEL_CLASS} .rose-wheel-summary-row:hover {
+    .${PANEL_CLASS} .rose-classic-mods-summary-row:hover {
       background: linear-gradient(to right, rgba(40, 45, 50, 0.9), rgba(40, 45, 50, 0.7));
       border-color: #5c5c61;
       border-left-color: #c8aa6e;
       transform: translateX(2px);
     }
 
-    .${PANEL_CLASS} .rose-wheel-summary-row:active {
+    .${PANEL_CLASS} .rose-classic-mods-summary-row:active {
       transform: scale(0.98);
       transition: transform 0.1s ease;
     }
 
-    .${PANEL_CLASS} .rose-wheel-summary-row.active {
+    .${PANEL_CLASS} .rose-classic-mods-summary-row.active {
       border-left: 3px solid #c8aa6e;
     }
 
-    .${PANEL_CLASS} .rose-wheel-summary-row:hover .rose-wheel-summary-icon {
+    .${PANEL_CLASS} .rose-classic-mods-summary-row.disabled {
+      cursor: not-allowed;
+      opacity: 0.45;
+      pointer-events: none;
+    }
+
+    .${PANEL_CLASS} .rose-classic-mods-summary-row:hover .rose-classic-mods-summary-icon {
       color: #c8aa6e;
     }
 
-    .${PANEL_CLASS} .rose-wheel-summary-icon {
+    .${PANEL_CLASS} .rose-classic-mods-summary-icon {
       width: 18px;
       height: 18px;
       flex-shrink: 0;
@@ -588,7 +612,7 @@
       transition: color 0.2s ease;
     }
 
-    .${PANEL_CLASS} .rose-wheel-summary-icon svg {
+    .${PANEL_CLASS} .rose-classic-mods-summary-icon svg {
       width: 18px;
       height: 18px;
       fill: none;
@@ -598,7 +622,7 @@
       stroke-linejoin: round;
     }
 
-    .${PANEL_CLASS} .rose-wheel-summary-left {
+    .${PANEL_CLASS} .rose-classic-mods-summary-left {
       flex: 1;
       min-width: 0;
       display: flex;
@@ -606,7 +630,7 @@
       gap: 6px;
     }
 
-    .${PANEL_CLASS} .rose-wheel-summary-label {
+    .${PANEL_CLASS} .rose-classic-mods-summary-label {
       color: #a09b8c;
       font-size: 12px;
       font-weight: 700;
@@ -614,20 +638,20 @@
       letter-spacing: 0.5px;
     }
 
-    .${PANEL_CLASS} .rose-wheel-summary-value {
+    .${PANEL_CLASS} .rose-classic-mods-summary-value {
       color: #f0e6d2;
       font-size: 13px;
       font-weight: 700;
       word-break: break-word;
     }
 
-    .${PANEL_CLASS} .rose-wheel-picker {
+    .${PANEL_CLASS} .rose-classic-mods-picker {
       flex: 1;
       min-height: 0;
       display: none;
     }
 
-    .${PANEL_CLASS} .rose-wheel-picker.active {
+    .${PANEL_CLASS} .rose-classic-mods-picker.active {
       display: flex;
       flex-direction: column;
       min-height: 0;
@@ -717,7 +741,7 @@
       gap: 12px;
       width: 100%;
     }
-    
+
     .${PANEL_CLASS} .mod-name {
       color: #f0e6d2;
       font-size: 13px;
@@ -737,7 +761,7 @@
       word-wrap: break-word;
     }
 
-    .${PANEL_CLASS} .mod-meta, 
+    .${PANEL_CLASS} .mod-meta,
     .${PANEL_CLASS} .mod-injection-note {
       color: #7a7a7d;
       font-size: 10px;
@@ -752,7 +776,7 @@
       font-style: italic;
     }
 
-    .${PANEL_CLASS} .rose-wheel-back-button {
+    .${PANEL_CLASS} .rose-classic-mods-back-button {
       background: transparent;
       border: 1px solid #c8aa6e;
       color: #c8aa6e;
@@ -766,14 +790,14 @@
       border-radius: 0;
     }
 
-    .${PANEL_CLASS} .rose-wheel-back-button:hover {
+    .${PANEL_CLASS} .rose-classic-mods-back-button:hover {
       background: rgba(200, 170, 110, 0.1);
       box-shadow: 0 0 8px rgba(200, 170, 110, 0.2);
     }
   `;
 
   function injectCSS() {
-    const styleId = "rose-custom-wheel-css";
+    const styleId = "rose-classic-mods-css";
     if (document.getElementById(styleId)) {
       return;
     }
@@ -794,8 +818,8 @@
     } catch (e) {
       button = document.createElement("div");
     }
-    button.className = "lol-uikit-flat-button idle rose-custom-wheel-button";
-    button.textContent = "Custom mods";
+    button.className = "lol-uikit-flat-button idle rose-classic-mods-button";
+    button.textContent = "Classic mods";
 
     // Ensure button has relative positioning for badge (only if not already positioned)
     const computedStyle = window.getComputedStyle(button);
@@ -809,11 +833,11 @@
     countBadge.textContent = "0";
     countBadge.style.display = "none"; // Hidden by default
     // Defaults (can be overridden live in DevTools on the element via CSS variables)
-    countBadge.style.setProperty("--rose-badge-top", "-4px");
-    countBadge.style.setProperty("--rose-badge-right", "-17px");
-    countBadge.style.setProperty("--rose-badge-left", "auto");
-    countBadge.style.setProperty("--rose-badge-translate-x", "60%");
-    countBadge.style.setProperty("--rose-badge-translate-y", "-60%");
+    countBadge.style.setProperty("--rose-classic-mods-badge-top", "-4px");
+    countBadge.style.setProperty("--rose-classic-mods-badge-right", "-17px");
+    countBadge.style.setProperty("--rose-classic-mods-badge-left", "auto");
+    countBadge.style.setProperty("--rose-classic-mods-badge-translate-x", "60%");
+    countBadge.style.setProperty("--rose-classic-mods-badge-translate-y", "-60%");
     button.appendChild(countBadge);
     button._countBadge = countBadge; // Store reference
 
@@ -876,7 +900,7 @@
     }
 
     const modal = document.createElement("div");
-    modal.className = "rose-custom-wheel-modal chroma-modal";
+    modal.className = "rose-classic-mods-modal chroma-modal";
 
     // Header Decoration removed as per user request
 
@@ -920,7 +944,7 @@
       if (panel && panel._rightTitle) {
         if (rightPaneMode === "picker") {
           const icon = SUMMARY_ICONS[activeTab] || "";
-          panel._rightTitle.innerHTML = `<span class="rose-wheel-title-icon">${icon}</span> Choose \u2022 ${escapeHtml(getTabLabel(activeTab))}`;
+          panel._rightTitle.innerHTML = `<span class="rose-classic-mods-title-icon">${icon}</span> Choose \u2022 ${escapeHtml(getTabLabel(activeTab))}`;
         } else {
           panel._rightTitle.textContent = "Custom Mods";
         }
@@ -1076,10 +1100,10 @@
 
     // Header + Summary + Picker (Summary rows contain the category buttons on the left)
     const rightHeader = document.createElement("div");
-    rightHeader.className = "rose-wheel-right-header";
+    rightHeader.className = "rose-classic-mods-right-header";
 
     const rightTitle = document.createElement("div");
-    rightTitle.className = "rose-wheel-right-title";
+    rightTitle.className = "rose-classic-mods-right-title";
     rightTitle.textContent = "Custom Mods";
 
     const headerButtons = document.createElement("div");
@@ -1087,7 +1111,7 @@
     headerButtons.style.gap = "8px";
 
     const backBtn = document.createElement("button");
-    backBtn.className = "rose-wheel-back-button";
+    backBtn.className = "rose-classic-mods-back-button";
     backBtn.textContent = "Back";
     backBtn.style.display = "none";
 
@@ -1098,29 +1122,35 @@
 
     // Summary view (all categories)
     const summaryView = document.createElement("div");
-    summaryView.className = "rose-wheel-summary";
+    summaryView.className = "rose-classic-mods-summary";
 
     panel._summaryValuesByTab = {};
     panel._summaryRowsByTab = {};
 
     SUMMARY_TABS.forEach((tab) => {
       const row = document.createElement("div");
-      row.className = "rose-wheel-summary-row";
+      row.className = "rose-classic-mods-summary-row";
+      const disabledReason = DISABLED_CLASSIC_TABS.get(tab.id);
       row.setAttribute("role", "button");
-      row.tabIndex = 0;
+      row.setAttribute("aria-disabled", disabledReason ? "true" : "false");
+      row.tabIndex = disabledReason ? -1 : 0;
+      if (disabledReason) {
+        row.classList.add("disabled");
+        row.title = disabledReason;
+      }
 
       // Left cell: value
       const left = document.createElement("div");
-      left.className = "rose-wheel-summary-left";
+      left.className = "rose-classic-mods-summary-left";
 
       const label = document.createElement("div");
-      label.className = "rose-wheel-summary-label";
+      label.className = "rose-classic-mods-summary-label";
       label.style.display = "flex";
       label.style.alignItems = "center";
       label.style.gap = "6px";
 
       const iconSpan = document.createElement("span");
-      iconSpan.className = "rose-wheel-summary-icon";
+      iconSpan.className = "rose-classic-mods-summary-icon";
       iconSpan.innerHTML = SUMMARY_ICONS[tab.id] || "";
       label.appendChild(iconSpan);
 
@@ -1129,7 +1159,7 @@
       label.appendChild(labelText);
 
       const value = document.createElement("div");
-      value.className = "rose-wheel-summary-value";
+      value.className = "rose-classic-mods-summary-value";
       value.textContent = getSelectedSummaryForTab(tab.id);
       panel._summaryValuesByTab[tab.id] = value;
 
@@ -1137,6 +1167,7 @@
       left.appendChild(value);
 
       const openPicker = () => {
+        if (disabledReason) return;
         switchTab(tab.id);
         setRightPaneMode("picker");
         refreshSummaryValues();
@@ -1157,7 +1188,7 @@
 
     // Picker view (reuses existing scrollable with tab contents)
     const pickerView = document.createElement("div");
-    pickerView.className = "rose-wheel-picker";
+    pickerView.className = "rose-classic-mods-picker";
     pickerView.appendChild(scrollable);
 
     backBtn.addEventListener("click", (e) => {
@@ -1300,7 +1331,7 @@
         expectedModId: selectedModId,
       });
     } else {
-      console.log(`[ROSE-CustomWheel] Sending mod selection:`, { championId, skinId, modId, modData });
+      log("info", "Mod selection requested", { championId, skinId, modId, modData });
       sendSkinModSelection({ championId, skinId, modId, modData });
     }
   }
@@ -1935,8 +1966,8 @@
 
   function updateChampionSelectTarget() {
     const target = classicModeActive
-      ? null
-      : document.querySelector(".champion-select");
+      ? document.querySelector(".champion-select")
+      : null;
     if (target === championSelectRoot) {
       // Even if target is the same, check if button needs to be attached
       if (target && (!button || !button.parentNode)) {
@@ -2187,6 +2218,7 @@
   }
 
   function handleSkinState(event) {
+    if (!classicModeActive) return;
     resetStaleChromaStateForSkin(event?.detail?.skinId);
 
     // Always request mods to update badge, even if panel is not open
@@ -2224,7 +2256,6 @@
     let count = 0;
     // Skins are only meaningful after champ lock.
     if (championLocked && isSelectedModForSkin()) count += 1;
-    if (selectedMapId) count += 1;
     if (selectedFontId) count += 1;
     if (selectedAnnouncerId) count += 1;
     // Sum the unique selections per category (UI / VO / Loading Screen / VFX / SFX / Others).
@@ -2275,7 +2306,7 @@
     pendingSelectionRequest = null;
 
     if (!detail.success) {
-      console.warn(`${LOG_PREFIX} Custom skin selection failed: ${detail.error || "unknown error"}`);
+      log("error", "Custom skin selection failed", detail.error || "unknown error");
       refreshSummaryValues();
       refreshButtonBadgeFromSelections();
       return;
@@ -2288,6 +2319,12 @@
       selectedModId = String(detail.relativePath || detail.modId || pending?.modId || "");
       selectedModSkinId = Number(detail.skinId || getCurrentSkinContext().skinId);
     }
+
+    log("info", "Custom Mod selection completed", {
+      operation: detail.operation || "unknown",
+      modId: detail.modId || detail.relativePath || null,
+      skinId: detail.skinId || pending?.skinId || null,
+    });
 
     if (isOpen) {
       updateModEntries(currentSkinMods);
@@ -2573,7 +2610,7 @@
     // historicMod can be a string (legacy) or an array (new format)
     const historicMod = detail.historicMod;
     const historicMods = Array.isArray(historicMod) ? historicMod : (historicMod ? [historicMod] : []);
-    
+
     const selectedIds = getSelectedIdsForCategory("others");
     if (historicMods.length > 0 && selectedIds.length === 0) {
       // Find all mods that match the historic paths
@@ -2744,9 +2781,9 @@
   whenReady(async () => {
     try {
       bridge = await waitForBridge();
-      console.log(`${LOG_PREFIX} Bridge connected`);
+      log("info", "Bridge connected");
     } catch (e) {
-      console.error(`${LOG_PREFIX} Failed to connect to bridge:`, e);
+      log("error", "Failed to connect to bridge", String(e));
     }
 
     injectCSS();
@@ -2758,6 +2795,11 @@
     // Keep the skin-state window event (published by SkinMonitor via CustomEvent)
     window.addEventListener(EVENT_SKIN_STATE, handleSkinState, {
       passive: true,
+    });
+    window.addEventListener(EVENT_CLASSIC_SELECTION, () => {
+      if (!classicModeActive) return;
+      requestModsForCurrentSkin();
+      if (isOpen && activeTab === "skins") refreshSummaryValues();
     });
 
     // Subscribe to bridge messages instead of window CustomEvents
@@ -2795,13 +2837,11 @@
 
       // Request initial data on every (re)connect
       bridge.onReady(() => {
-        requestMaps();
-        requestFonts();
-        requestAnnouncers();
-        for (const t of OTHER_CATEGORY_TABS) {
-          requestCategoryMods(t.id);
-        }
+        if (classicModeActive) requestGlobalMods();
       });
+
+      const classicState = window.__roseClassicWheelApi?.state?.();
+      if (classicState) handlePhaseChange(classicState);
     }
 
     // Reposition button when skin changes

--- a/Pengu Loader/plugins/ROSE-ClassicRandom/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicRandom/index.js
@@ -132,6 +132,8 @@
       classicMode && (phase === "ChampSelect" || phase === "FINALIZATION");
     if (!isInJadeChampSelect) {
       championLocked = false;
+      active = false;
+      enabled = false;
       removeButton();
       removeMarker();
       return;

--- a/Pengu Loader/plugins/ROSE-ClassicRandom/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicRandom/index.js
@@ -20,6 +20,14 @@
   let isInJadeChampSelect = false;
   let championLocked = false;
 
+  function log(level, message, data = null) {
+    const method = level === "error" ? "error" : level === "warn" ? "warn" : "log";
+    console[method](`[ClassicRandom] ${message}`, data || "");
+    try {
+      bridge?.send({ type: "plugin-log", source: "ClassicRandom", level, message, data, timestamp: Date.now() });
+    } catch (_) {}
+  }
+
   function jadeActive() {
     return window.__roseClassicWheelApi?.state?.().active === true;
   }
@@ -82,6 +90,7 @@
         const previousState = active ? "enabled" : "disabled";
         active = !active;
         enabled = active;
+        log("info", "Random toggle requested", { previousState, nextState: active ? "enabled" : "disabled" });
         render();
         bridge?.send({
           type: "dice-button-click",
@@ -164,6 +173,7 @@
     bridge.subscribe("random-mode-state", (data) => {
       active = data?.active === true;
       enabled = active;
+      log("info", "Random state confirmed", { active });
       render();
     });
     bridge.subscribe("local-asset-url", handleAsset);
@@ -174,6 +184,7 @@
     window.addEventListener("rose-jade-wheel-layout", handleWheelLayout);
     bridge.onReady(requestAssets);
     requestAssets();
+    log("info", "Classic random plugin initialized");
     new MutationObserver(render).observe(document.body, { childList: true, subtree: true });
     setInterval(render, 500);
   }

--- a/Pengu Loader/plugins/ROSE-ClassicRandom/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicRandom/index.js
@@ -6,19 +6,22 @@
   "use strict";
 
   const BUTTON_ID = "rose-jade-random-button";
+  const MARK_ID = "rose-jade-random-mark";
   const STYLE_ID = "rose-jade-random-style";
   const DISABLED_ASSET = "dice-disabled.png";
   const ENABLED_ASSET = "dice-enabled.png";
+  const FLAG_ASSET = "random_flag.png";
   let bridge = null;
   let active = false;
   let enabled = false;
   let disabledUrl = "";
   let enabledUrl = "";
+  let flagUrl = "";
   let isInJadeChampSelect = false;
   let championLocked = false;
 
   function jadeActive() {
-    return window.__roseJadeWheelDebug?.state?.().active === true;
+    return window.__roseClassicWheelApi?.state?.().active === true;
   }
 
   function selectedCard() {
@@ -31,9 +34,35 @@
     document.getElementById(BUTTON_ID)?.remove();
   }
 
+  function removeMarker() {
+    document.getElementById(MARK_ID)?.remove();
+  }
+
+  function renderMarker() {
+    if (!enabled) {
+      removeMarker();
+      return;
+    }
+    const card = selectedCard();
+    if (!card) {
+      removeMarker();
+      return;
+    }
+    let marker = document.getElementById(MARK_ID);
+    if (!marker) {
+      marker = document.createElement("div");
+      marker.id = MARK_ID;
+      marker.title = "Random skin";
+      marker.setAttribute("aria-label", "Random skin");
+    }
+    if (flagUrl) marker.style.backgroundImage = `url("${flagUrl}")`;
+    if (marker.parentElement !== card) card.appendChild(marker);
+  }
+
   function render() {
     if (!isInJadeChampSelect || !championLocked || !jadeActive()) {
       removeButton();
+      removeMarker();
       return;
     }
     const card = selectedCard();
@@ -50,8 +79,9 @@
       button.addEventListener("click", (event) => {
         event.preventDefault();
         event.stopPropagation();
-        const previousState = enabled ? "enabled" : "disabled";
-        enabled = !enabled;
+        const previousState = active ? "enabled" : "disabled";
+        active = !active;
+        enabled = active;
         render();
         bridge?.send({
           type: "dice-button-click",
@@ -66,17 +96,19 @@
     button.classList.toggle("rose-jade-random-button--enabled", enabled);
     button.dataset.active = enabled ? "true" : "false";
     button.setAttribute("aria-pressed", enabled ? "true" : "false");
+    renderMarker();
   }
 
   function handleAsset(data) {
     const url = String(data?.url || "").replace("localhost", "127.0.0.1");
     if (data?.assetPath === DISABLED_ASSET) disabledUrl = url;
     if (data?.assetPath === ENABLED_ASSET) enabledUrl = url;
+    if (data?.assetPath === FLAG_ASSET) flagUrl = url;
     render();
   }
 
   function requestAssets() {
-    for (const assetPath of [DISABLED_ASSET, ENABLED_ASSET]) {
+    for (const assetPath of [DISABLED_ASSET, ENABLED_ASSET, FLAG_ASSET]) {
       bridge?.send({ type: "request-local-asset", assetPath, timestamp: Date.now() });
     }
   }
@@ -84,12 +116,15 @@
   function handlePhaseChange(data) {
     const phase = String(data?.phase || "");
     const classicMode =
-      Number(data?.mapId) === 453 || String(data?.gameMode || "").toUpperCase() === "JADE";
+      Number(data?.mapId) === 453 ||
+      Number(data?.queueId) === 3260 ||
+      String(data?.gameMode || "").toUpperCase() === "JADE";
     isInJadeChampSelect =
       classicMode && (phase === "ChampSelect" || phase === "FINALIZATION");
     if (!isInJadeChampSelect) {
       championLocked = false;
       removeButton();
+      removeMarker();
       return;
     }
     render();
@@ -103,6 +138,7 @@
   function handleWheelLayout(event) {
     if (event?.detail?.active === false) {
       removeButton();
+      removeMarker();
       return;
     }
     render();
@@ -119,16 +155,22 @@
         width: 38px; height: 23px; padding: 0; border: 0; z-index: 25;
         background: transparent center / contain no-repeat; cursor: pointer;
       }
+      #${MARK_ID} {
+        position: absolute; top: -14px; right: -14px; width: 32px; height: 32px;
+        z-index: 24; pointer-events: none; background: center / contain no-repeat;
+      }
     `;
     document.head.appendChild(style);
     bridge.subscribe("random-mode-state", (data) => {
       active = data?.active === true;
-      enabled = active || data?.diceState === "enabled";
+      enabled = active;
       render();
     });
     bridge.subscribe("local-asset-url", handleAsset);
     bridge.subscribe("phase-change", handlePhaseChange);
     bridge.subscribe("champion-locked", handleChampionLocked);
+    const classicState = window.__roseClassicWheelApi?.state?.();
+    if (classicState) handlePhaseChange(classicState);
     window.addEventListener("rose-jade-wheel-layout", handleWheelLayout);
     bridge.onReady(requestAssets);
     requestAssets();

--- a/Pengu Loader/plugins/ROSE-ClassicRandom/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicRandom/index.js
@@ -1,0 +1,140 @@
+/**
+ * @name ROSE-ClassicRandom
+ * @description JADE-only random button, isolated from the regular carousel.
+ */
+(function initJadeRandom() {
+  "use strict";
+
+  const BUTTON_ID = "rose-jade-random-button";
+  const STYLE_ID = "rose-jade-random-style";
+  const DISABLED_ASSET = "dice-disabled.png";
+  const ENABLED_ASSET = "dice-enabled.png";
+  let bridge = null;
+  let active = false;
+  let enabled = false;
+  let disabledUrl = "";
+  let enabledUrl = "";
+  let isInJadeChampSelect = false;
+  let championLocked = false;
+
+  function jadeActive() {
+    return window.__roseJadeWheelDebug?.state?.().active === true;
+  }
+
+  function selectedCard() {
+    return document.querySelector(
+      ".rose-jade-native-card.rose-jade-native-card--selected:not(.skins-pane__skin-card--placeholder)"
+    );
+  }
+
+  function removeButton() {
+    document.getElementById(BUTTON_ID)?.remove();
+  }
+
+  function render() {
+    if (!isInJadeChampSelect || !championLocked || !jadeActive()) {
+      removeButton();
+      return;
+    }
+    const card = selectedCard();
+    if (!card) return;
+    let button = document.getElementById(BUTTON_ID);
+    if (!button) {
+      button = document.createElement("button");
+      button.id = BUTTON_ID;
+      button.className = "lu-random-dice-button rose-jade-random-button";
+      button.type = "button";
+      button.title = "Random skin";
+      button.addEventListener("pointerdown", (event) => event.stopPropagation());
+      button.addEventListener("mousedown", (event) => event.stopPropagation());
+      button.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const previousState = enabled ? "enabled" : "disabled";
+        enabled = !enabled;
+        render();
+        bridge?.send({
+          type: "dice-button-click",
+          state: previousState,
+          timestamp: Date.now(),
+        });
+      });
+    }
+    if (button.parentElement !== card) card.appendChild(button);
+    const image = enabled ? enabledUrl : disabledUrl;
+    button.style.backgroundImage = image ? `url("${image}")` : "none";
+    button.classList.toggle("rose-jade-random-button--enabled", enabled);
+    button.dataset.active = enabled ? "true" : "false";
+    button.setAttribute("aria-pressed", enabled ? "true" : "false");
+  }
+
+  function handleAsset(data) {
+    const url = String(data?.url || "").replace("localhost", "127.0.0.1");
+    if (data?.assetPath === DISABLED_ASSET) disabledUrl = url;
+    if (data?.assetPath === ENABLED_ASSET) enabledUrl = url;
+    render();
+  }
+
+  function requestAssets() {
+    for (const assetPath of [DISABLED_ASSET, ENABLED_ASSET]) {
+      bridge?.send({ type: "request-local-asset", assetPath, timestamp: Date.now() });
+    }
+  }
+
+  function handlePhaseChange(data) {
+    const phase = String(data?.phase || "");
+    const classicMode =
+      Number(data?.mapId) === 453 || String(data?.gameMode || "").toUpperCase() === "JADE";
+    isInJadeChampSelect =
+      classicMode && (phase === "ChampSelect" || phase === "FINALIZATION");
+    if (!isInJadeChampSelect) {
+      championLocked = false;
+      removeButton();
+      return;
+    }
+    render();
+  }
+
+  function handleChampionLocked(data) {
+    championLocked = data?.locked === true;
+    render();
+  }
+
+  function handleWheelLayout(event) {
+    if (event?.detail?.active === false) {
+      removeButton();
+      return;
+    }
+    render();
+  }
+
+  async function start() {
+    while (!window.__roseBridge) await new Promise((resolve) => setTimeout(resolve, 50));
+    bridge = window.__roseBridge;
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = `
+      #${BUTTON_ID} {
+        position: absolute; top: -43px; left: 50%; transform: translateX(-50%);
+        width: 38px; height: 23px; padding: 0; border: 0; z-index: 25;
+        background: transparent center / contain no-repeat; cursor: pointer;
+      }
+    `;
+    document.head.appendChild(style);
+    bridge.subscribe("random-mode-state", (data) => {
+      active = data?.active === true;
+      enabled = active || data?.diceState === "enabled";
+      render();
+    });
+    bridge.subscribe("local-asset-url", handleAsset);
+    bridge.subscribe("phase-change", handlePhaseChange);
+    bridge.subscribe("champion-locked", handleChampionLocked);
+    window.addEventListener("rose-jade-wheel-layout", handleWheelLayout);
+    bridge.onReady(requestAssets);
+    requestAssets();
+    new MutationObserver(render).observe(document.body, { childList: true, subtree: true });
+    setInterval(render, 500);
+  }
+
+  start();
+})();

--- a/Pengu Loader/plugins/ROSE-ClassicSkinSelector/index.js_
+++ b/Pengu Loader/plugins/ROSE-ClassicSkinSelector/index.js_
@@ -1,0 +1,789 @@
+(function createClassicSkinSelector() {
+  const LOG_PREFIX = "[ROSE-ClassicSkinSelector]";
+  const BUTTON_CLASS = "rose-classic-skin-mod-button";
+  const BUTTON_SELECTOR = `.${BUTTON_CLASS}`;
+  const PANEL_CLASS = "rose-classic-skin-mod-panel";
+  const PANEL_ID = "rose-classic-skin-mod-panel-container";
+  const CARD_SELECTOR = ".rose-jade-native-card.rose-jade-native-card--selected:not(.skins-pane__skin-card--placeholder)";
+  const EVENT_CLASSIC_SELECTION = "rose-classic-selection-change";
+  const REQUEST_TYPE = "request-skin-mods";
+  const BUTTON_ICON_ASSET_PATH = "button-skin.png";
+
+  let bridge = null;
+  let championLocked = false;
+  let classicModeActive = false;
+  let initialized = false;
+  let selectedModId = null;
+  let selectedModSkinId = null;
+  let modsForCurrentSkin = [];
+  let currentPhase = null;
+  let panel = null;
+  let panelButtonRef = null;
+  let panelSkinItemRef = null;
+  let customButtonIconUrl = null;
+  let selectionRequestCounter = 0;
+  let pendingSelectionRequest = null;
+  let lastSkinModsRequestKey = null;
+  let lastSkinModsRequestAt = 0;
+  let latestSkinModsRequestId = null;
+
+  function logInfo(message, extra) {
+    console.log(`${LOG_PREFIX} ${message}`, extra ?? "");
+  }
+
+  function applyCustomButtonIcon() {
+    if (!customButtonIconUrl) return;
+
+    document.querySelectorAll(`${BUTTON_SELECTOR} .content`).forEach((content) => {
+      content.style.backgroundImage = `url('${customButtonIconUrl}')`;
+      content.style.backgroundRepeat = "no-repeat";
+      content.style.backgroundPosition = "center";
+      content.style.backgroundSize = "contain";
+    });
+  }
+
+  function handleLocalAssetUrl(data) {
+    const assetPath = String(data?.assetPath || "").trim();
+    if (assetPath !== BUTTON_ICON_ASSET_PATH) return;
+
+    const url = typeof data?.url === "string" ? data.url.replace("localhost", "127.0.0.1") : "";
+    if (!url) return;
+
+    customButtonIconUrl = url;
+    applyCustomButtonIcon();
+  }
+
+  function waitForBridge() {
+    return new Promise((resolve, reject) => {
+      const timeout = 10000;
+      const interval = 50;
+      let elapsed = 0;
+
+      const check = () => {
+        if (window.__roseBridge) {
+          resolve(window.__roseBridge);
+          return;
+        }
+        elapsed += interval;
+        if (elapsed >= timeout) {
+          reject(new Error("Bridge not available"));
+          return;
+        }
+        setTimeout(check, interval);
+      };
+
+      check();
+    });
+  }
+
+  function isCurrentSkinItem(skinItem) {
+    return skinItem?.matches?.(CARD_SELECTOR) === true;
+  }
+
+  function normalizeModId(mod) {
+    return String(mod?.relativePath || mod?.modName || "");
+  }
+
+  function isModAvailableForSkin(mod, skinId = getCurrentSkinContext().skinId) {
+    if (!mod || mod._none) return false;
+    const requestedSkinId = Number(skinId);
+    if (!Number.isFinite(requestedSkinId)) return false;
+    if (mod.availableForRequestedSkin === true) return true;
+
+    const targetSkinIds = Array.isArray(mod.targetSkinIds)
+      ? mod.targetSkinIds.map(Number).filter(Number.isFinite)
+      : [];
+    if (targetSkinIds.includes(requestedSkinId)) return true;
+
+    return mod.availableForRequestedSkin == null && Number(mod.skinId) === requestedSkinId;
+  }
+
+  function isModSelected(mod, skinId = getCurrentSkinContext().skinId) {
+    const requestedSkinId = Number(skinId);
+    const selectedSkinId = Number(selectedModSkinId);
+    const hasSelectionForSkin = Boolean(selectedModId) &&
+      Number.isFinite(requestedSkinId) &&
+      Number.isFinite(selectedSkinId) &&
+      selectedSkinId === requestedSkinId;
+    if (mod?._none) return !hasSelectionForSkin;
+    return Boolean(selectedModId) &&
+      selectedModId === normalizeModId(mod) &&
+      hasSelectionForSkin;
+  }
+
+  function getCurrentSkinContext() {
+    const selection = window.__roseClassicWheelApi?.currentSelection?.();
+    const championId = Number(selection?.championId);
+    const skinId = Number(selection?.skinId);
+
+    return {
+      championId: Number.isFinite(championId) ? championId : null,
+      skinId: Number.isFinite(skinId) ? skinId : null,
+      skinName: String(selection?.selectedEntry?.name || selection?.parentEntry?.name || "Classic skin"),
+    };
+  }
+
+  function resetCustomSkinSessionState() {
+    selectedModId = null;
+    selectedModSkinId = null;
+    pendingSelectionRequest = null;
+    latestSkinModsRequestId = null;
+    modsForCurrentSkin = [];
+  }
+
+  function handlePhaseChange(data) {
+    const phase = String(data?.phase || "");
+    const previousPhase = currentPhase;
+    const wasActive = classicModeActive;
+    currentPhase = phase;
+    const classicContext =
+      Number(data?.mapId) === 453 ||
+      Number(data?.queueId) === 3260 ||
+      String(data?.gameMode || "").toUpperCase() === "JADE";
+    classicModeActive = classicContext && (phase === "ChampSelect" || phase === "FINALIZATION");
+
+    if (classicModeActive && !wasActive) {
+      resetCustomSkinSessionState();
+      requestModsForCurrentSkin();
+    } else if (!classicModeActive && wasActive) {
+      resetCustomSkinSessionState();
+      removeAllButtons();
+      closePanel();
+    }
+    if (previousPhase !== phase) logInfo(`Phase updated: ${phase || "unknown"}`, { classicModeActive });
+    scanSkinSelection();
+  }
+
+  function createSelectionRequestId() {
+    selectionRequestCounter += 1;
+    return `${LOG_PREFIX}-${Date.now()}-${selectionRequestCounter}`;
+  }
+
+  function injectCSS() {
+    const styleId = "rose-classic-skin-selector-style";
+    if (document.getElementById(styleId)) return;
+
+    const styleTag = document.createElement("style");
+    styleTag.id = styleId;
+    styleTag.textContent = getPluginCSS();
+    document.head.appendChild(styleTag);
+  }
+
+  function getPluginCSS() {
+    const btn = BUTTON_CLASS;
+    const pnl = PANEL_CLASS;
+    return `
+.${btn} {
+  pointer-events: auto; -webkit-user-select: none; list-style-type: none; cursor: pointer;
+  display: block !important; bottom: 1px; height: 25px; left: 50%; position: absolute;
+  transform: translateX(-50%) translateY(-205%); width: 25px; z-index: 10; direction: ltr;
+}
+.${btn}[data-hidden], .${btn}[data-hidden] * {
+  pointer-events: none !important; cursor: default !important; visibility: hidden !important;
+}
+.${btn} .outer-mask {
+  pointer-events: auto; cursor: pointer; border-radius: 50%;
+  box-shadow: 0 0 4px 1px rgba(1,10,19,.25); box-sizing: border-box; height: 100%;
+  overflow: hidden; position: relative;
+}
+.${btn} .frame-color {
+  pointer-events: auto; cursor: default;
+  background-image: linear-gradient(0deg,#695625 0,#a9852d 23%,#b88d35 93%,#c8aa6e);
+  box-sizing: border-box; height: 100%; overflow: hidden; width: 100%; padding: 2px;
+}
+.${btn} .content {
+  pointer-events: auto; cursor: pointer; display: block; background-color: #1e2328;
+  background-repeat: no-repeat; background-position: center; background-size: contain;
+  border: 2px solid #010a13; border-radius: 50%; height: 16px; margin: 1px; width: 16px;
+}
+.${btn} .inner-mask {
+  cursor: default; border-radius: 50%; box-sizing: border-box; overflow: hidden;
+  pointer-events: none; position: absolute;
+  box-shadow: inset 0 0 4px 4px rgba(0,0,0,.75);
+  width: calc(100% - 4px); height: calc(100% - 4px); left: 2px; top: 2px;
+}
+.rose-jade-native-card { position: relative; }
+.rose-jade-native-card .${btn} { z-index: 26; }
+.${pnl} { position: fixed; z-index: 10000; pointer-events: all; -webkit-user-select: none; }
+.${pnl}[data-no-button] { pointer-events: none; cursor: default !important; }
+.${pnl}[data-no-button] * { pointer-events: none !important; cursor: default !important; }
+.${pnl} .flyout { position: absolute; overflow: visible; pointer-events: all; -webkit-user-select: none; }
+.${pnl}[data-no-button] .flyout { pointer-events: none !important; cursor: default !important; }
+.${pnl} .flyout-frame { position: relative; transition: 250ms all cubic-bezier(0.02,0.85,0.08,0.99); }
+.${pnl} .flyout .caret, .${pnl} .flyout [class*="caret"],
+.${pnl} lol-uikit-flyout-frame .caret, .${pnl} lol-uikit-flyout-frame [class*="caret"],
+.${pnl} .flyout::part(caret), .${pnl} lol-uikit-flyout-frame::part(caret) {
+  z-index: 3 !important; position: relative;
+}
+.${pnl} .chroma-modal { background: #000; display: flex; flex-direction: column; width: 305px; position: relative; z-index: 0; }
+.${pnl} .chroma-modal.chroma-view { min-height: 355px; max-height: 420px; }
+.${pnl} .border {
+  position: absolute; top: 0; left: 0; box-sizing: border-box; background-color: transparent;
+  box-shadow: 0 0 0 1px rgba(1,10,19,0.48); transition: 250ms all cubic-bezier(0.02,0.85,0.08,0.99);
+  border-top: 2px solid transparent; border-left: 2px solid transparent;
+  border-right: 2px solid transparent; border-bottom: none;
+  border-image: linear-gradient(to top,#785a28 0,#463714 50%,#463714 100%) 1 stretch;
+  border-image-slice: 1 1 0 1; width: 100%; height: 100%; visibility: visible; z-index: 2; pointer-events: none;
+}
+.${pnl} .lc-flyout-content { position: relative; }
+.${pnl} .chroma-information {
+  background-image: url('lol-game-data/assets/content/src/LeagueClient/GameModeAssets/Classic_SRU/img/champ-select-flyout-background.jpg');
+  background-size: cover; border-bottom: thin solid #463714; flex-grow: 1; height: 315px;
+  position: relative; width: 100%; z-index: 1;
+}
+.${pnl} .chroma-information-image {
+  bottom: 0; left: 0; position: absolute; right: 0; top: 0;
+  background-size: contain; background-position: center; background-repeat: no-repeat;
+}
+.${pnl} .child-skin-name {
+  bottom: 10px; color: #f7f0de;
+  font-family: "LoL Display","Times New Roman",Times,Baskerville,Georgia,serif;
+  font-size: 24px; font-weight: 700; position: absolute; text-align: center; width: 100%;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.${pnl} .chroma-selection {
+  pointer-events: all; height: 100%; overflow: auto; transform: translateZ(0);
+  -webkit-mask-box-image-source: url("/fe/lol-static-assets/images/uikit/scrollable/scrollable-content-gradient-mask-bottom.png");
+  -webkit-mask-box-image-slice: 0 8 18 0 fill;
+  align-items: center; display: flex; flex-direction: row; flex-grow: 0; flex-wrap: wrap;
+  justify-content: center; max-height: 92px; min-height: 40px; padding: 7px 0;
+  width: 100%; position: relative; z-index: 1;
+}
+.${pnl}[data-no-button] .chroma-selection { pointer-events: none; cursor: default; }
+.${pnl} .chroma-selection ul { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; justify-content: center; }
+.${pnl} .chroma-selection li { list-style: none; margin: 2px 4px; padding: 0; display: flex; align-items: center; justify-content: center; }
+.${pnl} .chroma-skin-button {
+  pointer-events: all; align-items: center; border-radius: 50%; box-shadow: 0 0 2px #010a13;
+  border: none; display: flex; height: 26px; width: 26px; min-width: 26px; min-height: 26px;
+  max-width: 26px; max-height: 26px; aspect-ratio: 1/1; justify-content: center; margin: 0;
+  padding: 0; cursor: pointer; box-sizing: border-box; background: transparent !important;
+  background-color: transparent !important; flex: 0 0 26px; transform: scale(1);
+}
+.${pnl}[data-no-button] .chroma-skin-button { pointer-events: none !important; cursor: default !important; }
+.${pnl} .chroma-skin-button:not(.locked) { cursor: pointer; opacity: 1 !important; }
+.${pnl} .chroma-skin-button.locked { opacity: 1 !important; cursor: pointer; }
+.${pnl} .chroma-skin-button .contents {
+  pointer-events: all; align-items: center; border: 2px solid #010a13; border-radius: 50%;
+  display: flex; height: 18px; width: 18px; min-width: 18px; min-height: 18px;
+  max-width: 18px; max-height: 18px; aspect-ratio: 1/1; justify-content: center;
+  background: linear-gradient(135deg,#27211C 0,#27211C 50%,#27211C 50%,#27211C 100%);
+  box-shadow: 0 0 0 2px transparent; background-size: cover; background-position: center;
+  background-repeat: no-repeat; background-color: #1e2328; transform: scale(1);
+}
+.${pnl} .chroma-skin-button.selected .contents, .${pnl} .chroma-skin-button:hover .contents {
+  box-shadow: 0 0 0 2px #c89b3c; transform: scale(1);
+}
+.${pnl} .chroma-skin-button.locked:hover:not([purchase-disabled]) { opacity: 1 !important; }
+.${pnl} .chroma-skin-button.locked.purchase-disabled { opacity: 1 !important; pointer-events: none; }
+`;
+  }
+
+  function hasOtherPluginButtons(skinItem) {
+    return skinItem.querySelector(':scope > .lu-chroma-button, :scope > [class*="chroma-button"]') !== null;
+  }
+
+  function createFakeButton() {
+    const button = document.createElement("button");
+    button.className = BUTTON_CLASS;
+    button.type = "button";
+    button.title = "Select skin Mod";
+    button.setAttribute("aria-label", "Select skin Mod");
+
+    const outerMask = document.createElement("div");
+    outerMask.className = "outer-mask interactive";
+
+    const frameColor = document.createElement("div");
+    frameColor.className = "frame-color";
+
+    const content = document.createElement("div");
+    content.className = "content";
+
+    const innerMask = document.createElement("div");
+    innerMask.className = "inner-mask inner-shadow";
+
+    frameColor.appendChild(content);
+    frameColor.appendChild(innerMask);
+    outerMask.appendChild(frameColor);
+    button.appendChild(outerMask);
+
+    if (customButtonIconUrl) {
+      content.style.backgroundImage = `url('${customButtonIconUrl}')`;
+      content.style.backgroundRepeat = "no-repeat";
+      content.style.backgroundPosition = "center";
+      content.style.backgroundSize = "contain";
+    }
+
+    button.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const skinItem = button.closest(CARD_SELECTOR);
+      if (!skinItem) return;
+      if (!modsForCurrentSkin.length) return;
+
+      togglePanel(button, skinItem);
+    });
+
+    button.addEventListener("mousedown", (event) => {
+      event.stopPropagation();
+    });
+
+    return button;
+  }
+
+  function updateButtonVisibility(button, shouldShow) {
+    if (!button) return;
+
+    if (shouldShow) {
+      button.style.display = "block";
+      button.style.visibility = "visible";
+      button.style.pointerEvents = "auto";
+      button.style.opacity = "1";
+      button.style.cursor = "pointer";
+      button.removeAttribute("data-hidden");
+    } else {
+      button.style.display = "none";
+      button.style.visibility = "hidden";
+      button.style.pointerEvents = "none";
+      button.style.opacity = "0";
+      button.style.cursor = "default";
+      button.setAttribute("data-hidden", "true");
+      if (panel && panel.parentNode && panelButtonRef === button) {
+        closePanel();
+      }
+    }
+  }
+
+  function removeAllButtons() {
+    document.querySelectorAll(BUTTON_SELECTOR).forEach((node) => node.remove());
+  }
+
+  function sendDeselect(expectedModId = selectedModId) {
+    const { championId, skinId } = getCurrentSkinContext();
+    if (!bridge || !championId || !skinId) return;
+
+    const requestId = createSelectionRequestId();
+    pendingSelectionRequest = { requestId, operation: "deselect" };
+    bridge.send({
+      type: "select-skin-mod",
+      championId,
+      skinId,
+      modId: null,
+      expectedModId,
+      requestId,
+    });
+  }
+
+  function sendSelect(modId, modData) {
+    const { championId, skinId } = getCurrentSkinContext();
+    if (!bridge || !championId || !skinId) return;
+
+    const requestId = createSelectionRequestId();
+    pendingSelectionRequest = { requestId, operation: "select", modId };
+    bridge.send({ type: "select-skin-mod", championId, skinId, modId, modData, requestId });
+  }
+
+  function requestModsForCurrentSkin() {
+    if (!bridge) return;
+    const { championId, skinId } = getCurrentSkinContext();
+
+    if (!classicModeActive || !championLocked || !championId || !skinId) {
+      modsForCurrentSkin = [];
+      scanSkinSelection();
+      return;
+    }
+
+    const requestKey = `${championId}:${skinId}`;
+    const now = Date.now();
+    if (
+      requestKey === lastSkinModsRequestKey &&
+      now - lastSkinModsRequestAt < 750
+    ) {
+      return;
+    }
+    lastSkinModsRequestKey = requestKey;
+    lastSkinModsRequestAt = now;
+    latestSkinModsRequestId = createSelectionRequestId();
+    bridge.send({ type: REQUEST_TYPE, championId, skinId, requestId: latestSkinModsRequestId });
+  }
+
+  function createPanelForMods(mods, buttonElement) {
+    if (!buttonElement || !mods.length) return null;
+
+    const existing = document.getElementById(PANEL_ID);
+    if (existing) existing.remove();
+
+    const root = document.createElement("div");
+    root.id = PANEL_ID;
+    root.className = PANEL_CLASS;
+    root.style.position = "fixed";
+    root.style.top = "0";
+    root.style.left = "0";
+    root.style.width = "100%";
+    root.style.height = "100%";
+    root.style.pointerEvents = "none";
+
+    let flyout;
+    try {
+      flyout = document.createElement("lol-uikit-flyout-frame");
+      flyout.className = "flyout";
+      flyout.setAttribute("orientation", "top");
+      flyout.setAttribute("animated", "false");
+      flyout.setAttribute("caretoffset", "undefined");
+      flyout.setAttribute("borderless", "undefined");
+      flyout.setAttribute("caretless", "undefined");
+      flyout.setAttribute("show", "true");
+    } catch {
+      flyout = document.createElement("div");
+      flyout.className = "flyout";
+    }
+    flyout.style.position = "absolute";
+    flyout.style.overflow = "visible";
+    flyout.style.pointerEvents = "all";
+
+    let flyoutContent;
+    try {
+      flyoutContent = document.createElement("lc-flyout-content");
+    } catch {
+      flyoutContent = document.createElement("div");
+      flyoutContent.className = "lc-flyout-content";
+    }
+
+    const modal = document.createElement("div");
+    modal.className = "champ-select-chroma-modal chroma-view ember-view";
+
+    const border = document.createElement("div");
+    border.className = "border";
+
+    const chromaInfo = document.createElement("div");
+    chromaInfo.className = "chroma-information";
+
+    const preview = document.createElement("div");
+    preview.className = "chroma-information-image";
+
+    const skinName = document.createElement("div");
+    skinName.className = "child-skin-name";
+    skinName.textContent = getCurrentSkinContext().skinName;
+
+    chromaInfo.appendChild(preview);
+    chromaInfo.appendChild(skinName);
+
+    const scrollable = document.createElement("div");
+    scrollable.className = "chroma-selection";
+
+    const list = document.createElement("ul");
+
+    const setPreviewImage = (url, label) => {
+      preview.style.display = "block";
+      preview.style.backgroundImage = url ? `url('${url}')` : "";
+      skinName.textContent = label || getCurrentSkinContext().skinName;
+    };
+
+    const noneEntry = {
+      id: "__none__", modName: "Base Skin", thumbnailUrl: "",
+      description: "Disable custom skin mod", _none: true,
+    };
+
+    const visibleMods = [noneEntry, ...mods];
+
+    visibleMods.forEach((mod, index) => {
+      const modId = mod._none ? "__none__" : normalizeModId(mod);
+      const isSelected = isModSelected(mod, getCurrentSkinContext().skinId);
+
+      const item = document.createElement("li");
+      const emberView = document.createElement("div");
+      emberView.className = "ember-view";
+
+      const wheelButton = document.createElement("div");
+      wheelButton.className = `chroma-skin-button ${isSelected ? "selected" : ""}`;
+      wheelButton.title = mod.modName || `Custom Skin ${index + 1}`;
+      wheelButton.setAttribute("role", "button");
+      wheelButton.tabIndex = 0;
+
+      const contents = document.createElement("div");
+      contents.className = "contents";
+
+      const thumbnailUrl = mod.thumbnailUrl ? String(mod.thumbnailUrl).replace("localhost", "127.0.0.1") : "";
+      if (thumbnailUrl) {
+        contents.style.backgroundImage = `url('${thumbnailUrl}')`;
+      } else if (mod._none) {
+        contents.style.background = "linear-gradient(135deg,#f0e6d2,#f0e6d2 48%,#be1e37 0,#be1e37 52%,#f0e6d2 0,#f0e6d2)";
+      }
+
+      const applySelection = () => {
+        if (mod._none) {
+          if (selectedModId) sendDeselect(selectedModId);
+          closePanel();
+          return;
+        }
+        if (isModSelected(mod, getCurrentSkinContext().skinId)) {
+          sendDeselect(selectedModId);
+        } else {
+          sendSelect(modId, mod);
+        }
+        closePanel();
+      };
+
+      wheelButton.addEventListener("mouseenter", () => {
+        setPreviewImage(thumbnailUrl || "", mod._none ? getCurrentSkinContext().skinName : (mod.modName || getCurrentSkinContext().skinName));
+      });
+
+      wheelButton.addEventListener("mouseleave", () => {
+        const active = visibleMods.find(e => isModSelected(e, getCurrentSkinContext().skinId));
+        const au = active && active.thumbnailUrl ? String(active.thumbnailUrl).replace("localhost", "127.0.0.1") : "";
+        const al = active && !active._none ? (active.modName || getCurrentSkinContext().skinName) : getCurrentSkinContext().skinName;
+        setPreviewImage(au, al);
+      });
+
+      wheelButton.addEventListener("click", (event) => { event.preventDefault(); event.stopPropagation(); applySelection(); });
+      wheelButton.addEventListener("keydown", (event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        event.stopPropagation();
+        applySelection();
+      });
+      contents.addEventListener("click", (event) => { event.preventDefault(); event.stopPropagation(); applySelection(); });
+
+      wheelButton.appendChild(contents);
+      emberView.appendChild(wheelButton);
+      item.appendChild(emberView);
+      list.appendChild(item);
+    });
+
+    const active = visibleMods.find(e => isModSelected(e, getCurrentSkinContext().skinId));
+    const au = active && active.thumbnailUrl ? String(active.thumbnailUrl).replace("localhost", "127.0.0.1") : "";
+    const al = active && !active._none ? (active.modName || getCurrentSkinContext().skinName) : getCurrentSkinContext().skinName;
+    setPreviewImage(au, al);
+
+    scrollable.appendChild(list);
+    modal.appendChild(border);
+    modal.appendChild(chromaInfo);
+    modal.appendChild(scrollable);
+    flyoutContent.appendChild(modal);
+    flyout.appendChild(flyoutContent);
+    root.appendChild(flyout);
+
+    return root;
+  }
+
+  function positionPanel(panelElement, buttonElement) {
+    if (!panelElement || !buttonElement) return;
+    const flyout = panelElement.querySelector(".flyout");
+    if (!flyout) return;
+
+    const rect = buttonElement.getBoundingClientRect();
+    let fr = flyout.getBoundingClientRect();
+    if (!fr.width) fr = { width: 305, height: 420 };
+
+    const cx = rect.left + rect.width / 2;
+    flyout.style.left = `${Math.max(10, Math.min(cx - fr.width / 2, window.innerWidth - fr.width - 10))}px`;
+    flyout.style.top = `${Math.max(10, rect.top - fr.height - 14)}px`;
+  }
+
+  function closePanel() {
+    const existing = document.getElementById(PANEL_ID);
+    if (existing) existing.remove();
+    panel = null; panelButtonRef = null; panelSkinItemRef = null;
+  }
+
+  function togglePanel(buttonElement, skinItem) {
+    if (document.getElementById(PANEL_ID) && panelButtonRef === buttonElement) { closePanel(); return; }
+    closePanel();
+    if (!modsForCurrentSkin.length) return;
+
+    const built = createPanelForMods(modsForCurrentSkin, buttonElement);
+    if (!built) return;
+
+    panel = built; panelButtonRef = buttonElement; panelSkinItemRef = skinItem;
+    document.body.appendChild(panel);
+    positionPanel(panel, buttonElement);
+
+    setTimeout(() => {
+      document.addEventListener("click", function ch(e) {
+        if (!panel || !panel.parentNode) { document.removeEventListener("click", ch); return; }
+        if (panel.contains(e.target) || buttonElement.contains(e.target)) return;
+        closePanel(); document.removeEventListener("click", ch);
+      });
+    }, 100);
+  }
+
+  function ensureButtonOnItem(skinItem) {
+    if (!skinItem) return;
+
+    const isCurrent = isCurrentSkinItem(skinItem);
+    let existingButton = skinItem.querySelector(BUTTON_SELECTOR);
+
+    if (!classicModeActive || !championLocked || !isCurrent) {
+      if (existingButton) existingButton.remove();
+      return;
+    }
+
+    if (!existingButton) {
+      existingButton = createFakeButton();
+      if (hasOtherPluginButtons(skinItem)) {
+        existingButton.style.transform = "translateX(-50%) translateY(-260%)";
+      }
+      skinItem.appendChild(existingButton);
+    }
+
+    updateButtonVisibility(existingButton, modsForCurrentSkin.length > 0);
+  }
+
+  function scanSkinSelection() {
+    const skinItems = document.querySelectorAll(CARD_SELECTOR);
+    if (!skinItems.length) { removeAllButtons(); closePanel(); return; }
+    skinItems.forEach(s => ensureButtonOnItem(s));
+    if (!(panelSkinItemRef && panelSkinItemRef.isConnected && panelSkinItemRef.querySelector(BUTTON_SELECTOR) && modsForCurrentSkin.length > 0)) closePanel();
+  }
+
+  function handleSelectionResult(data) {
+    const detail = data?.detail || data;
+    if (!detail || detail.type !== "custom-mod-selection-result") return;
+
+    if (pendingSelectionRequest && detail.requestId && detail.requestId !== pendingSelectionRequest.requestId) {
+      return;
+    }
+
+    const pending = pendingSelectionRequest;
+    pendingSelectionRequest = null;
+
+    if (!detail.success) {
+      console.warn(`${LOG_PREFIX} Custom skin selection failed: ${detail.error || "unknown error"}`);
+      scanSkinSelection();
+      return;
+    }
+
+    if (detail.operation === "deselect") {
+      selectedModId = null;
+      selectedModSkinId = null;
+    } else if (detail.operation === "select") {
+      selectedModId = String(detail.relativePath || detail.modId || pending?.modId || "");
+      selectedModSkinId = Number(detail.skinId || getCurrentSkinContext().skinId);
+    }
+
+    scanSkinSelection();
+  }
+
+  function handleModsResponse(data) {
+    const detail = data?.detail || data;
+    if (!detail || detail.type !== "skin-mods-response") return;
+    if (detail.requestId && String(detail.requestId) !== String(latestSkinModsRequestId)) return;
+
+    const { skinId, championId } = getCurrentSkinContext();
+    if (!skinId || !championId) { modsForCurrentSkin = []; scanSkinSelection(); return; }
+
+    const rc = Number(detail.championId);
+    if (rc && rc !== championId) return;
+
+    const responseSkinId = Number(detail.skinId);
+    if (!responseSkinId || responseSkinId !== skinId) return;
+
+    modsForCurrentSkin = (Array.isArray(detail.mods) ? detail.mods : []).filter((mod) => (
+      isModAvailableForSkin(mod, skinId)
+    ));
+
+    if (selectedModId && !pendingSelectionRequest) {
+      const selectedEntry = modsForCurrentSkin.find((mod) => (
+        String(mod?.relativePath || mod?.modName || "") === String(selectedModId)
+      ));
+      if (!selectedEntry) {
+        sendDeselect(selectedModId);
+      }
+    }
+
+    if (!selectedModId && !pendingSelectionRequest && detail.historicMod) {
+      const match = modsForCurrentSkin.find(m => String(m?.relativePath || "").replace(/\\/g, "/") === String(detail.historicMod).replace(/\\/g, "/"));
+      if (match) { sendSelect(normalizeModId(match), match); }
+    }
+
+    scanSkinSelection();
+    if (panel && panel.parentNode && panelButtonRef) closePanel();
+  }
+
+  function handleClassicSelection() {
+    requestModsForCurrentSkin();
+    scanSkinSelection();
+    if (panel && panel.parentNode && panelButtonRef) positionPanel(panel, panelButtonRef);
+  }
+
+  function observeSkinSelection() {
+    const observer = new MutationObserver(() => scanSkinSelection());
+    observer.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ["class", "aria-selected"] });
+    setInterval(scanSkinSelection, 500);
+  }
+
+  async function init() {
+    if (initialized) return;
+    initialized = true;
+
+    injectCSS();
+
+    try { bridge = await waitForBridge(); logInfo("Bridge connected"); }
+    catch (error) { console.error(`${LOG_PREFIX} Bridge connection failed`, error); }
+
+    if (bridge) {
+      bridge.subscribe("skin-mods-response", (data) => handleModsResponse({ detail: data }));
+      bridge.subscribe("custom-mod-selection-result", (data) => handleSelectionResult({ detail: data }));
+      bridge.subscribe("phase-change", handlePhaseChange);
+      bridge.subscribe("local-asset-url", (data) => handleLocalAssetUrl(data));
+      bridge.subscribe("champion-locked", (data) => {
+        championLocked = Boolean(data?.locked);
+        if (!championLocked) {
+          modsForCurrentSkin = [];
+          selectedModId = null;
+          selectedModSkinId = null;
+          pendingSelectionRequest = null;
+          closePanel();
+        }
+        else { requestModsForCurrentSkin(); }
+        scanSkinSelection();
+      });
+      bridge.subscribe("custom-mod-state", (data) => {
+        if (!data) return;
+        if (data.active === false) {
+          selectedModId = null;
+          selectedModSkinId = null;
+        } else if (data.relativePath || data.modName) {
+          selectedModId = String(data.relativePath || data.modName);
+          const currentSkinId = Number(getCurrentSkinContext().skinId);
+          const targetSkinIds = Array.isArray(data.targetSkinIds)
+            ? data.targetSkinIds.map(Number).filter(Number.isFinite)
+            : [];
+          selectedModSkinId = targetSkinIds.includes(currentSkinId)
+            ? currentSkinId
+            : Number(data.skinId) || currentSkinId;
+        }
+        scanSkinSelection();
+      });
+      bridge.onReady(() => {
+        bridge.send({ type: "request-local-asset", assetPath: BUTTON_ICON_ASSET_PATH, timestamp: Date.now() });
+        if (classicModeActive) requestModsForCurrentSkin();
+      });
+      bridge.send({ type: "request-local-asset", assetPath: BUTTON_ICON_ASSET_PATH, timestamp: Date.now() });
+      const classicState = window.__roseClassicWheelApi?.state?.();
+      if (classicState) handlePhaseChange(classicState);
+    }
+
+    window.addEventListener(EVENT_CLASSIC_SELECTION, handleClassicSelection, { passive: true });
+    window.addEventListener("rose-jade-wheel-layout", (event) => {
+      if (event?.detail?.active === false) {
+        removeAllButtons();
+        closePanel();
+        return;
+      }
+      scanSkinSelection();
+    });
+    window.addEventListener("resize", () => { if (panel && panel.parentNode && panelButtonRef) positionPanel(panel, panelButtonRef); });
+    window.addEventListener("scroll", () => { if (panel && panel.parentNode && panelButtonRef) positionPanel(panel, panelButtonRef); });
+
+    observeSkinSelection();
+    if (classicModeActive) requestModsForCurrentSkin();
+    scanSkinSelection();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+  } else {
+    init();
+  }
+})();

--- a/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
@@ -866,7 +866,8 @@
   }
 
   function randomProjectionReady() {
-    return phase === "FINALIZATION" || phase === "GameStart";
+    return phase === "FINALIZATION" || phase === "GameStart" ||
+      document.querySelector(".champion-select.timer-less-than-11-seconds") !== null;
   }
 
   function applyPendingRandomVisualSelection() {
@@ -889,7 +890,7 @@
     }
     if (!projectResourceSelection(pendingRandomResourceSkinId, "random-state")) return;
     appliedRandomResourceSkinId = pendingRandomResourceSkinId;
-    log("info", "Classic random result projected during finalization", {
+    log("info", "Classic random result projected during finalization window", {
       rawSkinId: selection.rawSkinId,
       resourceSkinId: resourceSkinId(selection.rawSkinId),
     });

--- a/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
@@ -227,7 +227,10 @@
     const defaults = new Set(
       (protection.defaultLcuSkinIds || []).map(numeric).filter(Number.isFinite)
     );
-    return selected !== null && desired !== null && selected !== desired && defaults.has(selected);
+    const automaticProjectionSettled =
+      nativeProjectionTargetIndex < 0 && !pendingUserNavigation;
+    return selected !== null && desired !== null && selected !== desired &&
+      (defaults.has(selected) || automaticProjectionSettled);
   }
 
   function cloneWebsocketEvent(event, payload) {

--- a/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
@@ -12,14 +12,6 @@
   const JADE_CHAMPION_OFFSET = 60000;
   const JADE_CHAMPION_MIN = 60001;
   const JADE_CHAMPION_MAX = 60999;
-  const JADE_FALLBACK_DEFAULT_SKIN_NUMBER = 301;
-  const JADE_DEFAULT_CARRIER_OVERRIDES = new Map([
-    ...[
-      2, 15, 21, 22, 23, 26, 27, 31, 32, 33, 34, 35, 37, 40,
-      42, 45, 53, 54, 59, 62, 63, 67, 79, 89, 90, 96, 99, 117,
-    ].map((champion) => [champion, 0]),
-    [10, 302],
-  ]);
   const ROOT_ID = "rose-jade-skin-wheel";
   const STYLE_ID = "rose-jade-skin-wheel-styles";
   const HOST_CLASS = "rose-jade-native-host";
@@ -79,14 +71,11 @@
   let pendingRandomResourceSkinId = 0;
   let appliedRandomResourceSkinId = 0;
   let randomProjectionSuppressed = false;
-  let visualCarrierProtectionActive = false;
+  let visualRollbackProtectionActive = false;
   let projectedVariantRawSkinId = 0;
   let lastVisualCenterRawSkinId = 0;
   let lastLayoutKey = "";
   let lastVisualProtectionKey = "";
-  let lastReadRewriteKey = "";
-  let refreshNativeSkinPresentation = null;
-  let latestNativeSkinSelectorEvent = null;
   let lastCatalogSyncKey = "";
   let visualProtectionClearTimer = null;
 
@@ -160,31 +149,22 @@
     return (JADE_CHAMPION_OFFSET + resourceChampion) * 1000 + (id % 1000);
   }
 
-  function fallbackModeDefaultRawSkinId() {
-    if (!isJadeChampionId(rawChampionId)) return 0;
-    const skinNumber = JADE_DEFAULT_CARRIER_OVERRIDES.get(championId)
-      ?? JADE_FALLBACK_DEFAULT_SKIN_NUMBER;
-    return rawChampionId * 1000 + skinNumber;
-  }
-
   function isModeDefaultRawSkinId(value) {
     const id = numeric(value) || 0;
-    const expected = modeDefaultRawSkinId || fallbackModeDefaultRawSkinId();
+    const expected = modeDefaultRawSkinId;
     return id > 0 && expected > 0 && id === expected;
   }
 
   function isModeDefaultResourceSkinId(value) {
     const id = resourceSkinId(value);
-    const expected = resourceSkinId(
-      modeDefaultRawSkinId || fallbackModeDefaultRawSkinId()
-    );
+    const expected = resourceSkinId(modeDefaultRawSkinId);
     return id > 0 && expected > 0 && id === expected;
   }
 
   async function fetchJson(endpoint) {
     // Always read the real LCU state here. The native JADE controller receives
     // a visual-only projection below, while Python and this adapter must keep
-    // observing the official carrier selected in the client.
+    // observing the official default selected in the client.
     const response = await nativeFetch(endpoint, { credentials: "include" });
     if (!response || !response.ok) {
       throw new Error(`HTTP ${response ? response.status : "NO_RESPONSE"} for ${endpoint}`);
@@ -206,64 +186,15 @@
     return String(init?.method || input?.method || "GET").toUpperCase();
   }
 
-  function rewriteSessionSelection(data, desiredRawSkinId) {
-    if (!data || typeof data !== "object") return false;
-    const localCellId = numeric(data.localPlayerCellId);
-    if (localCellId === null || !Array.isArray(data.myTeam)) return false;
-    const localPlayer = data.myTeam.find(
-      (player) => numeric(player?.cellId) === localCellId
-    );
-    if (!localPlayer || numeric(localPlayer.selectedSkinId) === desiredRawSkinId) {
-      return false;
-    }
-    localPlayer.selectedSkinId = desiredRawSkinId;
-    return true;
-  }
-
-  function rewriteNativeRead(path, data) {
-    const desired = desiredVisualSelection;
-    if (
-      !active ||
-      !desired ||
-      (!visualCarrierProtectionActive && (desired.available || desired.isBase))
-    ) return false;
-    const desiredRawSkinId = desired.rawSkinId;
-
-    if (path === "/lol-champ-select/v1/skin-selector-info") {
-      if (!data || typeof data !== "object") return false;
-      if (numeric(data.selectedSkinId) === desiredRawSkinId) return false;
-      data.selectedSkinId = desiredRawSkinId;
-      return true;
-    }
-    if (path === "/lol-champ-select/v1/session") {
-      return rewriteSessionSelection(data, desiredRawSkinId);
-    }
-    return false;
-  }
-
   function shouldSuppressVisualRollback(selectedSkinId) {
     const protection = window.__roseJadeVisualProtection;
     if (!active || !protection?.active) return false;
     const selected = numeric(selectedSkinId);
     const desired = numeric(protection.desiredRawSkinId);
-    const carriers = new Set(
-      (protection.carrierRawSkinIds || []).map(numeric).filter(Number.isFinite)
+    const defaults = new Set(
+      (protection.defaultLcuSkinIds || []).map(numeric).filter(Number.isFinite)
     );
-    return selected !== null && desired !== null && selected !== desired && carriers.has(selected);
-  }
-
-  function cloneWebsocketEvent(event, payload) {
-    try {
-      return new MessageEvent(event.type || "message", {
-        data: JSON.stringify(payload),
-        origin: event.origin,
-        lastEventId: event.lastEventId,
-        source: event.source,
-        ports: event.ports,
-      });
-    } catch (_) {
-      return { data: JSON.stringify(payload) };
-    }
+    return selected !== null && desired !== null && selected !== desired && defaults.has(selected);
   }
 
   function installNativeWebsocketProjection() {
@@ -274,49 +205,6 @@
         const ws = api.champSelectBinding.socket._websocket;
         if (!ws || ws.__roseJadeReadProjection) return;
         const parentOnMessage = ws.onmessage;
-        refreshNativeSkinPresentation = async (desiredRawSkinId) => {
-          if (!active || !desiredRawSkinId) return;
-          let sourceEvent = latestNativeSkinSelectorEvent?.event || null;
-          let sourcePayload = latestNativeSkinSelectorEvent?.payload || null;
-          if (!sourcePayload) {
-            try {
-              const response = await nativeFetch(
-                "/lol-champ-select/v1/skin-selector-info",
-                { credentials: "include" }
-              );
-              if (!response?.ok) return;
-              sourcePayload = [8, "OnJsonApiEvent", {
-                data: await response.json(),
-                eventType: "Update",
-                uri: "/lol-champ-select/v1/skin-selector-info",
-              }];
-              sourceEvent = new MessageEvent("message", {
-                data: JSON.stringify(sourcePayload),
-              });
-              latestNativeSkinSelectorEvent = {
-                event: sourceEvent,
-                payload: sourcePayload,
-              };
-            } catch (error) {
-              log("warn", "Classic selector presentation refresh failed", String(error));
-              return;
-            }
-          }
-          if (!active) return;
-          const payload = JSON.parse(JSON.stringify(sourcePayload));
-          const selectedChampionId = numeric(payload[2]?.data?.selectedChampionId);
-          if (selectedChampionId && selectedChampionId !== Math.floor(desiredRawSkinId / 1000)) {
-            return;
-          }
-          payload[2].data.selectedSkinId = desiredRawSkinId;
-          parentOnMessage.call(
-            ws,
-            cloneWebsocketEvent(sourceEvent, payload)
-          );
-          log("info", "Refreshed native classic skin presentation", {
-            selectedSkinId: desiredRawSkinId,
-          });
-        };
         ws.onmessage = function roseJadeProjectedMessage(event) {
           try {
             const payload = JSON.parse(event.data);
@@ -326,24 +214,14 @@
             const eventData = payload[2];
             if (eventData?.uri === "/lol-champ-select/v1/skin-selector-info") {
               const selectedSkinId = eventData.data?.selectedSkinId;
-              latestNativeSkinSelectorEvent = { event, payload };
               if (shouldSuppressVisualRollback(selectedSkinId)) {
-                eventData.data.selectedSkinId = numeric(
-                  window.__roseJadeVisualProtection?.desiredRawSkinId
-                );
-                log("info", "Projected classic selector rollback", {
+                // ROSE-UI keeps an unowned regular skin visible by withholding
+                // the base-skin rollback event. JADE uses the same contract.
+                log("info", "Suppressed classic selector rollback", {
                   selectedSkinId,
-                  projectedSkinId: eventData.data.selectedSkinId,
+                  desiredSkinId: window.__roseJadeVisualProtection?.desiredRawSkinId,
                 });
-                return parentOnMessage.call(this, cloneWebsocketEvent(event, payload));
-              }
-            } else if (eventData?.uri === "/lol-champ-select/v1/session") {
-              const protection = window.__roseJadeVisualProtection;
-              if (
-                protection?.active &&
-                rewriteSessionSelection(eventData.data, numeric(protection.desiredRawSkinId))
-              ) {
-                return parentOnMessage.call(this, cloneWebsocketEvent(event, payload));
+                return;
               }
             }
           } catch (error) {
@@ -384,43 +262,7 @@
           // Let malformed or unrelated requests follow the native path.
         }
       }
-      const response = await nativeFetch(input, init);
-      if (
-        method !== "GET" ||
-        !response?.ok ||
-        (path !== "/lol-champ-select/v1/skin-selector-info" &&
-          path !== "/lol-champ-select/v1/session")
-      ) {
-        return response;
-      }
-
-      try {
-        const data = await response.clone().json();
-        if (!rewriteNativeRead(path, data)) return response;
-
-        const rewriteKey = `${path}|${desiredVisualSelection?.rawSkinId || 0}`;
-        if (rewriteKey !== lastReadRewriteKey) {
-          lastReadRewriteKey = rewriteKey;
-          log("info", "Projected classic visual selection into native read", {
-            path,
-            desiredRawSkinId: desiredVisualSelection?.rawSkinId || 0,
-          });
-        }
-        const headers = new Headers(response.headers);
-        headers.delete("content-length");
-        headers.delete("content-encoding");
-        return new Response(JSON.stringify(data), {
-          status: response.status,
-          statusText: response.statusText,
-          headers,
-        });
-      } catch (error) {
-        log("warn", "Classic native read projection failed", {
-          path,
-          error: String(error),
-        });
-        return response;
-      }
+      return nativeFetch(input, init);
     };
     projectedFetch.__roseJadeReadProjection = true;
     window.fetch = projectedFetch;
@@ -429,9 +271,6 @@
   function syncVisualSelection(entry, reason, userInitiated = false) {
     if (!bridge || !entry?.name || !entry.resourceSkinId) return;
     if (userInitiated) selectionGeneration += 1;
-    if (userInitiated && visualCarrierProtectionActive) {
-      refreshNativeSkinPresentation?.(entry.rawSkinId);
-    }
     try {
       // Python validates this ID against the active JADE carousel before it
       // updates the same injection state used by regular champion select.
@@ -439,19 +278,13 @@
         type: "classic-skin-selection",
         schemaVersion: 1,
         mode: JADE_MODE,
-        primeChampionId: entry.championId,
-        modeChampionId: entry.rawChampionId,
-        carrierLcuSkinId: modeDefaultRawSkinId || fallbackModeDefaultRawSkinId(),
-        carrierSkinNumber: (modeDefaultRawSkinId || fallbackModeDefaultRawSkinId()) % 1000,
-        visualSkinId: entry.resourceSkinId,
+        championId: entry.championId,
+        defaultSkinId: resourceSkinId(modeDefaultRawSkinId),
         skin: entry.name,
         originalName: entry.name,
         skinId: entry.resourceSkinId,
-        rawSkinId: entry.rawSkinId,
-        rawChampionId: entry.rawChampionId,
-        baseRawSkinId: modeDefaultRawSkinId || fallbackModeDefaultRawSkinId(),
         catalog: catalogBridgeEntries(),
-        randomEligibleRawSkinIds: catalog.map((item) => item.rawSkinId),
+        randomEligibleSkinIds: catalog.map((item) => item.resourceSkinId),
         source: "jade-wheel",
         reason,
         userInitiated,
@@ -482,8 +315,10 @@
       const id = numeric(skin.id ?? skin.skinId) || 0;
       if (id > 0) {
         entries.push({
-          id,
-          championId: numeric(skin.championId) || fallbackChampionId,
+          id: resourceSkinId(id),
+          championId: resourceChampionId(
+            numeric(skin.championId) || fallbackChampionId
+          ),
         });
       }
       for (const child of variantsOf(skin)) {
@@ -497,7 +332,7 @@
   function syncModeCatalog(reason) {
     if (!bridge || !rawChampionId || !catalog.length) return;
     const entries = catalogBridgeEntries();
-    const baseRawSkinId = modeDefaultRawSkinId || fallbackModeDefaultRawSkinId();
+    const baseRawSkinId = modeDefaultRawSkinId;
     const assetSnapshot = catalogAssetSnapshot();
     const key = `${rawChampionId}|${baseRawSkinId}|${assetSnapshot
       .map((entry) => `${entry.rawSkinId}:${entry.visualPath}`)
@@ -513,15 +348,11 @@
       type: "classic-mode-catalog",
       schemaVersion: 1,
       mode: JADE_MODE,
-      primeChampionId: championId,
-      modeChampionId: rawChampionId,
-      carrierLcuSkinId: baseRawSkinId,
-      carrierSkinNumber: baseRawSkinId % 1000,
-      rawChampionId,
-      selectedRawSkinId,
-      baseRawSkinId,
+      championId,
+      selectedSkinId: selectedResourceSkinId,
+      defaultSkinId: resourceSkinId(baseRawSkinId),
       catalog: entries,
-      randomEligibleRawSkinIds: catalog.map((entry) => entry.rawSkinId),
+      randomEligibleSkinIds: catalog.map((entry) => entry.resourceSkinId),
       reason,
       timestamp: Date.now(),
     });
@@ -538,25 +369,15 @@
     const protectedEntry = active && entry && (force || (!entry.available && !entry.isBase))
       ? entry
       : null;
-    const carrierRawSkinIds = protectedEntry
-      ? Array.from(
-          new Set(
-            [
-              jadeSkinId(protectedEntry.championId * 1000),
-              ...catalog
-                .filter((candidate) => candidate.isBase)
-                .flatMap((candidate) => [candidate.rawSkinId, candidate.resourceSkinId]),
-            ]
-              .filter((value) => Number.isFinite(value) && value > 0)
-          )
-        )
+    const defaultLcuSkinIds = protectedEntry && modeDefaultRawSkinId
+      ? [modeDefaultRawSkinId]
       : [];
     const detail = {
       active: Boolean(protectedEntry),
       reason,
       desiredRawSkinId: protectedEntry?.rawSkinId || 0,
       desiredResourceSkinId: protectedEntry?.resourceSkinId || 0,
-      carrierRawSkinIds,
+      defaultLcuSkinIds,
     };
     const protectionKey = JSON.stringify(detail);
     window.__roseJadeVisualProtection = detail;
@@ -717,7 +538,7 @@
     const id = numeric(resourceId) || 0;
     const isResourceBase = championId > 0 && id === championId * 1000;
     if (isResourceBase) {
-      const defaultRawSkinId = modeDefaultRawSkinId || fallbackModeDefaultRawSkinId();
+      const defaultRawSkinId = modeDefaultRawSkinId;
       const defaultEntry = catalog.find((entry) => entry.rawSkinId === defaultRawSkinId);
       if (defaultEntry) {
         return { entry: defaultEntry, rawSkinId: defaultEntry.rawSkinId };
@@ -753,17 +574,14 @@
       pendingHistoricResourceSkinId = 0;
       lastAppliedHistoricResourceSkinId = 0;
     }
-    visualCarrierProtectionActive = !isModeDefaultResourceSkinId(resourceId);
+    visualRollbackProtectionActive = !isModeDefaultResourceSkinId(resourceId);
     projectedVariantRawSkinId = rawSkinId;
     desiredVisualSelection = entry;
     projectedCatalogIndex = catalog.indexOf(entry);
     lastVisualCenterRawSkinId = 0;
     clearUserNavigation();
-    setVisualProtection(entry, reason, visualCarrierProtectionActive);
+    setVisualProtection(entry, reason, visualRollbackProtectionActive);
     scheduleNativeProjection(projectedCatalogIndex, () => {
-      if (active && desiredVisualSelection?.rawSkinId === entry.rawSkinId) {
-        refreshNativeSkinPresentation?.(entry.rawSkinId);
-      }
       if (typeof onComplete === "function") onComplete();
     });
     adaptNativeController();
@@ -835,7 +653,7 @@
         // The catalog is rebuilt every two seconds, so its entry objects are
         // not stable. Rebind the active projection by ID without replaying the
         // default-card staging animation.
-        visualCarrierProtectionActive = true;
+        visualRollbackProtectionActive = true;
         projectedVariantRawSkinId = selection.rawSkinId;
         desiredVisualSelection = selection.entry;
         projectedCatalogIndex = catalog.indexOf(selection.entry);
@@ -914,7 +732,7 @@
     if (!selection) return;
     if (pendingRandomResourceSkinId === appliedRandomResourceSkinId) {
       projectedVariantRawSkinId = selection.rawSkinId;
-      visualCarrierProtectionActive = !selection.entry.isBase;
+      visualRollbackProtectionActive = !selection.entry.isBase;
       desiredVisualSelection = selection.entry;
       projectedCatalogIndex = catalog.indexOf(selection.entry);
       setVisualProtection(selection.entry, "random-catalog-refresh", true);
@@ -1108,7 +926,7 @@
   function beginUserNavigation(targetRawSkinId = 0) {
     const targetId = numeric(targetRawSkinId) || 0;
     const targetEntry = targetId ? catalogEntryForRawSkinId(targetId) : null;
-    const hadVisualProtection = visualCarrierProtectionActive;
+    const hadVisualProtection = visualRollbackProtectionActive;
     if (
       historicRestoreInProgress || pendingHistoricResourceSkinId ||
       lastAppliedHistoricResourceSkinId
@@ -1123,21 +941,16 @@
       randomProjectionSuppressed = true;
     }
     if (targetEntry) {
-      visualCarrierProtectionActive = !targetEntry.available && !targetEntry.isBase;
+      visualRollbackProtectionActive = !targetEntry.available && !targetEntry.isBase;
       desiredVisualSelection = targetEntry;
       projectedCatalogIndex = catalog.indexOf(targetEntry);
       setVisualProtection(
         targetEntry,
         "user-navigation-target",
-        visualCarrierProtectionActive
+        visualRollbackProtectionActive
       );
-    } else {
-      visualCarrierProtectionActive = false;
-      projectedCatalogIndex = -1;
-      desiredVisualSelection = null;
-      setVisualProtection(null, "user-navigation");
     }
-    if (hadVisualProtection && !visualCarrierProtectionActive) {
+    if (targetEntry && hadVisualProtection && !visualRollbackProtectionActive) {
       for (const card of Array.from(adaptedCards)) clearCompatibility(card);
       adaptedCards.clear();
     }
@@ -1162,8 +975,8 @@
       lastAppliedHistoricResourceSkinId = 0;
     }
     projectedVariantRawSkinId = 0;
-    visualCarrierProtectionActive = !entry.available && !entry.isBase;
-    setVisualProtection(entry, reason, visualCarrierProtectionActive);
+    visualRollbackProtectionActive = !entry.available && !entry.isBase;
+    setVisualProtection(entry, reason, visualRollbackProtectionActive);
     desiredVisualSelection = entry;
     projectedCatalogIndex = catalog.indexOf(entry);
     syncVisualSelection(entry, reason, true);
@@ -1410,12 +1223,20 @@
     const navigationPending =
       pendingUserNavigation && Date.now() <= pendingUserNavigationUntil;
     if (pendingUserNavigation && !navigationPending) clearUserNavigation();
-    const followsUserNavigation = Boolean(
+    const followsKnownUserNavigation = Boolean(
       navigationPending &&
       pendingUserTargetRawSkinId &&
       centerEntry &&
       pendingUserTargetRawSkinId === centerEntry.rawSkinId
     );
+    const followsUnresolvedUserNavigation = Boolean(
+      navigationPending &&
+      !pendingUserTargetRawSkinId &&
+      centerEntry &&
+      centerEntry.rawSkinId !== lastVisualCenterRawSkinId
+    );
+    const followsUserNavigation =
+      followsKnownUserNavigation || followsUnresolvedUserNavigation;
     const isIntermediateUserNavigation = Boolean(
       navigationPending &&
       pendingUserTargetRawSkinId &&
@@ -1431,7 +1252,7 @@
       centerEntry &&
       desiredVisualSelection &&
       desiredVisualSelection.rawSkinId !== centerEntry.rawSkinId &&
-      visualCarrierProtectionActive &&
+      visualRollbackProtectionActive &&
       !followsUserNavigation &&
       !navigationPending &&
       nativeProjectionTargetIndex < 0
@@ -1439,24 +1260,17 @@
     if (centerEntry && centerEntry.rawSkinId !== lastVisualCenterRawSkinId) {
       lastVisualCenterRawSkinId = centerEntry.rawSkinId;
       if (isAutomaticSelectionDrift) {
-        if (refreshNativeSkinPresentation) {
-          refreshNativeSkinPresentation(desiredVisualSelection.rawSkinId);
-          log("info", "Reprojected classic selection after native drift", {
-            observedRawSkinId: centerEntry.rawSkinId,
-            desiredRawSkinId: desiredVisualSelection.rawSkinId,
-          });
-        } else {
-          log("warn", "Native classic selector projection is unavailable", {
-            observedRawSkinId: centerEntry.rawSkinId,
-            desiredRawSkinId: desiredVisualSelection.rawSkinId,
-          });
-        }
+        scheduleNativeProjection(projectedCatalogIndex);
+        log("info", "Restoring classic selection through native carousel", {
+          observedRawSkinId: centerEntry.rawSkinId,
+          desiredRawSkinId: desiredVisualSelection.rawSkinId,
+        });
       } else if (!isIntermediateUserNavigation && !isIntermediateNativeProjection) {
-        visualCarrierProtectionActive = !centerEntry.available && !centerEntry.isBase;
+        visualRollbackProtectionActive = !centerEntry.available && !centerEntry.isBase;
         setVisualProtection(
           centerEntry,
           "visual-center-change",
-          visualCarrierProtectionActive
+          visualRollbackProtectionActive
         );
         if (followsUserNavigation) {
           desiredVisualSelection = centerEntry;
@@ -1511,7 +1325,16 @@
     if (!active || !rawChampionId) return;
     if (!force && catalog.length && Date.now() - catalogLoadedAt < CATALOG_REFRESH_MS) return;
     const generation = requestGeneration;
+    const modeSkins = await fetchJson("/lol-champ-select/v1/skin-carousel-skins");
+    if (!active || generation !== requestGeneration) return;
     if (!modeDefaultRawSkinId) {
+      const rawEntries = (Array.isArray(modeSkins) ? modeSkins : []).filter(
+        (entry) => Math.floor((numeric(entry?.id ?? entry?.skinId) || 0) / 1000) === rawChampionId
+      );
+      const declaredDefault = rawEntries.find(
+        (entry) => entry?.isBase === true || entry?.isDefault === true
+      );
+      modeDefaultRawSkinId = numeric(declaredDefault?.id ?? declaredDefault?.skinId) || 0;
       try {
         const pickableSkinIds = await fetchJson(
           "/lol-lobby-team-builder/champ-select/v1/pickable-skin-ids"
@@ -1520,20 +1343,18 @@
         const candidates = (Array.isArray(pickableSkinIds) ? pickableSkinIds : [])
           .map((value) => numeric(value) || 0)
           .filter((value) => Math.floor(value / 1000) === rawChampionId);
-        const expected = fallbackModeDefaultRawSkinId();
-        modeDefaultRawSkinId = candidates.find((value) => value === expected)
-          || candidates.find((value) => value % 1000 >= 300)
-          || candidates.find((value) => value % 1000 === 0)
+        modeDefaultRawSkinId = modeDefaultRawSkinId
+          || candidates.find((value) => value === selectedRawSkinId)
+          || candidates[0]
           || 0;
       } catch (error) {
         log("debug", "Waiting for classic default skin catalog", String(error));
       }
       if (!modeDefaultRawSkinId) {
-        modeDefaultRawSkinId = fallbackModeDefaultRawSkinId();
+        modeDefaultRawSkinId = numeric(rawEntries[0]?.id ?? rawEntries[0]?.skinId) || 0;
       }
+      if (!modeDefaultRawSkinId) return;
     }
-    const modeSkins = await fetchJson("/lol-champ-select/v1/skin-carousel-skins");
-    if (!active || generation !== requestGeneration) return;
     const nextCatalog = (Array.isArray(modeSkins) ? modeSkins : [])
       .map(normalizeCatalogEntry)
       .filter(
@@ -1572,7 +1393,7 @@
       selectedResourceSkinId = resourceSkinId(nextRawSkin);
       if (championChanged) {
         cancelHistoricVisualRestore("champion-change", true);
-        visualCarrierProtectionActive = false;
+        visualRollbackProtectionActive = false;
         projectedCatalogIndex = -1;
         lastAppliedHistoricResourceSkinId = 0;
         appliedRandomResourceSkinId = 0;
@@ -1730,7 +1551,7 @@
     desiredVisualSelection = null;
     projectedCatalogIndex = -1;
     clearUserNavigation();
-    visualCarrierProtectionActive = false;
+    visualRollbackProtectionActive = false;
     pendingHistoricResourceSkinId = 0;
     lastAppliedHistoricResourceSkinId = 0;
     cancelHistoricVisualRestore("runtime-stop", true);
@@ -1745,8 +1566,6 @@
     pointerSelectionCommitted = false;
     lastVisualCenterRawSkinId = 0;
     lastVisualProtectionKey = "";
-    lastReadRewriteKey = "";
-    latestNativeSkinSelectorEvent = null;
     refreshInFlight = false;
     if (visualProtectionClearTimer) clearTimeout(visualProtectionClearTimer);
     visualProtectionClearTimer = setTimeout(() => {
@@ -1811,9 +1630,9 @@
         ) || parentEntry;
     return {
       championId,
-      rawChampionId,
       skinId: resourceSkinId(rawSkinId),
-      rawSkinId,
+      lcuChampionId: rawChampionId,
+      lcuSkinId: rawSkinId,
       selectedEntry,
       parentEntry,
     };
@@ -1855,9 +1674,9 @@
       mapId,
       queueId,
       championId,
-      rawChampionId,
-      selectedRawSkinId,
-      selectedResourceSkinId,
+      selectedSkinId: selectedResourceSkinId,
+      lcuChampionId: rawChampionId,
+      selectedLcuSkinId: selectedRawSkinId,
       modeSkinCount: catalog.length,
       nativeCardCount: nativeCards().length,
       adaptedCardCount: adaptedCards.size,
@@ -1865,9 +1684,9 @@
       projectedVariantRawSkinId,
       pendingUserTargetRawSkinId,
     }),
-    resourceChampionId,
-    resourceSkinId,
-    jadeSkinId,
+    championIdFromLcu: resourceChampionId,
+    skinIdFromLcu: resourceSkinId,
+    skinIdForLcu: jadeSkinId,
     shouldPatchLcuSelection,
     getModeSkinData,
     catalogAssetSnapshot,

--- a/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
@@ -1373,6 +1373,23 @@
       || catalog.find((entry) => entry.resourceSkinId === selectedResourceSkinId)
       || null;
     const centerEntry = visualCenterEntry || selectedCatalogEntry;
+    const settledOwnedUserSelection = Boolean(
+      pendingUserNavigation &&
+      Date.now() <= pendingUserNavigationUntil &&
+      selectedRawSkinId !== modeDefaultRawSkinId &&
+      selectedCatalogEntry?.available &&
+      visualCenterEntry?.rawSkinId === selectedCatalogEntry.rawSkinId &&
+      desiredVisualSelection?.rawSkinId !== selectedCatalogEntry.rawSkinId &&
+      nativeProjectionTargetIndex < 0
+    );
+    if (settledOwnedUserSelection) {
+      log("info", "Accepted native owned selection over stale carousel target", {
+        selectedRawSkinId,
+        staleTargetRawSkinId: desiredVisualSelection?.rawSkinId || 0,
+      });
+      publishNativeCardSelection(selectedCatalogEntry, "lcu-owned-selection");
+      clearUserNavigation();
+    }
     const navigationPending =
       pendingUserNavigation && Date.now() <= pendingUserNavigationUntil;
     if (pendingUserNavigation && !navigationPending) clearUserNavigation();

--- a/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
@@ -1436,7 +1436,13 @@
           desiredRawSkinId: desiredVisualSelection.rawSkinId,
         });
       } else if (!isIntermediateUserNavigation && !isIntermediateNativeProjection) {
-        visualRollbackProtectionActive = !centerEntry.available && !centerEntry.isBase;
+        const projectedChromaActive = Boolean(
+          projectedVariantRawSkinId &&
+          desiredVisualSelection?.rawSkinId === centerEntry.rawSkinId &&
+          projectedVariantRawSkinId !== centerEntry.rawSkinId
+        );
+        visualRollbackProtectionActive =
+          projectedChromaActive || (!centerEntry.available && !centerEntry.isBase);
         setVisualProtection(
           centerEntry,
           "visual-center-change",

--- a/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
@@ -1793,6 +1793,30 @@
     }));
   }
 
+  function replayBridgeState() {
+    if (!active || !catalog.length) return;
+    lastCatalogSyncKey = "";
+    syncModeCatalog("bridge-ready");
+
+    const selection = currentSelection();
+    const parent = catalogEntryForRawSkinId(selection?.lcuSkinId);
+    if (!selection || !parent) return;
+    const presentation = variantPresentation(selection.lcuSkinId, parent);
+    syncVisualSelection(
+      {
+        ...parent,
+        rawSkinId: presentation.rawSkinId,
+        resourceSkinId: presentation.resourceSkinId,
+        name: presentation.skinName,
+      },
+      "bridge-ready"
+    );
+    log("info", "Classic state replayed after bridge connection", {
+      rawSkinId: presentation.rawSkinId,
+      resourceSkinId: presentation.resourceSkinId,
+    });
+  }
+
   async function start() {
     if (typeof document === "undefined" || !document.body) {
       requestAnimationFrame(start);
@@ -1806,6 +1830,7 @@
     });
     bridge.subscribe("historic-state", handleHistoricState);
     bridge.subscribe("random-mode-state", handleRandomModeState);
+    bridge.onReady?.(replayBridgeState);
     await syncContextFromLcu();
     log("info", "Plugin initialized");
   }

--- a/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
@@ -387,6 +387,7 @@
       refreshNativeSkinPresentation?.(entry.rawSkinId);
     }
     try {
+      const entries = catalogBridgeEntries();
       // Python validates this ID against the active JADE carousel before it
       // updates the same injection state used by regular champion select.
       bridge.send({
@@ -398,8 +399,8 @@
         skin: entry.name,
         originalName: entry.name,
         skinId: entry.resourceSkinId,
-        catalog: catalogBridgeEntries(),
-        randomEligibleSkinIds: catalog.map((item) => item.resourceSkinId),
+        catalog: entries,
+        randomEligibleSkinIds: entries.map((item) => item.id),
         source: "jade-wheel",
         reason,
         userInitiated,
@@ -467,7 +468,7 @@
       selectedSkinId: selectedResourceSkinId,
       defaultSkinId: resourceSkinId(baseRawSkinId),
       catalog: entries,
-      randomEligibleSkinIds: catalog.map((entry) => entry.resourceSkinId),
+      randomEligibleSkinIds: entries.map((entry) => entry.id),
       reason,
       timestamp: Date.now(),
     });

--- a/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
@@ -122,8 +122,8 @@
     if (!bridge) return;
     try {
       bridge.send({
-        type: "chroma-log",
-        source: "JadeWheel",
+        type: "plugin-log",
+        source: "ClassicWheel",
         level,
         message,
         data,

--- a/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
@@ -26,7 +26,6 @@
   const CARD_CLASS = "rose-jade-native-card";
   const SELECTED_CLASS = "rose-jade-native-card--selected";
   const UNLOCKED_CLASS = "rose-jade-native-card--unlocked";
-  const EMPTY_CLASS = "rose-jade-native-card--empty";
   const ACTIVE_ROOT_CLASS = "rose-jade-wheel-active";
   const VISUAL_PROTECTION_EVENT = "rose-jade-visual-protection";
   const SELECTION_CHANGE_EVENT = "rose-classic-selection-change";
@@ -34,10 +33,6 @@
   const CATALOG_REFRESH_MS = 2000;
   const USER_NAVIGATION_WINDOW_MS = 6000;
   const nativeFetch = window.fetch.bind(window);
-  const COMPATIBILITY_CLASSES = [
-    CARD_CLASS,
-    SELECTED_CLASS,
-  ];
 
   let bridge = null;
   let active = false;
@@ -60,10 +55,8 @@
   let catalog = [];
   let catalogLoadedAt = 0;
   let adaptedCards = new Set();
-  const originalCardState = new WeakMap();
-  const adaptedCardState = new WeakMap();
-  const projectedImageState = new WeakMap();
   const lockOverlayState = new WeakMap();
+  let footerPresentationState = null;
   let desiredVisualSelection = null;
   let projectedCatalogIndex = -1;
   let nativeProjectionTargetIndex = -1;
@@ -281,9 +274,36 @@
         const ws = api.champSelectBinding.socket._websocket;
         if (!ws || ws.__roseJadeReadProjection) return;
         const parentOnMessage = ws.onmessage;
-        refreshNativeSkinPresentation = (desiredRawSkinId) => {
-          if (!active || !latestNativeSkinSelectorEvent || !desiredRawSkinId) return;
-          const payload = JSON.parse(JSON.stringify(latestNativeSkinSelectorEvent.payload));
+        refreshNativeSkinPresentation = async (desiredRawSkinId) => {
+          if (!active || !desiredRawSkinId) return;
+          let sourceEvent = latestNativeSkinSelectorEvent?.event || null;
+          let sourcePayload = latestNativeSkinSelectorEvent?.payload || null;
+          if (!sourcePayload) {
+            try {
+              const response = await nativeFetch(
+                "/lol-champ-select/v1/skin-selector-info",
+                { credentials: "include" }
+              );
+              if (!response?.ok) return;
+              sourcePayload = [8, "OnJsonApiEvent", {
+                data: await response.json(),
+                eventType: "Update",
+                uri: "/lol-champ-select/v1/skin-selector-info",
+              }];
+              sourceEvent = new MessageEvent("message", {
+                data: JSON.stringify(sourcePayload),
+              });
+              latestNativeSkinSelectorEvent = {
+                event: sourceEvent,
+                payload: sourcePayload,
+              };
+            } catch (error) {
+              log("warn", "Classic selector presentation refresh failed", String(error));
+              return;
+            }
+          }
+          if (!active) return;
+          const payload = JSON.parse(JSON.stringify(sourcePayload));
           const selectedChampionId = numeric(payload[2]?.data?.selectedChampionId);
           if (selectedChampionId && selectedChampionId !== Math.floor(desiredRawSkinId / 1000)) {
             return;
@@ -291,7 +311,7 @@
           payload[2].data.selectedSkinId = desiredRawSkinId;
           parentOnMessage.call(
             ws,
-            cloneWebsocketEvent(latestNativeSkinSelectorEvent.event, payload)
+            cloneWebsocketEvent(sourceEvent, payload)
           );
           log("info", "Refreshed native classic skin presentation", {
             selectedSkinId: desiredRawSkinId,
@@ -610,7 +630,7 @@
       isHiddenModeSkin0,
       available,
       visualPath: String(
-        entry.loadScreenPath || entry.splashPath || entry.uncenteredSplashPath || entry.tilePath || ""
+        entry.tilePath || entry.splashPath || entry.uncenteredSplashPath || entry.loadScreenPath || ""
       ),
       paths: paths.map(normalizeAssetPath).filter(Boolean),
       files: paths.map(assetFileName).filter(Boolean),
@@ -741,10 +761,7 @@
     clearUserNavigation();
     setVisualProtection(entry, reason, visualCarrierProtectionActive);
     scheduleNativeProjection(projectedCatalogIndex, () => {
-      if (
-        active && desiredVisualSelection?.rawSkinId === entry.rawSkinId &&
-        visualCarrierProtectionActive
-      ) {
+      if (active && desiredVisualSelection?.rawSkinId === entry.rawSkinId) {
         refreshNativeSkinPresentation?.(entry.rawSkinId);
       }
       if (typeof onComplete === "function") onComplete();
@@ -928,9 +945,8 @@
     );
 
     // JADE recycles its five card nodes and does not keep DOM order aligned
-    // with their visual left-to-right order. Historic projection can move the
-    // center node to DOM index 0, which used to erase every inferred card on
-    // its left. Always calculate carousel offsets from rendered positions.
+    // with their visual left-to-right order. Sort by the rendered position;
+    // descendant carousel-offset classes can remain stale after projection.
     return cards
       .map((card, domIndex) => {
         const rect = card.getBoundingClientRect();
@@ -960,14 +976,11 @@
 
   function elementSkinId(card) {
     const attributes = ["data-skin-id", "data-champion-skin-id", "skin-id"];
-    const original = originalCardState.get(card);
     for (const attribute of attributes) {
-      const value = numeric(original?.attributes.get(attribute));
+      const value = numeric(card.getAttribute(attribute));
       if (value && value > 0) return value;
     }
 
-    // Ignore the adapter attributes on the card itself. Native JADE recycles
-    // these nodes while moving the carousel, so those values may be stale.
     const nodes = card.querySelectorAll(
       "[data-skin-id], [data-champion-skin-id], [skin-id]"
     );
@@ -1030,32 +1043,8 @@
     return null;
   }
 
-  function rememberOriginalCardState(card) {
-    if (originalCardState.has(card)) return;
-    const attributes = new Map();
-    for (const name of [
-      "data-skin-id",
-      "data-champion-skin-id",
-      "skin-id",
-      "data-rose-lcu-skin-id",
-      "data-rose-resource-skin-id",
-      "data-rose-carousel-offset",
-    ]) {
-      attributes.set(name, card.hasAttribute(name) ? card.getAttribute(name) : null);
-    }
-    originalCardState.set(card, {
-      attributes,
-      classes: new Set(
-        Array.from(card.classList).filter(
-          (name) => COMPATIBILITY_CLASSES.includes(name)
-        )
-      ),
-    });
-  }
-
   function clearCompatibility(card) {
     if (!card) return;
-    adaptedCardState.delete(card);
     card.querySelectorAll(".skins-pane__locked-overlay, .skins-pane__locked-icon").forEach(
       (element) => {
         const original = lockOverlayState.get(element);
@@ -1074,38 +1063,11 @@
         lockOverlayState.delete(element);
       }
     );
-    card.classList.remove(UNLOCKED_CLASS, EMPTY_CLASS);
-    const original = originalCardState.get(card);
-    card.querySelectorAll("img").forEach((image) => {
-      if (image.hasAttribute("data-rose-jade-projected-image")) {
-        image.remove();
-        return;
-      }
-      const state = projectedImageState.get(image);
-      if (!state) return;
-      for (const [name, value] of Object.entries(state)) {
-        if (value === null) image.removeAttribute(name);
-        else image.setAttribute(name, value);
-      }
-      projectedImageState.delete(image);
-    });
-    for (const className of COMPATIBILITY_CLASSES) {
-      if (!original?.classes.has(className)) card.classList.remove(className);
-    }
-    for (const name of [
-      "data-skin-id",
-      "data-rose-lcu-skin-id",
-      "data-rose-resource-skin-id",
-      "data-rose-carousel-offset",
-    ]) {
-      const value = original?.attributes.get(name);
-      if (value === null || value === undefined) card.removeAttribute(name);
-      else card.setAttribute(name, value);
-    }
+    card.classList.remove(CARD_CLASS, SELECTED_CLASS, UNLOCKED_CLASS);
   }
 
-  function unlockNativeCard(card, entry) {
-    if (!card || !entry || entry.available || entry.isBase) return;
+  function unlockNativeCard(card) {
+    if (!card) return;
     card.classList.add(UNLOCKED_CLASS);
     card.querySelectorAll(".skins-pane__locked-overlay, .skins-pane__locked-icon").forEach(
       (element) => {
@@ -1131,76 +1093,22 @@
     );
   }
 
-  function applyCompatibility(
-    card,
-    entry,
-    offset,
-    selected,
-    stabilize = false
-  ) {
-    rememberOriginalCardState(card);
-    const stateKey = entry
-      ? `${entry.rawSkinId}|${entry.resourceSkinId}|${offset}|${selected}|${entry.available}`
-      : `empty|${offset}`;
-    const alreadyAdapted =
-      adaptedCardState.get(card) === stateKey &&
-      card.classList.contains(CARD_CLASS) &&
-      card.classList.contains(SELECTED_CLASS) === selected &&
-      card.getAttribute("data-rose-carousel-offset") === String(offset) &&
-      card.classList.contains(UNLOCKED_CLASS) === !entry?.available &&
-      card.getAttribute("data-rose-lcu-skin-id") === String(entry?.rawSkinId || "");
-    card.classList.toggle("rose-jade-native-card--stabilizing", stabilize);
-    card.classList.toggle(EMPTY_CLASS, !entry);
-    if (alreadyAdapted) {
-      // JADE recycles card nodes and may recreate the native lock overlay
-      // after our first pass. Reapply the idempotent unlock state here.
-      unlockNativeCard(card, entry);
-      adaptedCards.add(card);
-      return;
-    }
-    clearCompatibility(card);
-    if (!entry || card.classList.contains("skins-pane__skin-card--placeholder")) {
-      card.classList.toggle(EMPTY_CLASS, !entry);
+  function applyCompatibility(card, selected) {
+    if (!card) return;
+    if (card.classList.contains("skins-pane__skin-card--placeholder")) {
+      clearCompatibility(card);
       return;
     }
     card.classList.add(CARD_CLASS);
     card.classList.toggle(SELECTED_CLASS, selected);
-    card.setAttribute("data-rose-carousel-offset", String(offset));
-    card.setAttribute("data-rose-resource-skin-id", String(entry.resourceSkinId));
-    card.setAttribute("data-rose-lcu-skin-id", String(entry.rawSkinId));
-    unlockNativeCard(card, entry);
-    adaptedCardState.set(card, stateKey);
+    unlockNativeCard(card);
     adaptedCards.add(card);
-  }
-
-  function projectCardVisual(card, entry) {
-    const visualPath = entry?.visualPath || "";
-    if (!card || !visualPath) return;
-    if (!card.querySelector(".skins-pane__skin-image")) {
-      const image = document.createElement("img");
-      image.className = "skins-pane__skin-image";
-      image.setAttribute("data-rose-jade-projected-image", "true");
-      card.appendChild(image);
-    }
-    card.setAttribute("aria-label", entry.name);
-    card.setAttribute("title", entry.name);
-    for (const image of card.querySelectorAll(".skins-pane__skin-image")) {
-      if (!image.hasAttribute("data-rose-jade-projected-image") && !projectedImageState.has(image)) {
-        projectedImageState.set(image, {
-          src: image.hasAttribute("src") ? image.getAttribute("src") : null,
-          srcset: image.hasAttribute("srcset") ? image.getAttribute("srcset") : null,
-          alt: image.hasAttribute("alt") ? image.getAttribute("alt") : null,
-        });
-      }
-      if (image.getAttribute("src") !== visualPath) image.setAttribute("src", visualPath);
-      image.removeAttribute("srcset");
-      image.setAttribute("alt", entry.name);
-    }
   }
 
   function beginUserNavigation(targetRawSkinId = 0) {
     const targetId = numeric(targetRawSkinId) || 0;
     const targetEntry = targetId ? catalogEntryForRawSkinId(targetId) : null;
+    const hadVisualProtection = visualCarrierProtectionActive;
     if (
       historicRestoreInProgress || pendingHistoricResourceSkinId ||
       lastAppliedHistoricResourceSkinId
@@ -1214,15 +1122,22 @@
       appliedRandomResourceSkinId = 0;
       randomProjectionSuppressed = true;
     }
-    if (targetEntry && !targetEntry.available && !targetEntry.isBase) {
-      visualCarrierProtectionActive = true;
+    if (targetEntry) {
+      visualCarrierProtectionActive = !targetEntry.available && !targetEntry.isBase;
       desiredVisualSelection = targetEntry;
       projectedCatalogIndex = catalog.indexOf(targetEntry);
-      setVisualProtection(targetEntry, "user-navigation-target", true);
-    } else if (visualCarrierProtectionActive && (!targetId || targetEntry?.isBase)) {
+      setVisualProtection(
+        targetEntry,
+        "user-navigation-target",
+        visualCarrierProtectionActive
+      );
+    } else {
       visualCarrierProtectionActive = false;
       projectedCatalogIndex = -1;
+      desiredVisualSelection = null;
       setVisualProtection(null, "user-navigation");
+    }
+    if (hadVisualProtection && !visualCarrierProtectionActive) {
       for (const card of Array.from(adaptedCards)) clearCompatibility(card);
       adaptedCards.clear();
     }
@@ -1293,7 +1208,18 @@
     }
     const direction = nativeProjectionTargetIndex < currentIndex ? "left" : "right";
     const arrow = pane?.parentElement?.querySelector(`.skins-pane__arrow--${direction}`);
-    if (!arrow || arrow.classList.contains("skins-pane__arrow--disabled")) return;
+    if (!arrow || arrow.classList.contains("skins-pane__arrow--disabled")) {
+      log("warn", "Native classic carousel reached a boundary before projection target", {
+        currentIndex,
+        targetIndex: nativeProjectionTargetIndex,
+        direction,
+      });
+      nativeProjectionTargetIndex = -1;
+      nativeProjectionCurrentIndex = -1;
+      nativeProjectionComplete = null;
+      adaptNativeController();
+      return;
+    }
     drivingNativeProjection = true;
     arrow.click();
     drivingNativeProjection = false;
@@ -1304,15 +1230,26 @@
   function syncFooterPresentation(entry) {
     if (!pane || !entry) return;
     const root = pane.parentElement || pane;
-    const title = root.querySelector(".skins-pane__footer .skins-pane__skin-title");
     const subtitle = root.querySelector(".skins-pane__footer .skins-pane__sub-title");
-    if (title && title.textContent !== entry.name) title.textContent = entry.name;
     if (!subtitle) return;
-    const status = entry.available || entry.isBase
-      ? "OWNED"
-      : "UNLOCKED";
-    if (subtitle.textContent !== status) subtitle.textContent = status;
+    if (footerPresentationState?.element !== subtitle) restoreFooterPresentation();
+    if (!footerPresentationState) {
+      footerPresentationState = {
+        element: subtitle,
+        text: subtitle.textContent,
+        unlocked: subtitle.classList.contains("skins-pane__sub-title--unlocked"),
+      };
+    }
+    if (subtitle.textContent !== "UNLOCKED") subtitle.textContent = "UNLOCKED";
     subtitle.classList.add("skins-pane__sub-title--unlocked");
+  }
+
+  function restoreFooterPresentation() {
+    const state = footerPresentationState;
+    footerPresentationState = null;
+    if (!state?.element?.isConnected) return;
+    state.element.textContent = state.text;
+    state.element.classList.toggle("skins-pane__sub-title--unlocked", state.unlocked);
   }
 
   function handleNativePaneClick(event) {
@@ -1323,9 +1260,10 @@
     ) {
       return;
     }
-    const card = event.target?.closest?.(`.${CARD_CLASS}`);
+    const card = event.target?.closest?.(".skins-pane__skin-card");
     if (!card || !pane?.contains(card)) return;
-    const clickRawSkinId = numeric(card.getAttribute("data-rose-lcu-skin-id")) || 0;
+    const clickEntry = matchCardToCatalog(card);
+    const clickRawSkinId = clickEntry?.rawSkinId || 0;
     if (Date.now() <= pointerSelectionUntil && pointerSelectionRawSkinId) {
       if (pointerSelectionCommitted) return;
       const pointerEntry = catalog.find(
@@ -1346,7 +1284,7 @@
       pointerSelectionCommitted = true;
       return;
     }
-    const entry = catalog.find((candidate) => candidate.rawSkinId === clickRawSkinId);
+    const entry = clickEntry;
     if (!entry) return;
     beginUserNavigation(entry.rawSkinId);
     if (card.classList.contains("skins-pane__skin-card--center-tile")) {
@@ -1367,11 +1305,9 @@
       const currentIndex = centerEntry ? catalog.indexOf(centerEntry) : -1;
       const direction = arrow.classList.contains("skins-pane__arrow--left") ? -1 : 1;
       const target = currentIndex >= 0 ? catalog[currentIndex + direction] : null;
-      if (target) {
-        pendingHistoricResourceSkinId = 0;
-        projectedVariantRawSkinId = 0;
-        beginUserNavigation(target.rawSkinId);
-      }
+      pendingHistoricResourceSkinId = 0;
+      projectedVariantRawSkinId = 0;
+      beginUserNavigation(target?.rawSkinId || 0);
       return;
     }
     if (
@@ -1381,12 +1317,11 @@
     ) {
       return;
     }
-    const card = event.target?.closest?.(`.${CARD_CLASS}`);
+    const card = event.target?.closest?.(".skins-pane__skin-card");
     if (card && pane?.contains(card)) {
       pendingHistoricResourceSkinId = 0;
       projectedVariantRawSkinId = 0;
-      const rawSkinId = numeric(card.getAttribute("data-rose-lcu-skin-id")) || 0;
-      const entry = catalog.find((candidate) => candidate.rawSkinId === rawSkinId);
+      const entry = matchCardToCatalog(card);
       if (!entry) return;
       pointerSelectionRawSkinId = entry.rawSkinId;
       pointerSelectionUntil = Date.now() + 1500;
@@ -1467,18 +1402,11 @@
       centerCard.appendChild(overlay);
     }
     ensureHistoryAnchor(centerCard);
-    const centerSlot = cards.indexOf(centerCard);
     const visualCenterEntry = matchCardToCatalog(centerCard);
-    const selectedCatalogEntry = catalogEntryForRawSkinId(selectedRawSkinId);
-    let selectedIndex = selectedCatalogEntry ? catalog.indexOf(selectedCatalogEntry) : -1;
-    if (selectedIndex < 0) {
-      selectedIndex = catalog.findIndex(
-        (entry) => entry.resourceSkinId === selectedResourceSkinId
-      );
-    }
-    if (selectedIndex < 0) selectedIndex = 0;
-    let centerEntry = visualCenterEntry || catalog[selectedIndex] || null;
-    if (visualCenterEntry) selectedIndex = catalog.indexOf(visualCenterEntry);
+    const selectedCatalogEntry = catalogEntryForRawSkinId(selectedRawSkinId)
+      || catalog.find((entry) => entry.resourceSkinId === selectedResourceSkinId)
+      || null;
+    const centerEntry = visualCenterEntry || selectedCatalogEntry;
     const navigationPending =
       pendingUserNavigation && Date.now() <= pendingUserNavigationUntil;
     if (pendingUserNavigation && !navigationPending) clearUserNavigation();
@@ -1494,39 +1422,36 @@
       centerEntry &&
       pendingUserTargetRawSkinId !== centerEntry.rawSkinId
     );
-    const isAutomaticLcuRollback = Boolean(
+    const isIntermediateNativeProjection = Boolean(
+      nativeProjectionTargetIndex >= 0 &&
+      centerEntry &&
+      catalog.indexOf(centerEntry) !== nativeProjectionTargetIndex
+    );
+    const isAutomaticSelectionDrift = Boolean(
       centerEntry &&
       desiredVisualSelection &&
       desiredVisualSelection.rawSkinId !== centerEntry.rawSkinId &&
       visualCarrierProtectionActive &&
-      !followsUserNavigation
+      !followsUserNavigation &&
+      !navigationPending &&
+      nativeProjectionTargetIndex < 0
     );
-    if (isAutomaticLcuRollback) {
-      centerEntry = desiredVisualSelection;
-      selectedIndex = projectedCatalogIndex >= 0
-        ? projectedCatalogIndex
-        : catalog.indexOf(centerEntry);
-    }
-    const projectionActive = Boolean(
-      desiredVisualSelection &&
-      projectedCatalogIndex >= 0 &&
-      visualCarrierProtectionActive &&
-      !followsUserNavigation
-    );
-    if (projectionActive) {
-      centerEntry = desiredVisualSelection;
-      selectedIndex = projectedCatalogIndex;
-    }
-    const usedRawSkinIds = new Set(centerEntry ? [centerEntry.rawSkinId] : []);
-
     if (centerEntry && centerEntry.rawSkinId !== lastVisualCenterRawSkinId) {
       lastVisualCenterRawSkinId = centerEntry.rawSkinId;
-      if (isAutomaticLcuRollback) {
-        log("info", "Ignored automatic classic skin rollback", {
-          desiredResourceSkinId: desiredVisualSelection.resourceSkinId,
-          lcuResourceSkinId: visualCenterEntry?.resourceSkinId || selectedResourceSkinId,
-        });
-      } else if (!isIntermediateUserNavigation) {
+      if (isAutomaticSelectionDrift) {
+        if (refreshNativeSkinPresentation) {
+          refreshNativeSkinPresentation(desiredVisualSelection.rawSkinId);
+          log("info", "Reprojected classic selection after native drift", {
+            observedRawSkinId: centerEntry.rawSkinId,
+            desiredRawSkinId: desiredVisualSelection.rawSkinId,
+          });
+        } else {
+          log("warn", "Native classic selector projection is unavailable", {
+            observedRawSkinId: centerEntry.rawSkinId,
+            desiredRawSkinId: desiredVisualSelection.rawSkinId,
+          });
+        }
+      } else if (!isIntermediateUserNavigation && !isIntermediateNativeProjection) {
         visualCarrierProtectionActive = !centerEntry.available && !centerEntry.isBase;
         setVisualProtection(
           centerEntry,
@@ -1552,47 +1477,19 @@
       }
     }
 
-    const mapped = [];
-    for (let slot = 0; slot < cards.length; slot += 1) {
-      const card = cards[slot];
+    for (const card of cards) {
       if (card.classList.contains("skins-pane__skin-card--placeholder")) {
         clearCompatibility(card);
         continue;
       }
-      const directMatch = projectionActive ? null : matchCardToCatalog(card);
-      const inferredMatch = catalog[selectedIndex + (slot - centerSlot)] || null;
-      let entry = centerEntry || directMatch;
-      if (card !== centerCard) {
-        entry = [inferredMatch, directMatch].find(
-          (candidate) => candidate && !usedRawSkinIds.has(candidate.rawSkinId)
-        ) || null;
-      }
-      const offset = slot - centerSlot;
-      applyCompatibility(
-        card,
-        entry,
-        offset,
-        card === centerCard,
-        isAutomaticLcuRollback
-      );
-      if (projectionActive && entry) {
-        projectCardVisual(card, entry);
-      }
-      if (entry) {
-        usedRawSkinIds.add(entry.rawSkinId);
-        mapped.push(`${offset}:${entry.rawSkinId}:${entry.available ? "official" : "unlocked"}`);
-      }
+      // Native JADE owns the card content and position. ClassicWheel only
+      // removes the visual lock state and keeps its own center marker for
+      // companion plugins.
+      applyCompatibility(card, card === centerCard);
     }
     syncFooterPresentation(centerEntry);
-    const footer = pane.parentElement?.querySelector(".skins-pane__footer");
-    const leftArrow = pane.parentElement?.querySelector(".skins-pane__arrow--left");
-    const rightArrow = pane.parentElement?.querySelector(".skins-pane__arrow--right");
-    if (projectionActive && footer) {
-      leftArrow?.classList.toggle("skins-pane__arrow--disabled", selectedIndex <= 0);
-      rightArrow?.classList.toggle("skins-pane__arrow--disabled", selectedIndex >= catalog.length - 1);
-    }
 
-    const layoutKey = `${cards.length}|${catalog.length}|${selectedRawSkinId}|${mapped.join(",")}`;
+    const layoutKey = `${cards.length}|${catalog.length}|${selectedRawSkinId}|${centerEntry?.rawSkinId || 0}`;
     if (layoutKey !== lastLayoutKey) {
       lastLayoutKey = layoutKey;
       log("info", "Native classic skin selector adapted", {
@@ -1603,8 +1500,9 @@
         visualCenterRawSkinId: centerEntry?.rawSkinId || null,
         visualCenterResourceSkinId: centerEntry?.resourceSkinId || null,
         nativeCenterRawSkinId: visualCenterEntry?.rawSkinId || null,
-        visualProjectionActive: isAutomaticLcuRollback,
-        mapped,
+        visualProjectionActive: false,
+        nativeContentPreserved: true,
+        frontendUnlocked: true,
       });
     }
   }
@@ -1751,12 +1649,6 @@
         cursor: pointer !important;
       }
 
-      .${CARD_CLASS}.rose-jade-native-card--stabilizing,
-      .${CARD_CLASS}.rose-jade-native-card--stabilizing * {
-        transition: none !important;
-        animation: none !important;
-      }
-
       .${UNLOCKED_CLASS} .skins-pane__locked-overlay,
       .${UNLOCKED_CLASS} .skins-pane__locked-icon {
         display: none !important;
@@ -1771,18 +1663,6 @@
         pointer-events: none !important;
       }
 
-      .${EMPTY_CLASS} {
-        visibility: hidden !important;
-        pointer-events: none !important;
-        border-color: transparent !important;
-      }
-
-      .${ACTIVE_ROOT_CLASS} .champion-select-center-container--picking-skins
-        .skins-pane__skin-card--placeholder {
-        border: none !important;
-        visibility: hidden !important;
-        pointer-events: none !important;
-      }
     `;
     document.head.appendChild(style);
   }
@@ -1790,6 +1670,7 @@
   function cleanupDom() {
     for (const card of Array.from(adaptedCards)) clearCompatibility(card);
     adaptedCards.clear();
+    restoreFooterPresentation();
     pane?.removeEventListener("click", handleNativePaneClick, true);
     document.querySelectorAll(`.${HOST_CLASS}`).forEach((element) => {
       element.classList.remove(HOST_CLASS);
@@ -1953,6 +1834,7 @@
       return;
     }
     bridge = await waitForBridge();
+    installNativeWebsocketProjection();
     bridge.subscribe("phase-change", handlePhaseChange);
     bridge.subscribe("champion-locked", () => {
       if (active) refreshSelection(true);

--- a/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
@@ -76,6 +76,9 @@
   let lastVisualCenterRawSkinId = 0;
   let lastLayoutKey = "";
   let lastVisualProtectionKey = "";
+  let lastReadRewriteKey = "";
+  let refreshNativeSkinPresentation = null;
+  let latestNativeSkinSelectorEvent = null;
   let lastCatalogSyncKey = "";
   let visualProtectionClearTimer = null;
 
@@ -186,6 +189,36 @@
     return String(init?.method || input?.method || "GET").toUpperCase();
   }
 
+  function rewriteSessionSelection(data, desiredRawSkinId) {
+    if (!data || typeof data !== "object") return false;
+    const localCellId = numeric(data.localPlayerCellId);
+    if (localCellId === null || !Array.isArray(data.myTeam)) return false;
+    const localPlayer = data.myTeam.find(
+      (player) => numeric(player?.cellId) === localCellId
+    );
+    if (!localPlayer || numeric(localPlayer.selectedSkinId) === desiredRawSkinId) {
+      return false;
+    }
+    localPlayer.selectedSkinId = desiredRawSkinId;
+    return true;
+  }
+
+  function rewriteNativeRead(path, data) {
+    const protection = window.__roseJadeVisualProtection;
+    const desiredRawSkinId = numeric(protection?.desiredRawSkinId);
+    if (!active || !protection?.active || !desiredRawSkinId) return false;
+    if (path === "/lol-champ-select/v1/skin-selector-info") {
+      if (!data || typeof data !== "object") return false;
+      if (numeric(data.selectedSkinId) === desiredRawSkinId) return false;
+      data.selectedSkinId = desiredRawSkinId;
+      return true;
+    }
+    if (path === "/lol-champ-select/v1/session") {
+      return rewriteSessionSelection(data, desiredRawSkinId);
+    }
+    return false;
+  }
+
   function shouldSuppressVisualRollback(selectedSkinId) {
     const protection = window.__roseJadeVisualProtection;
     if (!active || !protection?.active) return false;
@@ -197,6 +230,20 @@
     return selected !== null && desired !== null && selected !== desired && defaults.has(selected);
   }
 
+  function cloneWebsocketEvent(event, payload) {
+    try {
+      return new MessageEvent(event.type || "message", {
+        data: JSON.stringify(payload),
+        origin: event.origin,
+        lastEventId: event.lastEventId,
+        source: event.source,
+        ports: event.ports,
+      });
+    } catch (_) {
+      return { data: JSON.stringify(payload) };
+    }
+  }
+
   function installNativeWebsocketProjection() {
     if (installNativeWebsocketProjection.registered || !window.rcp?.postInit) return;
     installNativeWebsocketProjection.registered = true;
@@ -205,6 +252,22 @@
         const ws = api.champSelectBinding.socket._websocket;
         if (!ws || ws.__roseJadeReadProjection) return;
         const parentOnMessage = ws.onmessage;
+        refreshNativeSkinPresentation = (desiredRawSkinId) => {
+          if (!active || !latestNativeSkinSelectorEvent || !desiredRawSkinId) return;
+          const payload = JSON.parse(JSON.stringify(latestNativeSkinSelectorEvent.payload));
+          const selectedChampionId = numeric(payload[2]?.data?.selectedChampionId);
+          if (selectedChampionId && selectedChampionId !== Math.floor(desiredRawSkinId / 1000)) {
+            return;
+          }
+          payload[2].data.selectedSkinId = desiredRawSkinId;
+          parentOnMessage.call(
+            ws,
+            cloneWebsocketEvent(latestNativeSkinSelectorEvent.event, payload)
+          );
+          log("info", "Refreshed native classic skin presentation", {
+            selectedSkinId: desiredRawSkinId,
+          });
+        };
         ws.onmessage = function roseJadeProjectedMessage(event) {
           try {
             const payload = JSON.parse(event.data);
@@ -214,14 +277,27 @@
             const eventData = payload[2];
             if (eventData?.uri === "/lol-champ-select/v1/skin-selector-info") {
               const selectedSkinId = eventData.data?.selectedSkinId;
+              latestNativeSkinSelectorEvent = { event, payload };
               if (shouldSuppressVisualRollback(selectedSkinId)) {
-                // ROSE-UI keeps an unowned regular skin visible by withholding
-                // the base-skin rollback event. JADE uses the same contract.
-                log("info", "Suppressed classic selector rollback", {
+                eventData.data.selectedSkinId = numeric(
+                  window.__roseJadeVisualProtection?.desiredRawSkinId
+                );
+                log("info", "Projected classic selector rollback", {
                   selectedSkinId,
-                  desiredSkinId: window.__roseJadeVisualProtection?.desiredRawSkinId,
+                  projectedSkinId: eventData.data.selectedSkinId,
                 });
-                return;
+                return parentOnMessage.call(this, cloneWebsocketEvent(event, payload));
+              }
+            } else if (eventData?.uri === "/lol-champ-select/v1/session") {
+              const protection = window.__roseJadeVisualProtection;
+              if (
+                protection?.active &&
+                rewriteSessionSelection(
+                  eventData.data,
+                  numeric(protection.desiredRawSkinId)
+                )
+              ) {
+                return parentOnMessage.call(this, cloneWebsocketEvent(event, payload));
               }
             }
           } catch (error) {
@@ -262,7 +338,43 @@
           // Let malformed or unrelated requests follow the native path.
         }
       }
-      return nativeFetch(input, init);
+      const response = await nativeFetch(input, init);
+      if (
+        method !== "GET" ||
+        !response?.ok ||
+        (path !== "/lol-champ-select/v1/skin-selector-info" &&
+          path !== "/lol-champ-select/v1/session")
+      ) {
+        return response;
+      }
+      try {
+        const data = await response.clone().json();
+        if (!rewriteNativeRead(path, data)) return response;
+        const desiredRawSkinId = numeric(
+          window.__roseJadeVisualProtection?.desiredRawSkinId
+        ) || 0;
+        const rewriteKey = `${path}|${desiredRawSkinId}`;
+        if (rewriteKey !== lastReadRewriteKey) {
+          lastReadRewriteKey = rewriteKey;
+          log("info", "Projected classic visual selection into native read", {
+            path,
+            desiredRawSkinId,
+          });
+        }
+        const headers = new Headers(response.headers);
+        headers.delete("content-length");
+        return new Response(JSON.stringify(data), {
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+        });
+      } catch (error) {
+        log("warn", "Classic native read projection failed", {
+          path,
+          error: String(error),
+        });
+        return response;
+      }
     };
     projectedFetch.__roseJadeReadProjection = true;
     window.fetch = projectedFetch;
@@ -271,6 +383,9 @@
   function syncVisualSelection(entry, reason, userInitiated = false) {
     if (!bridge || !entry?.name || !entry.resourceSkinId) return;
     if (userInitiated) selectionGeneration += 1;
+    if (visualRollbackProtectionActive) {
+      refreshNativeSkinPresentation?.(entry.rawSkinId);
+    }
     try {
       // Python validates this ID against the active JADE carousel before it
       // updates the same injection state used by regular champion select.
@@ -496,6 +611,32 @@
     return catalog.map(catalogAssetDetails).filter(Boolean);
   }
 
+  function resolveModeCarrierRawSkinId(rawEntries, pickableSkinIds) {
+    const entryIds = new Set(
+      rawEntries.map((entry) => numeric(entry?.id ?? entry?.skinId) || 0).filter(Boolean)
+    );
+    const pickable = pickableSkinIds.filter((value) => entryIds.has(value));
+    const isSpecialCarrier = (value) => value % 1000 === 301 || value % 1000 === 302;
+    const declaredDefault = rawEntries.find(
+      (entry) => entry?.isBase === true || entry?.isDefault === true
+    );
+    const declaredDefaultId = numeric(declaredDefault?.id ?? declaredDefault?.skinId) || 0;
+
+    // JADE initially selects its champion carrier. Preserve Skin301/Skin302
+    // when present; Skin0 is the carrier only for champions without one.
+    return (
+      (entryIds.has(selectedRawSkinId) && isSpecialCarrier(selectedRawSkinId)
+        ? selectedRawSkinId
+        : 0) ||
+      pickable.find(isSpecialCarrier) ||
+      declaredDefaultId ||
+      (entryIds.has(selectedRawSkinId) ? selectedRawSkinId : 0) ||
+      pickable[0] ||
+      [...entryIds][0] ||
+      0
+    );
+  }
+
   function getModeSkinData(rawSkinId) {
     const id = numeric(rawSkinId);
     if (!active || id === null) return null;
@@ -582,6 +723,13 @@
     clearUserNavigation();
     setVisualProtection(entry, reason, visualRollbackProtectionActive);
     scheduleNativeProjection(projectedCatalogIndex, () => {
+      if (
+        active &&
+        desiredVisualSelection?.rawSkinId === entry.rawSkinId &&
+        visualRollbackProtectionActive
+      ) {
+        refreshNativeSkinPresentation?.(entry.rawSkinId);
+      }
       if (typeof onComplete === "function") onComplete();
     });
     adaptNativeController();
@@ -1331,29 +1479,25 @@
       const rawEntries = (Array.isArray(modeSkins) ? modeSkins : []).filter(
         (entry) => Math.floor((numeric(entry?.id ?? entry?.skinId) || 0) / 1000) === rawChampionId
       );
-      const declaredDefault = rawEntries.find(
-        (entry) => entry?.isBase === true || entry?.isDefault === true
-      );
-      modeDefaultRawSkinId = numeric(declaredDefault?.id ?? declaredDefault?.skinId) || 0;
+      let candidates = [];
       try {
         const pickableSkinIds = await fetchJson(
           "/lol-lobby-team-builder/champ-select/v1/pickable-skin-ids"
         );
         if (!active || generation !== requestGeneration) return;
-        const candidates = (Array.isArray(pickableSkinIds) ? pickableSkinIds : [])
+        candidates = (Array.isArray(pickableSkinIds) ? pickableSkinIds : [])
           .map((value) => numeric(value) || 0)
           .filter((value) => Math.floor(value / 1000) === rawChampionId);
-        modeDefaultRawSkinId = modeDefaultRawSkinId
-          || candidates.find((value) => value === selectedRawSkinId)
-          || candidates[0]
-          || 0;
       } catch (error) {
         log("debug", "Waiting for classic default skin catalog", String(error));
       }
-      if (!modeDefaultRawSkinId) {
-        modeDefaultRawSkinId = numeric(rawEntries[0]?.id ?? rawEntries[0]?.skinId) || 0;
-      }
+      modeDefaultRawSkinId = resolveModeCarrierRawSkinId(rawEntries, candidates);
       if (!modeDefaultRawSkinId) return;
+      log("info", "Classic champion carrier resolved", {
+        rawChampionId,
+        carrierRawSkinId: modeDefaultRawSkinId,
+        initialSelectedRawSkinId: selectedRawSkinId,
+      });
     }
     const nextCatalog = (Array.isArray(modeSkins) ? modeSkins : [])
       .map(normalizeCatalogEntry)
@@ -1566,6 +1710,8 @@
     pointerSelectionCommitted = false;
     lastVisualCenterRawSkinId = 0;
     lastVisualProtectionKey = "";
+    lastReadRewriteKey = "";
+    latestNativeSkinSelectorEvent = null;
     refreshInFlight = false;
     if (visualProtectionClearTimer) clearTimeout(visualProtectionClearTimer);
     visualProtectionClearTimer = setTimeout(() => {

--- a/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
@@ -29,6 +29,7 @@
   const EMPTY_CLASS = "rose-jade-native-card--empty";
   const ACTIVE_ROOT_CLASS = "rose-jade-wheel-active";
   const VISUAL_PROTECTION_EVENT = "rose-jade-visual-protection";
+  const SELECTION_CHANGE_EVENT = "rose-classic-selection-change";
   const POLL_INTERVAL_MS = 450;
   const CATALOG_REFRESH_MS = 2000;
   const USER_NAVIGATION_WINDOW_MS = 6000;
@@ -82,12 +83,17 @@
   let historicRestoreGeneration = 0;
   let historicRestoreInProgress = false;
   let randomModeActive = false;
+  let pendingRandomResourceSkinId = 0;
+  let appliedRandomResourceSkinId = 0;
+  let randomProjectionSuppressed = false;
   let visualCarrierProtectionActive = false;
   let projectedVariantRawSkinId = 0;
   let lastVisualCenterRawSkinId = 0;
   let lastLayoutKey = "";
   let lastVisualProtectionKey = "";
   let lastReadRewriteKey = "";
+  let refreshNativeSkinPresentation = null;
+  let latestNativeSkinSelectorEvent = null;
   let lastCatalogSyncKey = "";
   let visualProtectionClearTimer = null;
 
@@ -275,6 +281,22 @@
         const ws = api.champSelectBinding.socket._websocket;
         if (!ws || ws.__roseJadeReadProjection) return;
         const parentOnMessage = ws.onmessage;
+        refreshNativeSkinPresentation = (desiredRawSkinId) => {
+          if (!active || !latestNativeSkinSelectorEvent || !desiredRawSkinId) return;
+          const payload = JSON.parse(JSON.stringify(latestNativeSkinSelectorEvent.payload));
+          const selectedChampionId = numeric(payload[2]?.data?.selectedChampionId);
+          if (selectedChampionId && selectedChampionId !== Math.floor(desiredRawSkinId / 1000)) {
+            return;
+          }
+          payload[2].data.selectedSkinId = desiredRawSkinId;
+          parentOnMessage.call(
+            ws,
+            cloneWebsocketEvent(latestNativeSkinSelectorEvent.event, payload)
+          );
+          log("info", "Refreshed native classic skin presentation", {
+            selectedSkinId: desiredRawSkinId,
+          });
+        };
         ws.onmessage = function roseJadeProjectedMessage(event) {
           try {
             const payload = JSON.parse(event.data);
@@ -284,9 +306,16 @@
             const eventData = payload[2];
             if (eventData?.uri === "/lol-champ-select/v1/skin-selector-info") {
               const selectedSkinId = eventData.data?.selectedSkinId;
+              latestNativeSkinSelectorEvent = { event, payload };
               if (shouldSuppressVisualRollback(selectedSkinId)) {
-                log("info", "Suppressed classic selector rollback", { selectedSkinId });
-                return;
+                eventData.data.selectedSkinId = numeric(
+                  window.__roseJadeVisualProtection?.desiredRawSkinId
+                );
+                log("info", "Projected classic selector rollback", {
+                  selectedSkinId,
+                  projectedSkinId: eventData.data.selectedSkinId,
+                });
+                return parentOnMessage.call(this, cloneWebsocketEvent(event, payload));
               }
             } else if (eventData?.uri === "/lol-champ-select/v1/session") {
               const protection = window.__roseJadeVisualProtection;
@@ -318,14 +347,14 @@
       const method = requestMethod(input, init);
       if (
         active &&
-        visualCarrierProtectionActive &&
         method === "PATCH" &&
         path === "/lol-champ-select/v1/session/my-selection"
       ) {
         try {
           const body = JSON.parse(String(init?.body || "{}"));
           const requestedRawSkinId = numeric(body.selectedSkinId) || 0;
-          if (catalogEntryForRawSkinId(requestedRawSkinId)) {
+          const requestedEntry = catalogEntryForRawSkinId(requestedRawSkinId);
+          if (requestedEntry && !requestedEntry.available && !requestedEntry.isBase) {
             log("info", "Deferred classic LCU write to finalization", {
               requestedRawSkinId,
             });
@@ -380,6 +409,9 @@
   function syncVisualSelection(entry, reason, userInitiated = false) {
     if (!bridge || !entry?.name || !entry.resourceSkinId) return;
     if (userInitiated) selectionGeneration += 1;
+    if (userInitiated && visualCarrierProtectionActive) {
+      refreshNativeSkinPresentation?.(entry.rawSkinId);
+    }
     try {
       // Python validates this ID against the active JADE carousel before it
       // updates the same injection state used by regular champion select.
@@ -399,6 +431,7 @@
         rawChampionId: entry.rawChampionId,
         baseRawSkinId: modeDefaultRawSkinId || fallbackModeDefaultRawSkinId(),
         catalog: catalogBridgeEntries(),
+        randomEligibleRawSkinIds: catalog.map((item) => item.rawSkinId),
         source: "jade-wheel",
         reason,
         userInitiated,
@@ -406,6 +439,7 @@
         available: entry.available === true,
         timestamp: Date.now(),
       });
+      dispatchSelectionChange(reason);
       log("info", "Classic visual skin synced", {
         reason,
         rawSkinId: entry.rawSkinId,
@@ -467,6 +501,7 @@
       selectedRawSkinId,
       baseRawSkinId,
       catalog: entries,
+      randomEligibleRawSkinIds: catalog.map((entry) => entry.rawSkinId),
       reason,
       timestamp: Date.now(),
     });
@@ -685,7 +720,11 @@
     return null;
   }
 
-  function projectResourceSelection(resourceId, reason = "external-state") {
+  function projectResourceSelection(
+    resourceId,
+    reason = "external-state",
+    onComplete = null
+  ) {
     if (!active || !catalog.length) return false;
     const selection = catalogSelectionForResourceSkinId(resourceId);
     if (!selection) return false;
@@ -701,8 +740,17 @@
     lastVisualCenterRawSkinId = 0;
     clearUserNavigation();
     setVisualProtection(entry, reason, visualCarrierProtectionActive);
-    scheduleNativeProjection(projectedCatalogIndex);
+    scheduleNativeProjection(projectedCatalogIndex, () => {
+      if (
+        active && desiredVisualSelection?.rawSkinId === entry.rawSkinId &&
+        visualCarrierProtectionActive
+      ) {
+        refreshNativeSkinPresentation?.(entry.rawSkinId);
+      }
+      if (typeof onComplete === "function") onComplete();
+    });
     adaptNativeController();
+    dispatchSelectionChange(reason);
     log("info", "Classic resource selection projected into native selector", {
       reason,
       resourceSkinId: numeric(resourceId) || 0,
@@ -731,9 +779,9 @@
     ) {
       return;
     }
-    if (projectResourceSelection(resourceId, "historic-restore")) {
-      const selection = catalogSelectionForResourceSkinId(resourceId);
-      scheduleNativeProjection(projectedCatalogIndex, () => {
+    const selection = catalogSelectionForResourceSkinId(resourceId);
+    if (
+      projectResourceSelection(resourceId, "historic-restore", () => {
         if (
           !active || generation !== historicRestoreGeneration ||
           pendingHistoricResourceSkinId !== resourceId
@@ -749,12 +797,13 @@
         window.dispatchEvent(new CustomEvent("rose-jade-historic-presentation", {
           detail: presentation,
         }));
-        log("info", "Classic history projected after native default staging", {
+        log("info", "Classic history projected into native selector", {
           historicResourceSkinId: resourceId,
           visualRawSkinId: selection?.entry?.rawSkinId || 0,
           variantRawSkinId: selection?.rawSkinId || 0,
         });
-      });
+      })
+    ) {
       return;
     }
     historicRestoreInProgress = false;
@@ -778,36 +827,11 @@
         return;
       }
       if (historicRestoreInProgress) return;
-      const defaultEntry = catalog.find((entry) => entry.isBase) || null;
-      if (!defaultEntry || defaultEntry === selection.entry) {
-        finishHistoricVisualSelection(
-          pendingHistoricResourceSkinId,
-          historicRestoreGeneration
-        );
-        return;
-      }
       historicRestoreInProgress = true;
       const resourceId = pendingHistoricResourceSkinId;
       const generation = ++historicRestoreGeneration;
-      setHistoricPresentationReady(false, "historic-default-stage");
-      visualCarrierProtectionActive = false;
-      projectedVariantRawSkinId = defaultEntry.rawSkinId;
-      desiredVisualSelection = defaultEntry;
-      projectedCatalogIndex = catalog.indexOf(defaultEntry);
-      lastVisualCenterRawSkinId = 0;
-      clearUserNavigation();
-      setVisualProtection(null, "historic-default-stage");
-      adaptNativeController();
-      scheduleNativeProjection(projectedCatalogIndex, () => {
-        setTimeout(
-          () => finishHistoricVisualSelection(resourceId, generation),
-          100
-        );
-      });
-      log("info", "Classic history restore staged from native default", {
-        historicResourceSkinId: resourceId,
-        defaultRawSkinId: defaultEntry.rawSkinId,
-      });
+      setHistoricPresentationReady(false, "historic-restore");
+      finishHistoricVisualSelection(resourceId, generation);
       return;
     }
     cancelHistoricVisualRestore("historic-default", true);
@@ -827,31 +851,64 @@
       : 0;
     if (!pendingHistoricResourceSkinId) {
       cancelHistoricVisualRestore("historic-disabled", true);
+      cancelNativeProjection();
       lastAppliedHistoricResourceSkinId = 0;
     }
     if (pendingHistoricResourceSkinId) applyHistoricVisualSelection();
   }
 
   function handleRandomModeState(data) {
+    const wasActive = randomModeActive;
     randomModeActive = data?.active === true;
-    if (!randomModeActive) return;
+    if (!randomModeActive) {
+      if (wasActive && appliedRandomResourceSkinId) cancelNativeProjection();
+      pendingRandomResourceSkinId = 0;
+      appliedRandomResourceSkinId = 0;
+      randomProjectionSuppressed = false;
+      return;
+    }
     cancelHistoricVisualRestore("random-mode", true);
     pendingHistoricResourceSkinId = 0;
     lastAppliedHistoricResourceSkinId = 0;
-    projectedVariantRawSkinId = 0;
-    clearUserNavigation();
-    const defaultEntry = catalog.find((entry) => entry.isBase) || null;
-    if (!defaultEntry) return;
-    visualCarrierProtectionActive = false;
-    desiredVisualSelection = defaultEntry;
-    projectedCatalogIndex = catalog.indexOf(defaultEntry);
-    lastVisualCenterRawSkinId = 0;
-    setVisualProtection(null, "random-default-presentation");
-    adaptNativeController();
-    scheduleNativeProjection(projectedCatalogIndex);
-    log("info", "Random mode skipped history and centered the classic default", {
-      rawSkinId: defaultEntry.rawSkinId,
-      resourceSkinId: defaultEntry.resourceSkinId,
+    const nextRandomResourceSkinId = numeric(data?.randomSkinId) || 0;
+    const resultChanged = nextRandomResourceSkinId !== pendingRandomResourceSkinId;
+    if (resultChanged) appliedRandomResourceSkinId = 0;
+    pendingRandomResourceSkinId = nextRandomResourceSkinId;
+    if (!wasActive || resultChanged) {
+      cancelNativeProjection();
+      clearUserNavigation();
+    }
+    if (!wasActive) randomProjectionSuppressed = false;
+    applyPendingRandomVisualSelection();
+  }
+
+  function randomProjectionReady() {
+    return phase === "FINALIZATION" || phase === "GameStart";
+  }
+
+  function applyPendingRandomVisualSelection() {
+    if (
+      !active || !randomModeActive || randomProjectionSuppressed ||
+      !pendingRandomResourceSkinId || !randomProjectionReady() || !catalog.length
+    ) {
+      return;
+    }
+    const selection = catalogSelectionForResourceSkinId(pendingRandomResourceSkinId);
+    if (!selection) return;
+    if (pendingRandomResourceSkinId === appliedRandomResourceSkinId) {
+      projectedVariantRawSkinId = selection.rawSkinId;
+      visualCarrierProtectionActive = !selection.entry.isBase;
+      desiredVisualSelection = selection.entry;
+      projectedCatalogIndex = catalog.indexOf(selection.entry);
+      setVisualProtection(selection.entry, "random-catalog-refresh", true);
+      adaptNativeController();
+      return;
+    }
+    if (!projectResourceSelection(pendingRandomResourceSkinId, "random-state")) return;
+    appliedRandomResourceSkinId = pendingRandomResourceSkinId;
+    log("info", "Classic random result projected during finalization", {
+      rawSkinId: selection.rawSkinId,
+      resourceSkinId: resourceSkinId(selection.rawSkinId),
     });
   }
 
@@ -1142,10 +1199,27 @@
   }
 
   function beginUserNavigation(targetRawSkinId = 0) {
-    if (pendingHistoricResourceSkinId || lastAppliedHistoricResourceSkinId) {
-      setHistoricPresentationReady(false, "user-navigation");
+    const targetId = numeric(targetRawSkinId) || 0;
+    const targetEntry = targetId ? catalogEntryForRawSkinId(targetId) : null;
+    if (
+      historicRestoreInProgress || pendingHistoricResourceSkinId ||
+      lastAppliedHistoricResourceSkinId
+    ) {
+      cancelHistoricVisualRestore("user-navigation", true);
+      pendingHistoricResourceSkinId = 0;
+      lastAppliedHistoricResourceSkinId = 0;
     }
-    if (visualCarrierProtectionActive) {
+    cancelNativeProjection();
+    if (randomModeActive) {
+      appliedRandomResourceSkinId = 0;
+      randomProjectionSuppressed = true;
+    }
+    if (targetEntry && !targetEntry.available && !targetEntry.isBase) {
+      visualCarrierProtectionActive = true;
+      desiredVisualSelection = targetEntry;
+      projectedCatalogIndex = catalog.indexOf(targetEntry);
+      setVisualProtection(targetEntry, "user-navigation-target", true);
+    } else if (visualCarrierProtectionActive && (!targetId || targetEntry?.isBase)) {
       visualCarrierProtectionActive = false;
       projectedCatalogIndex = -1;
       setVisualProtection(null, "user-navigation");
@@ -1154,7 +1228,7 @@
     }
     pendingUserNavigation = true;
     pendingUserNavigationUntil = Date.now() + USER_NAVIGATION_WINDOW_MS;
-    pendingUserTargetRawSkinId = numeric(targetRawSkinId) || 0;
+    pendingUserTargetRawSkinId = targetId;
     pendingUserSelectionPublished = false;
   }
 
@@ -1179,6 +1253,14 @@
     projectedCatalogIndex = catalog.indexOf(entry);
     syncVisualSelection(entry, reason, true);
     pendingUserSelectionPublished = true;
+  }
+
+  function cancelNativeProjection() {
+    if (nativeProjectionTimer) clearTimeout(nativeProjectionTimer);
+    nativeProjectionTimer = null;
+    nativeProjectionTargetIndex = -1;
+    nativeProjectionCurrentIndex = -1;
+    nativeProjectionComplete = null;
   }
 
   function scheduleNativeProjection(targetIndex, onComplete = null) {
@@ -1323,7 +1405,13 @@
     if (active && (event.key === "ArrowLeft" || event.key === "ArrowRight")) {
       pendingHistoricResourceSkinId = 0;
       projectedVariantRawSkinId = 0;
-      beginUserNavigation();
+      const cards = nativeCards();
+      const centerCard = selectedNativeCard(cards);
+      const centerEntry = centerCard ? matchCardToCatalog(centerCard) : null;
+      const currentIndex = centerEntry ? catalog.indexOf(centerEntry) : -1;
+      const direction = event.key === "ArrowLeft" ? -1 : 1;
+      const target = currentIndex >= 0 ? catalog[currentIndex + direction] : null;
+      beginUserNavigation(target?.rawSkinId || 0);
     }
   }
 
@@ -1356,8 +1444,7 @@
     );
     if (!anchor) {
       anchor = document.createElement("div");
-      anchor.className =
-        "rose-jade-history-anchor skin-selection-item-information loyalty-reward-icon--rewards";
+      anchor.className = "rose-jade-history-anchor";
       centerCard.appendChild(anchor);
     }
   }
@@ -1440,8 +1527,7 @@
           lcuResourceSkinId: visualCenterEntry?.resourceSkinId || selectedResourceSkinId,
         });
       } else if (!isIntermediateUserNavigation) {
-        visualCarrierProtectionActive =
-          !centerEntry.available && !centerEntry.isBase;
+        visualCarrierProtectionActive = !centerEntry.available && !centerEntry.isBase;
         setVisualProtection(
           centerEntry,
           "visual-center-change",
@@ -1569,6 +1655,7 @@
     catalog = nextCatalog;
     syncModeCatalog(force ? "forced-refresh" : "refresh");
     applyHistoricVisualSelection();
+    applyPendingRandomVisualSelection();
   }
 
   async function refreshSelection(forceCatalog = false) {
@@ -1590,6 +1677,8 @@
         visualCarrierProtectionActive = false;
         projectedCatalogIndex = -1;
         lastAppliedHistoricResourceSkinId = 0;
+        appliedRandomResourceSkinId = 0;
+        randomProjectionSuppressed = false;
         projectedVariantRawSkinId = 0;
         setVisualProtection(null, "champion-change");
         desiredVisualSelection = null;
@@ -1604,6 +1693,7 @@
       }
       await loadModeCatalog(forceCatalog || championChanged || !catalog.length);
       adaptNativeController();
+      dispatchSelectionChange(championChanged ? "champion-change" : "selection-refresh");
     } catch (error) {
       log("debug", "Waiting for native classic skin selector", String(error));
     } finally {
@@ -1765,6 +1855,9 @@
     cancelHistoricVisualRestore("runtime-stop", true);
     nativeProjectionComplete = null;
     randomModeActive = false;
+    pendingRandomResourceSkinId = 0;
+    appliedRandomResourceSkinId = 0;
+    randomProjectionSuppressed = false;
     projectedVariantRawSkinId = 0;
     pointerSelectionRawSkinId = 0;
     pointerSelectionUntil = 0;
@@ -1772,6 +1865,7 @@
     lastVisualCenterRawSkinId = 0;
     lastVisualProtectionKey = "";
     lastReadRewriteKey = "";
+    latestNativeSkinSelectorEvent = null;
     refreshInFlight = false;
     if (visualProtectionClearTimer) clearTimeout(visualProtectionClearTimer);
     visualProtectionClearTimer = setTimeout(() => {
@@ -1815,7 +1909,42 @@
     mapId = data.mapId ?? mapId;
     queueId = data.queueId ?? queueId;
     reconcileRuntime();
+    applyPendingRandomVisualSelection();
     if (isChampSelectPhase() && !isJadeClassicContext()) syncContextFromLcu();
+  }
+
+  function currentSelection() {
+    if (!active) return null;
+    const rawSkinId = numeric(
+      projectedVariantRawSkinId ||
+      desiredVisualSelection?.rawSkinId ||
+      selectedRawSkinId
+    ) || 0;
+    const catalogEntry = catalogEntryForRawSkinId(rawSkinId);
+    if (!catalogEntry || !rawSkinId) return null;
+    const parentEntry = catalogEntry.rawSkin;
+    const selectedEntry = catalogEntry.rawSkinId === rawSkinId
+      ? parentEntry
+      : variantsOf(parentEntry).find(
+          (entry) => numeric(entry?.id ?? entry?.skinId) === rawSkinId
+        ) || parentEntry;
+    return {
+      championId,
+      rawChampionId,
+      skinId: resourceSkinId(rawSkinId),
+      rawSkinId,
+      selectedEntry,
+      parentEntry,
+    };
+  }
+
+  function dispatchSelectionChange(reason) {
+    window.dispatchEvent(new CustomEvent(SELECTION_CHANGE_EVENT, {
+      detail: {
+        reason: String(reason || ""),
+        selection: currentSelection(),
+      },
+    }));
   }
 
   async function start() {
@@ -1834,8 +1963,9 @@
     log("info", "Plugin initialized");
   }
 
-  window.__roseJadeWheelDebug = {
+  const classicWheelApi = {
     refresh: () => refreshSelection(true),
+    currentSelection,
     state: () => ({
       active,
       phase,
@@ -1862,6 +1992,8 @@
     catalogData: () => catalog.map((entry) => entry.rawSkin),
     projectResourceSelection,
   };
+  window.__roseClassicWheelApi = classicWheelApi;
+  window.__roseJadeWheelDebug = classicWheelApi;
 
   start().catch((error) => log("error", "Plugin initialization failed", String(error)));
 })();

--- a/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
+++ b/Pengu Loader/plugins/ROSE-ClassicWheel/index.js
@@ -1,0 +1,1867 @@
+/**
+ * @name ROSE-ClassicWheel
+ * @author Rose contributors
+ * @description Compatibility adapter for the native JADE skin selector.
+ */
+(function initJadeWheelAdapter() {
+  "use strict";
+
+  const LOG_PREFIX = "[JadeWheel]";
+  const JADE_MODE = "JADE";
+  const JADE_MAP_ID = 453;
+  const JADE_CHAMPION_OFFSET = 60000;
+  const JADE_CHAMPION_MIN = 60001;
+  const JADE_CHAMPION_MAX = 60999;
+  const JADE_FALLBACK_DEFAULT_SKIN_NUMBER = 301;
+  const JADE_DEFAULT_CARRIER_OVERRIDES = new Map([
+    ...[
+      2, 15, 21, 22, 23, 26, 27, 31, 32, 33, 34, 35, 37, 40,
+      42, 45, 53, 54, 59, 62, 63, 67, 79, 89, 90, 96, 99, 117,
+    ].map((champion) => [champion, 0]),
+    [10, 302],
+  ]);
+  const ROOT_ID = "rose-jade-skin-wheel";
+  const STYLE_ID = "rose-jade-skin-wheel-styles";
+  const HOST_CLASS = "rose-jade-native-host";
+  const CARD_CLASS = "rose-jade-native-card";
+  const SELECTED_CLASS = "rose-jade-native-card--selected";
+  const UNLOCKED_CLASS = "rose-jade-native-card--unlocked";
+  const EMPTY_CLASS = "rose-jade-native-card--empty";
+  const ACTIVE_ROOT_CLASS = "rose-jade-wheel-active";
+  const VISUAL_PROTECTION_EVENT = "rose-jade-visual-protection";
+  const POLL_INTERVAL_MS = 450;
+  const CATALOG_REFRESH_MS = 2000;
+  const USER_NAVIGATION_WINDOW_MS = 6000;
+  const nativeFetch = window.fetch.bind(window);
+  const COMPATIBILITY_CLASSES = [
+    CARD_CLASS,
+    SELECTED_CLASS,
+  ];
+
+  let bridge = null;
+  let active = false;
+  let phase = null;
+  let gameMode = null;
+  let mapId = null;
+  let queueId = null;
+  let pane = null;
+  let overlay = null;
+  let observer = null;
+  let pollTimer = null;
+  let refreshInFlight = false;
+  let requestGeneration = 0;
+  let selectionGeneration = 0;
+  let rawChampionId = 0;
+  let championId = 0;
+  let selectedRawSkinId = 0;
+  let selectedResourceSkinId = 0;
+  let modeDefaultRawSkinId = 0;
+  let catalog = [];
+  let catalogLoadedAt = 0;
+  let adaptedCards = new Set();
+  const originalCardState = new WeakMap();
+  const adaptedCardState = new WeakMap();
+  const projectedImageState = new WeakMap();
+  const lockOverlayState = new WeakMap();
+  let desiredVisualSelection = null;
+  let projectedCatalogIndex = -1;
+  let nativeProjectionTargetIndex = -1;
+  let nativeProjectionCurrentIndex = -1;
+  let nativeProjectionTimer = null;
+  let nativeProjectionComplete = null;
+  let drivingNativeProjection = false;
+  let pendingUserNavigation = false;
+  let pendingUserNavigationUntil = 0;
+  let pendingUserTargetRawSkinId = 0;
+  let pendingUserSelectionPublished = false;
+  let pointerSelectionRawSkinId = 0;
+  let pointerSelectionUntil = 0;
+  let pointerSelectionCommitted = false;
+  let pendingHistoricResourceSkinId = 0;
+  let lastAppliedHistoricResourceSkinId = 0;
+  let historicRestoreGeneration = 0;
+  let historicRestoreInProgress = false;
+  let randomModeActive = false;
+  let visualCarrierProtectionActive = false;
+  let projectedVariantRawSkinId = 0;
+  let lastVisualCenterRawSkinId = 0;
+  let lastLayoutKey = "";
+  let lastVisualProtectionKey = "";
+  let lastReadRewriteKey = "";
+  let lastCatalogSyncKey = "";
+  let visualProtectionClearTimer = null;
+
+  function waitForBridge() {
+    return new Promise((resolve) => {
+      const startedAt = Date.now();
+      let warned = false;
+      const check = () => {
+        if (window.__roseBridge) {
+          resolve(window.__roseBridge);
+          return;
+        }
+        if (!warned && Date.now() - startedAt >= 10000) {
+          warned = true;
+          console.warn(`${LOG_PREFIX} bridge is still unavailable`);
+        }
+        setTimeout(check, 50);
+      };
+      check();
+    });
+  }
+
+  function log(level, message, data = null) {
+    const method = level === "error" ? "error" : level === "warn" ? "warn" : "log";
+    console[method](`${LOG_PREFIX} ${message}`, data || "");
+    if (!bridge) return;
+    try {
+      bridge.send({
+        type: "chroma-log",
+        source: "JadeWheel",
+        level,
+        message,
+        data,
+        timestamp: Date.now(),
+      });
+    } catch (_) {
+      // The shared bridge owns reconnect handling.
+    }
+  }
+
+  function numeric(value) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  function isJadeChampionId(value) {
+    const id = numeric(value);
+    return id !== null && id >= JADE_CHAMPION_MIN && id <= JADE_CHAMPION_MAX;
+  }
+
+  function resourceChampionId(value) {
+    const id = numeric(value) || 0;
+    return isJadeChampionId(id) ? id - JADE_CHAMPION_OFFSET : id;
+  }
+
+  function resourceSkinId(value) {
+    const id = numeric(value) || 0;
+    const rawChampion = Math.floor(id / 1000);
+    if (!isJadeChampionId(rawChampion)) return id;
+
+    const resourceChampion = resourceChampionId(rawChampion);
+    const skinNumber = id % 1000;
+    return resourceChampion * 1000 + skinNumber;
+  }
+
+  function jadeSkinId(value) {
+    const id = numeric(value) || 0;
+    const resourceChampion = Math.floor(id / 1000);
+    if (isJadeChampionId(resourceChampion)) return id;
+    if (resourceChampion <= 0 || resourceChampion >= 1000) return id;
+    return (JADE_CHAMPION_OFFSET + resourceChampion) * 1000 + (id % 1000);
+  }
+
+  function fallbackModeDefaultRawSkinId() {
+    if (!isJadeChampionId(rawChampionId)) return 0;
+    const skinNumber = JADE_DEFAULT_CARRIER_OVERRIDES.get(championId)
+      ?? JADE_FALLBACK_DEFAULT_SKIN_NUMBER;
+    return rawChampionId * 1000 + skinNumber;
+  }
+
+  function isModeDefaultRawSkinId(value) {
+    const id = numeric(value) || 0;
+    const expected = modeDefaultRawSkinId || fallbackModeDefaultRawSkinId();
+    return id > 0 && expected > 0 && id === expected;
+  }
+
+  function isModeDefaultResourceSkinId(value) {
+    const id = resourceSkinId(value);
+    const expected = resourceSkinId(
+      modeDefaultRawSkinId || fallbackModeDefaultRawSkinId()
+    );
+    return id > 0 && expected > 0 && id === expected;
+  }
+
+  async function fetchJson(endpoint) {
+    // Always read the real LCU state here. The native JADE controller receives
+    // a visual-only projection below, while Python and this adapter must keep
+    // observing the official carrier selected in the client.
+    const response = await nativeFetch(endpoint, { credentials: "include" });
+    if (!response || !response.ok) {
+      throw new Error(`HTTP ${response ? response.status : "NO_RESPONSE"} for ${endpoint}`);
+    }
+    if (response.status === 204) return null;
+    return response.json();
+  }
+
+  function requestPath(input) {
+    try {
+      const value = typeof input === "string" ? input : input?.url;
+      return new URL(value, window.location.origin).pathname;
+    } catch (_) {
+      return "";
+    }
+  }
+
+  function requestMethod(input, init) {
+    return String(init?.method || input?.method || "GET").toUpperCase();
+  }
+
+  function rewriteSessionSelection(data, desiredRawSkinId) {
+    if (!data || typeof data !== "object") return false;
+    const localCellId = numeric(data.localPlayerCellId);
+    if (localCellId === null || !Array.isArray(data.myTeam)) return false;
+    const localPlayer = data.myTeam.find(
+      (player) => numeric(player?.cellId) === localCellId
+    );
+    if (!localPlayer || numeric(localPlayer.selectedSkinId) === desiredRawSkinId) {
+      return false;
+    }
+    localPlayer.selectedSkinId = desiredRawSkinId;
+    return true;
+  }
+
+  function rewriteNativeRead(path, data) {
+    const desired = desiredVisualSelection;
+    if (
+      !active ||
+      !desired ||
+      (!visualCarrierProtectionActive && (desired.available || desired.isBase))
+    ) return false;
+    const desiredRawSkinId = desired.rawSkinId;
+
+    if (path === "/lol-champ-select/v1/skin-selector-info") {
+      if (!data || typeof data !== "object") return false;
+      if (numeric(data.selectedSkinId) === desiredRawSkinId) return false;
+      data.selectedSkinId = desiredRawSkinId;
+      return true;
+    }
+    if (path === "/lol-champ-select/v1/session") {
+      return rewriteSessionSelection(data, desiredRawSkinId);
+    }
+    return false;
+  }
+
+  function shouldSuppressVisualRollback(selectedSkinId) {
+    const protection = window.__roseJadeVisualProtection;
+    if (!active || !protection?.active) return false;
+    const selected = numeric(selectedSkinId);
+    const desired = numeric(protection.desiredRawSkinId);
+    const carriers = new Set(
+      (protection.carrierRawSkinIds || []).map(numeric).filter(Number.isFinite)
+    );
+    return selected !== null && desired !== null && selected !== desired && carriers.has(selected);
+  }
+
+  function cloneWebsocketEvent(event, payload) {
+    try {
+      return new MessageEvent(event.type || "message", {
+        data: JSON.stringify(payload),
+        origin: event.origin,
+        lastEventId: event.lastEventId,
+        source: event.source,
+        ports: event.ports,
+      });
+    } catch (_) {
+      return { data: JSON.stringify(payload) };
+    }
+  }
+
+  function installNativeWebsocketProjection() {
+    if (installNativeWebsocketProjection.registered || !window.rcp?.postInit) return;
+    installNativeWebsocketProjection.registered = true;
+    window.rcp.postInit("rcp-fe-lol-champ-select", (api) => {
+      try {
+        const ws = api.champSelectBinding.socket._websocket;
+        if (!ws || ws.__roseJadeReadProjection) return;
+        const parentOnMessage = ws.onmessage;
+        ws.onmessage = function roseJadeProjectedMessage(event) {
+          try {
+            const payload = JSON.parse(event.data);
+            if (payload?.[1] !== "OnJsonApiEvent") {
+              return parentOnMessage.call(this, event);
+            }
+            const eventData = payload[2];
+            if (eventData?.uri === "/lol-champ-select/v1/skin-selector-info") {
+              const selectedSkinId = eventData.data?.selectedSkinId;
+              if (shouldSuppressVisualRollback(selectedSkinId)) {
+                log("info", "Suppressed classic selector rollback", { selectedSkinId });
+                return;
+              }
+            } else if (eventData?.uri === "/lol-champ-select/v1/session") {
+              const protection = window.__roseJadeVisualProtection;
+              if (
+                protection?.active &&
+                rewriteSessionSelection(eventData.data, numeric(protection.desiredRawSkinId))
+              ) {
+                return parentOnMessage.call(this, cloneWebsocketEvent(event, payload));
+              }
+            }
+          } catch (error) {
+            log("warn", "Classic websocket projection failed", String(error));
+          }
+          return parentOnMessage.call(this, event);
+        };
+        ws.__roseJadeReadProjection = true;
+        log("info", "Classic websocket projection installed");
+      } catch (error) {
+        log("warn", "Classic websocket projection unavailable", String(error));
+      }
+    });
+  }
+
+  function installNativeReadProjection() {
+    if (window.fetch?.__roseJadeReadProjection) return;
+
+    const projectedFetch = async function roseJadeProjectedFetch(input, init) {
+      const path = requestPath(input);
+      const method = requestMethod(input, init);
+      if (
+        active &&
+        visualCarrierProtectionActive &&
+        method === "PATCH" &&
+        path === "/lol-champ-select/v1/session/my-selection"
+      ) {
+        try {
+          const body = JSON.parse(String(init?.body || "{}"));
+          const requestedRawSkinId = numeric(body.selectedSkinId) || 0;
+          if (catalogEntryForRawSkinId(requestedRawSkinId)) {
+            log("info", "Deferred classic LCU write to finalization", {
+              requestedRawSkinId,
+            });
+            return new Response(null, { status: 204 });
+          }
+        } catch (_) {
+          // Let malformed or unrelated requests follow the native path.
+        }
+      }
+      const response = await nativeFetch(input, init);
+      if (
+        method !== "GET" ||
+        !response?.ok ||
+        (path !== "/lol-champ-select/v1/skin-selector-info" &&
+          path !== "/lol-champ-select/v1/session")
+      ) {
+        return response;
+      }
+
+      try {
+        const data = await response.clone().json();
+        if (!rewriteNativeRead(path, data)) return response;
+
+        const rewriteKey = `${path}|${desiredVisualSelection?.rawSkinId || 0}`;
+        if (rewriteKey !== lastReadRewriteKey) {
+          lastReadRewriteKey = rewriteKey;
+          log("info", "Projected classic visual selection into native read", {
+            path,
+            desiredRawSkinId: desiredVisualSelection?.rawSkinId || 0,
+          });
+        }
+        const headers = new Headers(response.headers);
+        headers.delete("content-length");
+        headers.delete("content-encoding");
+        return new Response(JSON.stringify(data), {
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+        });
+      } catch (error) {
+        log("warn", "Classic native read projection failed", {
+          path,
+          error: String(error),
+        });
+        return response;
+      }
+    };
+    projectedFetch.__roseJadeReadProjection = true;
+    window.fetch = projectedFetch;
+  }
+
+  function syncVisualSelection(entry, reason, userInitiated = false) {
+    if (!bridge || !entry?.name || !entry.resourceSkinId) return;
+    if (userInitiated) selectionGeneration += 1;
+    try {
+      // Python validates this ID against the active JADE carousel before it
+      // updates the same injection state used by regular champion select.
+      bridge.send({
+        type: "classic-skin-selection",
+        schemaVersion: 1,
+        mode: JADE_MODE,
+        primeChampionId: entry.championId,
+        modeChampionId: entry.rawChampionId,
+        carrierLcuSkinId: modeDefaultRawSkinId || fallbackModeDefaultRawSkinId(),
+        carrierSkinNumber: (modeDefaultRawSkinId || fallbackModeDefaultRawSkinId()) % 1000,
+        visualSkinId: entry.resourceSkinId,
+        skin: entry.name,
+        originalName: entry.name,
+        skinId: entry.resourceSkinId,
+        rawSkinId: entry.rawSkinId,
+        rawChampionId: entry.rawChampionId,
+        baseRawSkinId: modeDefaultRawSkinId || fallbackModeDefaultRawSkinId(),
+        catalog: catalogBridgeEntries(),
+        source: "jade-wheel",
+        reason,
+        userInitiated,
+        selectionGeneration,
+        available: entry.available === true,
+        timestamp: Date.now(),
+      });
+      log("info", "Classic visual skin synced", {
+        reason,
+        rawSkinId: entry.rawSkinId,
+        resourceSkinId: entry.resourceSkinId,
+        name: entry.name,
+      });
+    } catch (error) {
+      log("warn", "Classic visual skin sync failed", {
+        reason,
+        resourceSkinId: entry.resourceSkinId,
+        error: String(error),
+      });
+    }
+  }
+
+  function catalogBridgeEntries() {
+    const entries = [];
+    const append = (skin, fallbackChampionId) => {
+      if (!skin || typeof skin !== "object") return;
+      const id = numeric(skin.id ?? skin.skinId) || 0;
+      if (id > 0) {
+        entries.push({
+          id,
+          championId: numeric(skin.championId) || fallbackChampionId,
+        });
+      }
+      for (const child of variantsOf(skin)) {
+        append(child, fallbackChampionId);
+      }
+    };
+    for (const entry of catalog) append(entry.rawSkin, entry.rawChampionId);
+    return entries;
+  }
+
+  function syncModeCatalog(reason) {
+    if (!bridge || !rawChampionId || !catalog.length) return;
+    const entries = catalogBridgeEntries();
+    const baseRawSkinId = modeDefaultRawSkinId || fallbackModeDefaultRawSkinId();
+    const assetSnapshot = catalogAssetSnapshot();
+    const key = `${rawChampionId}|${baseRawSkinId}|${assetSnapshot
+      .map((entry) => `${entry.rawSkinId}:${entry.visualPath}`)
+      .join(",")}`;
+    if (key === lastCatalogSyncKey && reason !== "forced-refresh") return;
+    lastCatalogSyncKey = key;
+    const defaultAsset = assetSnapshot.find(
+      (entry) => entry.rawSkinId === baseRawSkinId
+    ) || null;
+    window.__roseJadeCatalogAssets = assetSnapshot;
+    window.__roseJadeModeDefaultAsset = defaultAsset;
+    bridge.send({
+      type: "classic-mode-catalog",
+      schemaVersion: 1,
+      mode: JADE_MODE,
+      primeChampionId: championId,
+      modeChampionId: rawChampionId,
+      carrierLcuSkinId: baseRawSkinId,
+      carrierSkinNumber: baseRawSkinId % 1000,
+      rawChampionId,
+      selectedRawSkinId,
+      baseRawSkinId,
+      catalog: entries,
+      reason,
+      timestamp: Date.now(),
+    });
+    log("info", "Classic skin catalog synced", {
+      reason,
+      rawChampionId,
+      baseRawSkinId,
+      skinCount: entries.length,
+      defaultAsset,
+    });
+  }
+
+  function setVisualProtection(entry, reason, force = false) {
+    const protectedEntry = active && entry && (force || (!entry.available && !entry.isBase))
+      ? entry
+      : null;
+    const carrierRawSkinIds = protectedEntry
+      ? Array.from(
+          new Set(
+            [
+              jadeSkinId(protectedEntry.championId * 1000),
+              ...catalog
+                .filter((candidate) => candidate.isBase)
+                .flatMap((candidate) => [candidate.rawSkinId, candidate.resourceSkinId]),
+            ]
+              .filter((value) => Number.isFinite(value) && value > 0)
+          )
+        )
+      : [];
+    const detail = {
+      active: Boolean(protectedEntry),
+      reason,
+      desiredRawSkinId: protectedEntry?.rawSkinId || 0,
+      desiredResourceSkinId: protectedEntry?.resourceSkinId || 0,
+      carrierRawSkinIds,
+    };
+    const protectionKey = JSON.stringify(detail);
+    window.__roseJadeVisualProtection = detail;
+    window.dispatchEvent(new CustomEvent(VISUAL_PROTECTION_EVENT, { detail }));
+    if (protectionKey !== lastVisualProtectionKey) {
+      lastVisualProtectionKey = protectionKey;
+      log("info", detail.active ? "Classic visual selection protected" : "Classic visual protection cleared", detail);
+    }
+  }
+
+  function shouldPatchLcuSelection() {
+    if (!active) return true;
+    const visualEntry = desiredVisualSelection || catalog.find(
+      (entry) => entry.rawSkinId === lastVisualCenterRawSkinId
+    );
+    return !visualEntry || visualEntry.available || visualEntry.isBase;
+  }
+
+  function isJadeClassicContext() {
+    return String(gameMode || "").toUpperCase() === JADE_MODE ||
+      Number(queueId) === 3260 || Number(mapId) === JADE_MAP_ID;
+  }
+
+  function isChampSelectPhase() {
+    return phase === "ChampSelect" || phase === "FINALIZATION" || phase === "GameStart";
+  }
+
+  function normalizeAssetPath(value) {
+    const input = String(value || "").trim();
+    if (!input) return "";
+    try {
+      return decodeURIComponent(new URL(input, window.location.origin).pathname).toLowerCase();
+    } catch (_) {
+      return input.split(/[?#]/, 1)[0].toLowerCase();
+    }
+  }
+
+  function assetFileName(value) {
+    const path = normalizeAssetPath(value);
+    return path.slice(path.lastIndexOf("/") + 1);
+  }
+
+  function normalizeCatalogEntry(entry) {
+    if (!entry || typeof entry !== "object") return null;
+    const rawSkinId = numeric(entry.id ?? entry.skinId) || 0;
+    if (!rawSkinId) return null;
+    const rawEntryChampion = numeric(entry.championId) || Math.floor(rawSkinId / 1000);
+    const normalizedSkinId = resourceSkinId(rawSkinId);
+    const ownership = entry.ownership && typeof entry.ownership === "object"
+      ? entry.ownership
+      : {};
+    const rental = ownership.rental && typeof ownership.rental === "object"
+      ? ownership.rental
+      : {};
+    const isBase = isModeDefaultRawSkinId(rawSkinId);
+    const isHiddenModeSkin0 = rawSkinId % 1000 === 0 && !isBase;
+    const available = isBase || ownership.owned === true || rental.rented === true;
+    const paths = [
+      entry.tilePath,
+      entry.splashPath,
+      entry.uncenteredSplashPath,
+      entry.loadScreenPath,
+    ].filter(Boolean);
+    return {
+      rawChampionId: rawEntryChampion,
+      championId: resourceChampionId(rawEntryChampion),
+      rawSkinId,
+      resourceSkinId: normalizedSkinId,
+      name: String(entry.name || ""),
+      isBase,
+      isHiddenModeSkin0,
+      available,
+      visualPath: String(
+        entry.loadScreenPath || entry.splashPath || entry.uncenteredSplashPath || entry.tilePath || ""
+      ),
+      paths: paths.map(normalizeAssetPath).filter(Boolean),
+      files: paths.map(assetFileName).filter(Boolean),
+      rawSkin: entry,
+    };
+  }
+
+  function variantsOf(skin) {
+    const variants = [
+      ...(Array.isArray(skin?.childSkins) ? skin.childSkins : []),
+      ...(Array.isArray(skin?.chromas) ? skin.chromas : []),
+    ];
+    const seen = new Set();
+    return variants.filter((variant) => {
+      const id = numeric(variant?.id ?? variant?.skinId) || 0;
+      if (!id || seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+  }
+
+  function catalogAssetDetails(entry) {
+    if (!entry) return null;
+    const skin = entry.rawSkin && typeof entry.rawSkin === "object"
+      ? entry.rawSkin
+      : {};
+    return {
+      rawSkinId: entry.rawSkinId,
+      resourceSkinId: entry.resourceSkinId,
+      name: entry.name,
+      isBase: entry.isBase,
+      available: entry.available,
+      visualPath: entry.visualPath,
+      tilePath: String(skin.tilePath || ""),
+      splashPath: String(skin.splashPath || ""),
+      uncenteredSplashPath: String(skin.uncenteredSplashPath || ""),
+      loadScreenPath: String(skin.loadScreenPath || ""),
+    };
+  }
+
+  function catalogAssetSnapshot() {
+    return catalog.map(catalogAssetDetails).filter(Boolean);
+  }
+
+  function getModeSkinData(rawSkinId) {
+    const id = numeric(rawSkinId);
+    if (!active || id === null) return null;
+    for (const entry of catalog) {
+      if (entry.rawSkinId === id) return entry.rawSkin;
+      const child = variantsOf(entry.rawSkin).find(
+        (candidate) => numeric(candidate?.id ?? candidate?.skinId) === id
+      );
+      if (child) return child;
+    }
+    return null;
+  }
+
+  function variantPresentation(rawSkinId, fallbackEntry) {
+    const skin = getModeSkinData(rawSkinId);
+    const colors = Array.isArray(skin?.colors)
+      ? skin.colors.filter(Boolean)
+      : [];
+    return {
+      skinName: String(skin?.name || fallbackEntry?.name || ""),
+      rawSkinId: numeric(rawSkinId) || fallbackEntry?.rawSkinId || 0,
+      resourceSkinId: resourceSkinId(rawSkinId || fallbackEntry?.rawSkinId || 0),
+      colors,
+      primaryColor: String(skin?.primaryColor || colors[0] || ""),
+    };
+  }
+
+  function catalogEntryForRawSkinId(rawSkinId) {
+    const id = numeric(rawSkinId);
+    if (id === null) return null;
+    return catalog.find((entry) => {
+      if (entry.rawSkinId === id) return true;
+      return variantsOf(entry.rawSkin).some(
+        (child) => numeric(child?.id ?? child?.skinId) === id
+      );
+    }) || null;
+  }
+
+  function catalogSelectionForResourceSkinId(resourceId) {
+    const id = numeric(resourceId) || 0;
+    const isResourceBase = championId > 0 && id === championId * 1000;
+    if (isResourceBase) {
+      const defaultRawSkinId = modeDefaultRawSkinId || fallbackModeDefaultRawSkinId();
+      const defaultEntry = catalog.find((entry) => entry.rawSkinId === defaultRawSkinId);
+      if (defaultEntry) {
+        return { entry: defaultEntry, rawSkinId: defaultEntry.rawSkinId };
+      }
+    }
+    for (const entry of catalog) {
+      if (entry.resourceSkinId === id) {
+        return { entry, rawSkinId: entry.rawSkinId };
+      }
+      const child = variantsOf(entry.rawSkin).find(
+        (candidate) => resourceSkinId(candidate?.id ?? candidate?.skinId) === id
+      );
+      if (child) {
+        return {
+          entry,
+          rawSkinId: numeric(child?.id ?? child?.skinId) || entry.rawSkinId,
+        };
+      }
+    }
+    return null;
+  }
+
+  function projectResourceSelection(resourceId, reason = "external-state") {
+    if (!active || !catalog.length) return false;
+    const selection = catalogSelectionForResourceSkinId(resourceId);
+    if (!selection) return false;
+    const { entry, rawSkinId } = selection;
+    if (reason === "random-state" || reason === "chroma-state") {
+      pendingHistoricResourceSkinId = 0;
+      lastAppliedHistoricResourceSkinId = 0;
+    }
+    visualCarrierProtectionActive = !isModeDefaultResourceSkinId(resourceId);
+    projectedVariantRawSkinId = rawSkinId;
+    desiredVisualSelection = entry;
+    projectedCatalogIndex = catalog.indexOf(entry);
+    lastVisualCenterRawSkinId = 0;
+    clearUserNavigation();
+    setVisualProtection(entry, reason, visualCarrierProtectionActive);
+    scheduleNativeProjection(projectedCatalogIndex);
+    adaptNativeController();
+    log("info", "Classic resource selection projected into native selector", {
+      reason,
+      resourceSkinId: numeric(resourceId) || 0,
+      visualRawSkinId: entry.rawSkinId,
+      variantRawSkinId: rawSkinId,
+    });
+    return true;
+  }
+
+  function setHistoricPresentationReady(ready, reason) {
+    window.dispatchEvent(new CustomEvent("rose-jade-historic-presentation-state", {
+      detail: { ready: ready === true, reason: String(reason || "") },
+    }));
+  }
+
+  function cancelHistoricVisualRestore(reason, hidePresentation = false) {
+    historicRestoreGeneration += 1;
+    historicRestoreInProgress = false;
+    if (hidePresentation) setHistoricPresentationReady(false, reason);
+  }
+
+  function finishHistoricVisualSelection(resourceId, generation) {
+    if (
+      !active || generation !== historicRestoreGeneration ||
+      pendingHistoricResourceSkinId !== resourceId
+    ) {
+      return;
+    }
+    if (projectResourceSelection(resourceId, "historic-restore")) {
+      const selection = catalogSelectionForResourceSkinId(resourceId);
+      scheduleNativeProjection(projectedCatalogIndex, () => {
+        if (
+          !active || generation !== historicRestoreGeneration ||
+          pendingHistoricResourceSkinId !== resourceId
+        ) {
+          return;
+        }
+        historicRestoreInProgress = false;
+        lastAppliedHistoricResourceSkinId = resourceId;
+        const presentation = variantPresentation(
+          selection?.rawSkinId,
+          selection?.entry
+        );
+        window.dispatchEvent(new CustomEvent("rose-jade-historic-presentation", {
+          detail: presentation,
+        }));
+        log("info", "Classic history projected after native default staging", {
+          historicResourceSkinId: resourceId,
+          visualRawSkinId: selection?.entry?.rawSkinId || 0,
+          variantRawSkinId: selection?.rawSkinId || 0,
+        });
+      });
+      return;
+    }
+    historicRestoreInProgress = false;
+  }
+
+  function applyHistoricVisualSelection() {
+    if (!active || !pendingHistoricResourceSkinId || !catalog.length) return;
+    if (!isModeDefaultResourceSkinId(pendingHistoricResourceSkinId)) {
+      const selection = catalogSelectionForResourceSkinId(pendingHistoricResourceSkinId);
+      if (!selection) return;
+      if (pendingHistoricResourceSkinId === lastAppliedHistoricResourceSkinId) {
+        // The catalog is rebuilt every two seconds, so its entry objects are
+        // not stable. Rebind the active projection by ID without replaying the
+        // default-card staging animation.
+        visualCarrierProtectionActive = true;
+        projectedVariantRawSkinId = selection.rawSkinId;
+        desiredVisualSelection = selection.entry;
+        projectedCatalogIndex = catalog.indexOf(selection.entry);
+        setVisualProtection(selection.entry, "historic-catalog-refresh", true);
+        adaptNativeController();
+        return;
+      }
+      if (historicRestoreInProgress) return;
+      const defaultEntry = catalog.find((entry) => entry.isBase) || null;
+      if (!defaultEntry || defaultEntry === selection.entry) {
+        finishHistoricVisualSelection(
+          pendingHistoricResourceSkinId,
+          historicRestoreGeneration
+        );
+        return;
+      }
+      historicRestoreInProgress = true;
+      const resourceId = pendingHistoricResourceSkinId;
+      const generation = ++historicRestoreGeneration;
+      setHistoricPresentationReady(false, "historic-default-stage");
+      visualCarrierProtectionActive = false;
+      projectedVariantRawSkinId = defaultEntry.rawSkinId;
+      desiredVisualSelection = defaultEntry;
+      projectedCatalogIndex = catalog.indexOf(defaultEntry);
+      lastVisualCenterRawSkinId = 0;
+      clearUserNavigation();
+      setVisualProtection(null, "historic-default-stage");
+      adaptNativeController();
+      scheduleNativeProjection(projectedCatalogIndex, () => {
+        setTimeout(
+          () => finishHistoricVisualSelection(resourceId, generation),
+          100
+        );
+      });
+      log("info", "Classic history restore staged from native default", {
+        historicResourceSkinId: resourceId,
+        defaultRawSkinId: defaultEntry.rawSkinId,
+      });
+      return;
+    }
+    cancelHistoricVisualRestore("historic-default", true);
+    pendingHistoricResourceSkinId = 0;
+    lastAppliedHistoricResourceSkinId = 0;
+  }
+
+  function handleHistoricState(data) {
+    if (randomModeActive) {
+      cancelHistoricVisualRestore("random-mode", true);
+      pendingHistoricResourceSkinId = 0;
+      lastAppliedHistoricResourceSkinId = 0;
+      return;
+    }
+    pendingHistoricResourceSkinId = data?.active === true
+      ? numeric(data.historicSkinId) || 0
+      : 0;
+    if (!pendingHistoricResourceSkinId) {
+      cancelHistoricVisualRestore("historic-disabled", true);
+      lastAppliedHistoricResourceSkinId = 0;
+    }
+    if (pendingHistoricResourceSkinId) applyHistoricVisualSelection();
+  }
+
+  function handleRandomModeState(data) {
+    randomModeActive = data?.active === true;
+    if (!randomModeActive) return;
+    cancelHistoricVisualRestore("random-mode", true);
+    pendingHistoricResourceSkinId = 0;
+    lastAppliedHistoricResourceSkinId = 0;
+    projectedVariantRawSkinId = 0;
+    clearUserNavigation();
+    const defaultEntry = catalog.find((entry) => entry.isBase) || null;
+    if (!defaultEntry) return;
+    visualCarrierProtectionActive = false;
+    desiredVisualSelection = defaultEntry;
+    projectedCatalogIndex = catalog.indexOf(defaultEntry);
+    lastVisualCenterRawSkinId = 0;
+    setVisualProtection(null, "random-default-presentation");
+    adaptNativeController();
+    scheduleNativeProjection(projectedCatalogIndex);
+    log("info", "Random mode skipped history and centered the classic default", {
+      rawSkinId: defaultEntry.rawSkinId,
+      resourceSkinId: defaultEntry.resourceSkinId,
+    });
+  }
+
+  function findNativePane() {
+    const center = document.querySelector(".champion-select-center-container--picking-skins");
+    const candidate = center?.querySelector(".skins-pane__content") || null;
+    if (!candidate) return null;
+    const rect = candidate.getBoundingClientRect();
+    if (rect.width < 200 || rect.height < 120) return null;
+    return candidate;
+  }
+
+  function nativeCards(host = pane) {
+    if (!host) return [];
+    const cards = Array.from(host.children).filter(
+      (child) => child.classList?.contains("skins-pane__skin-card")
+    );
+
+    // JADE recycles its five card nodes and does not keep DOM order aligned
+    // with their visual left-to-right order. Historic projection can move the
+    // center node to DOM index 0, which used to erase every inferred card on
+    // its left. Always calculate carousel offsets from rendered positions.
+    return cards
+      .map((card, domIndex) => {
+        const rect = card.getBoundingClientRect();
+        const visualX = rect.width > 0
+          ? rect.left + rect.width / 2
+          : Number.POSITIVE_INFINITY;
+        return { card, domIndex, visualX };
+      })
+      .sort((left, right) => {
+        if (left.visualX !== right.visualX) return left.visualX - right.visualX;
+        return left.domIndex - right.domIndex;
+      })
+      .map(({ card }) => card);
+  }
+
+  function selectedNativeCard(cards) {
+    return (
+      cards.find((card) => card.classList.contains("skins-pane__skin-card--center-tile")) ||
+      cards.find(
+        (card) =>
+          card.classList.contains("skins-pane__skin-card--selected-skin") &&
+          !card.classList.contains("skins-pane__skin-card--placeholder")
+      ) ||
+      null
+    );
+  }
+
+  function elementSkinId(card) {
+    const attributes = ["data-skin-id", "data-champion-skin-id", "skin-id"];
+    const original = originalCardState.get(card);
+    for (const attribute of attributes) {
+      const value = numeric(original?.attributes.get(attribute));
+      if (value && value > 0) return value;
+    }
+
+    // Ignore the adapter attributes on the card itself. Native JADE recycles
+    // these nodes while moving the carousel, so those values may be stale.
+    const nodes = card.querySelectorAll(
+      "[data-skin-id], [data-champion-skin-id], [skin-id]"
+    );
+    for (const node of nodes) {
+      for (const attribute of attributes) {
+        const value = numeric(node.getAttribute?.(attribute));
+        if (value && value > 0) return value;
+      }
+    }
+    return 0;
+  }
+
+  function cardAssets(card) {
+    const values = [];
+    for (const image of card.querySelectorAll("img[src], source[srcset]")) {
+      values.push(image.currentSrc, image.getAttribute("src"), image.getAttribute("srcset"));
+    }
+    for (const node of [card, ...card.querySelectorAll("[style*='background']")]) {
+      const background = node.style?.backgroundImage || "";
+      const match = background.match(/url\(["']?([^"')]+)["']?\)/i);
+      if (match) values.push(match[1]);
+    }
+    const paths = values.map(normalizeAssetPath).filter(Boolean);
+    return {
+      paths,
+      files: paths.map(assetFileName).filter(Boolean),
+    };
+  }
+
+  function matchCardToCatalog(card) {
+    // JADE recycles its five card nodes while changing their images. Match the
+    // live visual assets before attributes remembered from an earlier slot.
+    const assets = cardAssets(card);
+    for (const entry of catalog) {
+      if (entry.paths.some((path) => assets.paths.includes(path))) return entry;
+    }
+    for (const entry of catalog) {
+      if (entry.files.some((file) => file && assets.files.includes(file))) return entry;
+    }
+
+    const label = String(
+      card.getAttribute("aria-label") ||
+      card.getAttribute("title") ||
+      card.querySelector("img[alt]")?.getAttribute("alt") ||
+      ""
+    ).trim();
+    if (label) {
+      const nameMatch = catalog.find((entry) => entry.name && entry.name === label);
+      if (nameMatch) return nameMatch;
+    }
+
+    const directId = elementSkinId(card);
+    if (directId) {
+      const rawMatch = catalog.find((entry) => entry.rawSkinId === directId);
+      if (rawMatch) return rawMatch;
+      const resourceId = resourceSkinId(directId);
+      const resourceMatch = catalog.find((entry) => entry.resourceSkinId === resourceId);
+      if (resourceMatch) return resourceMatch;
+    }
+    return null;
+  }
+
+  function rememberOriginalCardState(card) {
+    if (originalCardState.has(card)) return;
+    const attributes = new Map();
+    for (const name of [
+      "data-skin-id",
+      "data-champion-skin-id",
+      "skin-id",
+      "data-rose-lcu-skin-id",
+      "data-rose-resource-skin-id",
+      "data-rose-carousel-offset",
+    ]) {
+      attributes.set(name, card.hasAttribute(name) ? card.getAttribute(name) : null);
+    }
+    originalCardState.set(card, {
+      attributes,
+      classes: new Set(
+        Array.from(card.classList).filter(
+          (name) => COMPATIBILITY_CLASSES.includes(name)
+        )
+      ),
+    });
+  }
+
+  function clearCompatibility(card) {
+    if (!card) return;
+    adaptedCardState.delete(card);
+    card.querySelectorAll(".skins-pane__locked-overlay, .skins-pane__locked-icon").forEach(
+      (element) => {
+        const original = lockOverlayState.get(element);
+        if (!original) return;
+        if (original.display) element.style.setProperty("display", original.display.value, original.display.priority);
+        else element.style.removeProperty("display");
+        if (original.pointerEvents) {
+          element.style.setProperty(
+            "pointer-events",
+            original.pointerEvents.value,
+            original.pointerEvents.priority
+          );
+        } else {
+          element.style.removeProperty("pointer-events");
+        }
+        lockOverlayState.delete(element);
+      }
+    );
+    card.classList.remove(UNLOCKED_CLASS, EMPTY_CLASS);
+    const original = originalCardState.get(card);
+    card.querySelectorAll("img").forEach((image) => {
+      if (image.hasAttribute("data-rose-jade-projected-image")) {
+        image.remove();
+        return;
+      }
+      const state = projectedImageState.get(image);
+      if (!state) return;
+      for (const [name, value] of Object.entries(state)) {
+        if (value === null) image.removeAttribute(name);
+        else image.setAttribute(name, value);
+      }
+      projectedImageState.delete(image);
+    });
+    for (const className of COMPATIBILITY_CLASSES) {
+      if (!original?.classes.has(className)) card.classList.remove(className);
+    }
+    for (const name of [
+      "data-skin-id",
+      "data-rose-lcu-skin-id",
+      "data-rose-resource-skin-id",
+      "data-rose-carousel-offset",
+    ]) {
+      const value = original?.attributes.get(name);
+      if (value === null || value === undefined) card.removeAttribute(name);
+      else card.setAttribute(name, value);
+    }
+  }
+
+  function unlockNativeCard(card, entry) {
+    if (!card || !entry || entry.available || entry.isBase) return;
+    card.classList.add(UNLOCKED_CLASS);
+    card.querySelectorAll(".skins-pane__locked-overlay, .skins-pane__locked-icon").forEach(
+      (element) => {
+        if (!lockOverlayState.has(element)) {
+          lockOverlayState.set(element, {
+            display: element.style.getPropertyValue("display")
+              ? {
+                  value: element.style.getPropertyValue("display"),
+                  priority: element.style.getPropertyPriority("display"),
+                }
+              : null,
+            pointerEvents: element.style.getPropertyValue("pointer-events")
+              ? {
+                  value: element.style.getPropertyValue("pointer-events"),
+                  priority: element.style.getPropertyPriority("pointer-events"),
+                }
+              : null,
+          });
+        }
+        element.style.setProperty("display", "none", "important");
+        element.style.setProperty("pointer-events", "none", "important");
+      }
+    );
+  }
+
+  function applyCompatibility(
+    card,
+    entry,
+    offset,
+    selected,
+    stabilize = false
+  ) {
+    rememberOriginalCardState(card);
+    const stateKey = entry
+      ? `${entry.rawSkinId}|${entry.resourceSkinId}|${offset}|${selected}|${entry.available}`
+      : `empty|${offset}`;
+    const alreadyAdapted =
+      adaptedCardState.get(card) === stateKey &&
+      card.classList.contains(CARD_CLASS) &&
+      card.classList.contains(SELECTED_CLASS) === selected &&
+      card.getAttribute("data-rose-carousel-offset") === String(offset) &&
+      card.classList.contains(UNLOCKED_CLASS) === !entry?.available &&
+      card.getAttribute("data-rose-lcu-skin-id") === String(entry?.rawSkinId || "");
+    card.classList.toggle("rose-jade-native-card--stabilizing", stabilize);
+    card.classList.toggle(EMPTY_CLASS, !entry);
+    if (alreadyAdapted) {
+      // JADE recycles card nodes and may recreate the native lock overlay
+      // after our first pass. Reapply the idempotent unlock state here.
+      unlockNativeCard(card, entry);
+      adaptedCards.add(card);
+      return;
+    }
+    clearCompatibility(card);
+    if (!entry || card.classList.contains("skins-pane__skin-card--placeholder")) {
+      card.classList.toggle(EMPTY_CLASS, !entry);
+      return;
+    }
+    card.classList.add(CARD_CLASS);
+    card.classList.toggle(SELECTED_CLASS, selected);
+    card.setAttribute("data-rose-carousel-offset", String(offset));
+    card.setAttribute("data-rose-resource-skin-id", String(entry.resourceSkinId));
+    card.setAttribute("data-rose-lcu-skin-id", String(entry.rawSkinId));
+    unlockNativeCard(card, entry);
+    adaptedCardState.set(card, stateKey);
+    adaptedCards.add(card);
+  }
+
+  function projectCardVisual(card, entry) {
+    const visualPath = entry?.visualPath || "";
+    if (!card || !visualPath) return;
+    if (!card.querySelector(".skins-pane__skin-image")) {
+      const image = document.createElement("img");
+      image.className = "skins-pane__skin-image";
+      image.setAttribute("data-rose-jade-projected-image", "true");
+      card.appendChild(image);
+    }
+    card.setAttribute("aria-label", entry.name);
+    card.setAttribute("title", entry.name);
+    for (const image of card.querySelectorAll(".skins-pane__skin-image")) {
+      if (!image.hasAttribute("data-rose-jade-projected-image") && !projectedImageState.has(image)) {
+        projectedImageState.set(image, {
+          src: image.hasAttribute("src") ? image.getAttribute("src") : null,
+          srcset: image.hasAttribute("srcset") ? image.getAttribute("srcset") : null,
+          alt: image.hasAttribute("alt") ? image.getAttribute("alt") : null,
+        });
+      }
+      if (image.getAttribute("src") !== visualPath) image.setAttribute("src", visualPath);
+      image.removeAttribute("srcset");
+      image.setAttribute("alt", entry.name);
+    }
+  }
+
+  function beginUserNavigation(targetRawSkinId = 0) {
+    if (pendingHistoricResourceSkinId || lastAppliedHistoricResourceSkinId) {
+      setHistoricPresentationReady(false, "user-navigation");
+    }
+    if (visualCarrierProtectionActive) {
+      visualCarrierProtectionActive = false;
+      projectedCatalogIndex = -1;
+      setVisualProtection(null, "user-navigation");
+      for (const card of Array.from(adaptedCards)) clearCompatibility(card);
+      adaptedCards.clear();
+    }
+    pendingUserNavigation = true;
+    pendingUserNavigationUntil = Date.now() + USER_NAVIGATION_WINDOW_MS;
+    pendingUserTargetRawSkinId = numeric(targetRawSkinId) || 0;
+    pendingUserSelectionPublished = false;
+  }
+
+  function clearUserNavigation() {
+    pendingUserNavigation = false;
+    pendingUserNavigationUntil = 0;
+    pendingUserTargetRawSkinId = 0;
+    pendingUserSelectionPublished = false;
+  }
+
+  function publishNativeCardSelection(entry, reason) {
+    if (!entry) return;
+    if (pendingHistoricResourceSkinId || lastAppliedHistoricResourceSkinId) {
+      cancelHistoricVisualRestore("explicit-selection", true);
+      pendingHistoricResourceSkinId = 0;
+      lastAppliedHistoricResourceSkinId = 0;
+    }
+    projectedVariantRawSkinId = 0;
+    visualCarrierProtectionActive = !entry.available && !entry.isBase;
+    setVisualProtection(entry, reason, visualCarrierProtectionActive);
+    desiredVisualSelection = entry;
+    projectedCatalogIndex = catalog.indexOf(entry);
+    syncVisualSelection(entry, reason, true);
+    pendingUserSelectionPublished = true;
+  }
+
+  function scheduleNativeProjection(targetIndex, onComplete = null) {
+    nativeProjectionTargetIndex = Number.isInteger(targetIndex) ? targetIndex : -1;
+    nativeProjectionComplete = typeof onComplete === "function" ? onComplete : null;
+    const cards = nativeCards();
+    const centerCard = selectedNativeCard(cards);
+    const centerEntry = centerCard ? matchCardToCatalog(centerCard) : null;
+    nativeProjectionCurrentIndex = centerEntry ? catalog.indexOf(centerEntry) : -1;
+    if (nativeProjectionTimer) clearTimeout(nativeProjectionTimer);
+    nativeProjectionTimer = setTimeout(stepNativeProjection, 0);
+  }
+
+  function stepNativeProjection() {
+    nativeProjectionTimer = null;
+    if (!active || nativeProjectionTargetIndex < 0 || !catalog.length) return;
+    const currentIndex = nativeProjectionCurrentIndex;
+    if (currentIndex === nativeProjectionTargetIndex) {
+      const complete = nativeProjectionComplete;
+      nativeProjectionTargetIndex = -1;
+      nativeProjectionCurrentIndex = -1;
+      nativeProjectionComplete = null;
+      adaptNativeController();
+      if (complete) setTimeout(complete, 0);
+      return;
+    }
+    if (currentIndex < 0) {
+      nativeProjectionTimer = setTimeout(stepNativeProjection, 80);
+      return;
+    }
+    const direction = nativeProjectionTargetIndex < currentIndex ? "left" : "right";
+    const arrow = pane?.parentElement?.querySelector(`.skins-pane__arrow--${direction}`);
+    if (!arrow || arrow.classList.contains("skins-pane__arrow--disabled")) return;
+    drivingNativeProjection = true;
+    arrow.click();
+    drivingNativeProjection = false;
+    nativeProjectionCurrentIndex += direction === "left" ? -1 : 1;
+    nativeProjectionTimer = setTimeout(stepNativeProjection, 80);
+  }
+
+  function syncFooterPresentation(entry) {
+    if (!pane || !entry) return;
+    const root = pane.parentElement || pane;
+    const title = root.querySelector(".skins-pane__footer .skins-pane__skin-title");
+    const subtitle = root.querySelector(".skins-pane__footer .skins-pane__sub-title");
+    if (title && title.textContent !== entry.name) title.textContent = entry.name;
+    if (!subtitle) return;
+    const status = entry.available || entry.isBase
+      ? "OWNED"
+      : "UNLOCKED";
+    if (subtitle.textContent !== status) subtitle.textContent = status;
+    subtitle.classList.add("skins-pane__sub-title--unlocked");
+  }
+
+  function handleNativePaneClick(event) {
+    if (
+      event.target?.closest?.(
+        ".chroma-button, .lu-chroma-button, .forms-wheel-button, .lu-random-dice-button"
+      )
+    ) {
+      return;
+    }
+    const card = event.target?.closest?.(`.${CARD_CLASS}`);
+    if (!card || !pane?.contains(card)) return;
+    const clickRawSkinId = numeric(card.getAttribute("data-rose-lcu-skin-id")) || 0;
+    if (Date.now() <= pointerSelectionUntil && pointerSelectionRawSkinId) {
+      if (pointerSelectionCommitted) return;
+      const pointerEntry = catalog.find(
+        (candidate) => candidate.rawSkinId === pointerSelectionRawSkinId
+      );
+      if (!pointerEntry) return;
+      if (clickRawSkinId !== pointerSelectionRawSkinId) {
+        log("info", "Ignored recycled classic carousel click", {
+          pointerRawSkinId: pointerSelectionRawSkinId,
+          clickRawSkinId,
+        });
+      }
+      beginUserNavigation(pointerEntry.rawSkinId);
+      if (card.classList.contains("skins-pane__skin-card--center-tile")) {
+        publishNativeCardSelection(pointerEntry, "native-card-click");
+        clearUserNavigation();
+      }
+      pointerSelectionCommitted = true;
+      return;
+    }
+    const entry = catalog.find((candidate) => candidate.rawSkinId === clickRawSkinId);
+    if (!entry) return;
+    beginUserNavigation(entry.rawSkinId);
+    if (card.classList.contains("skins-pane__skin-card--center-tile")) {
+      publishNativeCardSelection(entry, "native-card-click");
+      clearUserNavigation();
+    }
+  }
+
+  function handleUserNavigation(event) {
+    if (!active) return;
+    const arrow = event.target?.closest?.(
+      ".skins-pane__arrow--left, .skins-pane__arrow--right"
+    );
+    if (arrow && !drivingNativeProjection) {
+      const cards = nativeCards();
+      const centerCard = selectedNativeCard(cards);
+      const centerEntry = centerCard ? matchCardToCatalog(centerCard) : null;
+      const currentIndex = centerEntry ? catalog.indexOf(centerEntry) : -1;
+      const direction = arrow.classList.contains("skins-pane__arrow--left") ? -1 : 1;
+      const target = currentIndex >= 0 ? catalog[currentIndex + direction] : null;
+      if (target) {
+        pendingHistoricResourceSkinId = 0;
+        projectedVariantRawSkinId = 0;
+        beginUserNavigation(target.rawSkinId);
+      }
+      return;
+    }
+    if (
+      event.target?.closest?.(
+        ".chroma-button, .lu-chroma-button, .forms-wheel-button, .lu-random-dice-button"
+      )
+    ) {
+      return;
+    }
+    const card = event.target?.closest?.(`.${CARD_CLASS}`);
+    if (card && pane?.contains(card)) {
+      pendingHistoricResourceSkinId = 0;
+      projectedVariantRawSkinId = 0;
+      const rawSkinId = numeric(card.getAttribute("data-rose-lcu-skin-id")) || 0;
+      const entry = catalog.find((candidate) => candidate.rawSkinId === rawSkinId);
+      if (!entry) return;
+      pointerSelectionRawSkinId = entry.rawSkinId;
+      pointerSelectionUntil = Date.now() + 1500;
+      pointerSelectionCommitted = false;
+      beginUserNavigation(entry.rawSkinId);
+      return;
+    }
+    if (event.target?.closest?.(".champion-select-center-container--picking-skins")) {
+      pendingHistoricResourceSkinId = 0;
+      projectedVariantRawSkinId = 0;
+      beginUserNavigation();
+    }
+  }
+
+  function handleUserNavigationKey(event) {
+    if (active && (event.key === "ArrowLeft" || event.key === "ArrowRight")) {
+      pendingHistoricResourceSkinId = 0;
+      projectedVariantRawSkinId = 0;
+      beginUserNavigation();
+    }
+  }
+
+  function ensureOverlay() {
+    if (!pane) return;
+    if (overlay && overlay.isConnected) return;
+    document.getElementById(ROOT_ID)?.remove();
+    overlay = document.createElement("div");
+    overlay.id = ROOT_ID;
+    overlay.className = "rose-jade-wheel-jade-pane";
+    overlay.setAttribute("aria-hidden", "true");
+
+    pane.classList.add(HOST_CLASS);
+    pane.addEventListener("click", handleNativePaneClick, true);
+    pane.appendChild(overlay);
+    window.dispatchEvent(
+      new CustomEvent("rose-jade-wheel-layout", {
+        detail: { active: true, rootId: ROOT_ID, native: true },
+      })
+    );
+  }
+
+  function ensureHistoryAnchor(centerCard) {
+    if (!centerCard) return;
+    document.querySelectorAll(".rose-jade-history-anchor").forEach((anchor) => {
+      if (anchor.parentElement !== centerCard) anchor.remove();
+    });
+    let anchor = Array.from(centerCard.children).find(
+      (child) => child.classList?.contains("rose-jade-history-anchor")
+    );
+    if (!anchor) {
+      anchor = document.createElement("div");
+      anchor.className =
+        "rose-jade-history-anchor skin-selection-item-information loyalty-reward-icon--rewards";
+      centerCard.appendChild(anchor);
+    }
+  }
+
+  function adaptNativeController() {
+    if (!active || !catalog.length) return;
+    const nextPane = findNativePane();
+    if (!nextPane) return;
+    if (pane && pane !== nextPane) cleanupDom();
+    pane = nextPane;
+    ensureOverlay();
+
+    const cards = nativeCards();
+    const centerCard = selectedNativeCard(cards);
+    if (!centerCard) return;
+    if (overlay?.parentElement !== centerCard) {
+      if (window.getComputedStyle(centerCard).position === "static") {
+        centerCard.style.position = "relative";
+      }
+      centerCard.appendChild(overlay);
+    }
+    ensureHistoryAnchor(centerCard);
+    const centerSlot = cards.indexOf(centerCard);
+    const visualCenterEntry = matchCardToCatalog(centerCard);
+    const selectedCatalogEntry = catalogEntryForRawSkinId(selectedRawSkinId);
+    let selectedIndex = selectedCatalogEntry ? catalog.indexOf(selectedCatalogEntry) : -1;
+    if (selectedIndex < 0) {
+      selectedIndex = catalog.findIndex(
+        (entry) => entry.resourceSkinId === selectedResourceSkinId
+      );
+    }
+    if (selectedIndex < 0) selectedIndex = 0;
+    let centerEntry = visualCenterEntry || catalog[selectedIndex] || null;
+    if (visualCenterEntry) selectedIndex = catalog.indexOf(visualCenterEntry);
+    const navigationPending =
+      pendingUserNavigation && Date.now() <= pendingUserNavigationUntil;
+    if (pendingUserNavigation && !navigationPending) clearUserNavigation();
+    const followsUserNavigation = Boolean(
+      navigationPending &&
+      pendingUserTargetRawSkinId &&
+      centerEntry &&
+      pendingUserTargetRawSkinId === centerEntry.rawSkinId
+    );
+    const isIntermediateUserNavigation = Boolean(
+      navigationPending &&
+      pendingUserTargetRawSkinId &&
+      centerEntry &&
+      pendingUserTargetRawSkinId !== centerEntry.rawSkinId
+    );
+    const isAutomaticLcuRollback = Boolean(
+      centerEntry &&
+      desiredVisualSelection &&
+      desiredVisualSelection.rawSkinId !== centerEntry.rawSkinId &&
+      visualCarrierProtectionActive &&
+      !followsUserNavigation
+    );
+    if (isAutomaticLcuRollback) {
+      centerEntry = desiredVisualSelection;
+      selectedIndex = projectedCatalogIndex >= 0
+        ? projectedCatalogIndex
+        : catalog.indexOf(centerEntry);
+    }
+    const projectionActive = Boolean(
+      desiredVisualSelection &&
+      projectedCatalogIndex >= 0 &&
+      visualCarrierProtectionActive &&
+      !followsUserNavigation
+    );
+    if (projectionActive) {
+      centerEntry = desiredVisualSelection;
+      selectedIndex = projectedCatalogIndex;
+    }
+    const usedRawSkinIds = new Set(centerEntry ? [centerEntry.rawSkinId] : []);
+
+    if (centerEntry && centerEntry.rawSkinId !== lastVisualCenterRawSkinId) {
+      lastVisualCenterRawSkinId = centerEntry.rawSkinId;
+      if (isAutomaticLcuRollback) {
+        log("info", "Ignored automatic classic skin rollback", {
+          desiredResourceSkinId: desiredVisualSelection.resourceSkinId,
+          lcuResourceSkinId: visualCenterEntry?.resourceSkinId || selectedResourceSkinId,
+        });
+      } else if (!isIntermediateUserNavigation) {
+        visualCarrierProtectionActive =
+          !centerEntry.available && !centerEntry.isBase;
+        setVisualProtection(
+          centerEntry,
+          "visual-center-change",
+          visualCarrierProtectionActive
+        );
+        if (followsUserNavigation) {
+          desiredVisualSelection = centerEntry;
+          projectedCatalogIndex = catalog.indexOf(centerEntry);
+          if (!pendingUserSelectionPublished) {
+            syncVisualSelection(centerEntry, "visual-center-change", true);
+            pendingUserSelectionPublished = true;
+          }
+        }
+      }
+      if (followsUserNavigation) clearUserNavigation();
+    }
+
+    for (const oldCard of Array.from(adaptedCards)) {
+      if (!cards.includes(oldCard)) {
+        clearCompatibility(oldCard);
+        adaptedCards.delete(oldCard);
+      }
+    }
+
+    const mapped = [];
+    for (let slot = 0; slot < cards.length; slot += 1) {
+      const card = cards[slot];
+      if (card.classList.contains("skins-pane__skin-card--placeholder")) {
+        clearCompatibility(card);
+        continue;
+      }
+      const directMatch = projectionActive ? null : matchCardToCatalog(card);
+      const inferredMatch = catalog[selectedIndex + (slot - centerSlot)] || null;
+      let entry = centerEntry || directMatch;
+      if (card !== centerCard) {
+        entry = [inferredMatch, directMatch].find(
+          (candidate) => candidate && !usedRawSkinIds.has(candidate.rawSkinId)
+        ) || null;
+      }
+      const offset = slot - centerSlot;
+      applyCompatibility(
+        card,
+        entry,
+        offset,
+        card === centerCard,
+        isAutomaticLcuRollback
+      );
+      if (projectionActive && entry) {
+        projectCardVisual(card, entry);
+      }
+      if (entry) {
+        usedRawSkinIds.add(entry.rawSkinId);
+        mapped.push(`${offset}:${entry.rawSkinId}:${entry.available ? "official" : "unlocked"}`);
+      }
+    }
+    syncFooterPresentation(centerEntry);
+    const footer = pane.parentElement?.querySelector(".skins-pane__footer");
+    const leftArrow = pane.parentElement?.querySelector(".skins-pane__arrow--left");
+    const rightArrow = pane.parentElement?.querySelector(".skins-pane__arrow--right");
+    if (projectionActive && footer) {
+      leftArrow?.classList.toggle("skins-pane__arrow--disabled", selectedIndex <= 0);
+      rightArrow?.classList.toggle("skins-pane__arrow--disabled", selectedIndex >= catalog.length - 1);
+    }
+
+    const layoutKey = `${cards.length}|${catalog.length}|${selectedRawSkinId}|${mapped.join(",")}`;
+    if (layoutKey !== lastLayoutKey) {
+      lastLayoutKey = layoutKey;
+      log("info", "Native classic skin selector adapted", {
+        nativeCardCount: cards.length,
+        modeSkinCount: catalog.length,
+        selectedRawSkinId,
+        selectedResourceSkinId,
+        visualCenterRawSkinId: centerEntry?.rawSkinId || null,
+        visualCenterResourceSkinId: centerEntry?.resourceSkinId || null,
+        nativeCenterRawSkinId: visualCenterEntry?.rawSkinId || null,
+        visualProjectionActive: isAutomaticLcuRollback,
+        mapped,
+      });
+    }
+  }
+
+  async function loadModeCatalog(force = false) {
+    if (!active || !rawChampionId) return;
+    if (!force && catalog.length && Date.now() - catalogLoadedAt < CATALOG_REFRESH_MS) return;
+    const generation = requestGeneration;
+    if (!modeDefaultRawSkinId) {
+      try {
+        const pickableSkinIds = await fetchJson(
+          "/lol-lobby-team-builder/champ-select/v1/pickable-skin-ids"
+        );
+        if (!active || generation !== requestGeneration) return;
+        const candidates = (Array.isArray(pickableSkinIds) ? pickableSkinIds : [])
+          .map((value) => numeric(value) || 0)
+          .filter((value) => Math.floor(value / 1000) === rawChampionId);
+        const expected = fallbackModeDefaultRawSkinId();
+        modeDefaultRawSkinId = candidates.find((value) => value === expected)
+          || candidates.find((value) => value % 1000 >= 300)
+          || candidates.find((value) => value % 1000 === 0)
+          || 0;
+      } catch (error) {
+        log("debug", "Waiting for classic default skin catalog", String(error));
+      }
+      if (!modeDefaultRawSkinId) {
+        modeDefaultRawSkinId = fallbackModeDefaultRawSkinId();
+      }
+    }
+    const modeSkins = await fetchJson("/lol-champ-select/v1/skin-carousel-skins");
+    if (!active || generation !== requestGeneration) return;
+    const nextCatalog = (Array.isArray(modeSkins) ? modeSkins : [])
+      .map(normalizeCatalogEntry)
+      .filter(
+        (entry) =>
+          entry && entry.championId === championId && !entry.isHiddenModeSkin0
+      );
+    catalogLoadedAt = Date.now();
+    if (!nextCatalog.length) return;
+    // Riot's JADE component always moves its native classic default to index
+    // zero. Mirror that exact order so projected history/random navigation and
+    // the native finite carousel share the same left/right boundaries.
+    const defaultIndex = nextCatalog.findIndex((entry) => entry.isBase);
+    if (defaultIndex > 0) {
+      const [defaultEntry] = nextCatalog.splice(defaultIndex, 1);
+      nextCatalog.unshift(defaultEntry);
+    }
+    catalog = nextCatalog;
+    syncModeCatalog(force ? "forced-refresh" : "refresh");
+    applyHistoricVisualSelection();
+  }
+
+  async function refreshSelection(forceCatalog = false) {
+    if (!active || refreshInFlight) return;
+    refreshInFlight = true;
+    try {
+      const info = await fetchJson("/lol-champ-select/v1/skin-selector-info");
+      if (!active || !info) return;
+      const nextRawChampion = numeric(info.selectedChampionId) || 0;
+      const nextChampion = resourceChampionId(nextRawChampion);
+      const nextRawSkin = numeric(info.selectedSkinId) || 0;
+      const championChanged = nextRawChampion !== rawChampionId;
+      rawChampionId = nextRawChampion;
+      championId = nextChampion;
+      selectedRawSkinId = nextRawSkin;
+      selectedResourceSkinId = resourceSkinId(nextRawSkin);
+      if (championChanged) {
+        cancelHistoricVisualRestore("champion-change", true);
+        visualCarrierProtectionActive = false;
+        projectedCatalogIndex = -1;
+        lastAppliedHistoricResourceSkinId = 0;
+        projectedVariantRawSkinId = 0;
+        setVisualProtection(null, "champion-change");
+        desiredVisualSelection = null;
+        pendingUserNavigation = false;
+        pendingUserNavigationUntil = 0;
+        pendingUserTargetRawSkinId = 0;
+        pendingUserSelectionPublished = false;
+        catalog = [];
+        catalogLoadedAt = 0;
+        modeDefaultRawSkinId = 0;
+        lastCatalogSyncKey = "";
+      }
+      await loadModeCatalog(forceCatalog || championChanged || !catalog.length);
+      adaptNativeController();
+    } catch (error) {
+      log("debug", "Waiting for native classic skin selector", String(error));
+    } finally {
+      refreshInFlight = false;
+    }
+  }
+
+  function injectStyles() {
+    if (document.getElementById(STYLE_ID)) return;
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = `
+      .${HOST_CLASS} {
+        position: relative !important;
+      }
+
+      #${ROOT_ID}.rose-jade-wheel-jade-pane {
+        position: absolute !important;
+        inset: 0 !important;
+        z-index: 20 !important;
+        pointer-events: none !important;
+      }
+
+      .${CARD_CLASS}.${SELECTED_CLASS} > .rose-jade-history-anchor {
+        position: absolute !important;
+        top: -14px !important;
+        right: -14px !important;
+        left: auto !important;
+        width: 32px !important;
+        height: 32px !important;
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        z-index: 24 !important;
+        pointer-events: none !important;
+      }
+
+      .${CARD_CLASS}.${SELECTED_CLASS} > .lu-chroma-button,
+      .${CARD_CLASS}.${SELECTED_CLASS} > .forms-wheel-button {
+        top: -12px !important;
+        bottom: auto !important;
+        left: 50% !important;
+        transform: translateX(-50%) !important;
+        z-index: 14 !important;
+      }
+
+      .${CARD_CLASS}.${SELECTED_CLASS} > .lu-random-dice-button {
+        top: -43px !important;
+        left: 50% !important;
+        transform: translateX(-50%) !important;
+        z-index: 15 !important;
+      }
+
+      .${UNLOCKED_CLASS} {
+        cursor: pointer !important;
+      }
+
+      .${CARD_CLASS}.rose-jade-native-card--stabilizing,
+      .${CARD_CLASS}.rose-jade-native-card--stabilizing * {
+        transition: none !important;
+        animation: none !important;
+      }
+
+      .${UNLOCKED_CLASS} .skins-pane__locked-overlay,
+      .${UNLOCKED_CLASS} .skins-pane__locked-icon {
+        display: none !important;
+        pointer-events: none !important;
+      }
+
+      .${ACTIVE_ROOT_CLASS} .champion-select-center-container--picking-skins
+        .skins-pane__content .skins-pane__locked-overlay,
+      .${ACTIVE_ROOT_CLASS} .champion-select-center-container--picking-skins
+        .skins-pane__content .skins-pane__locked-icon {
+        display: none !important;
+        pointer-events: none !important;
+      }
+
+      .${EMPTY_CLASS} {
+        visibility: hidden !important;
+        pointer-events: none !important;
+        border-color: transparent !important;
+      }
+
+      .${ACTIVE_ROOT_CLASS} .champion-select-center-container--picking-skins
+        .skins-pane__skin-card--placeholder {
+        border: none !important;
+        visibility: hidden !important;
+        pointer-events: none !important;
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  function cleanupDom() {
+    for (const card of Array.from(adaptedCards)) clearCompatibility(card);
+    adaptedCards.clear();
+    pane?.removeEventListener("click", handleNativePaneClick, true);
+    document.querySelectorAll(`.${HOST_CLASS}`).forEach((element) => {
+      element.classList.remove(HOST_CLASS);
+    });
+    document.getElementById(ROOT_ID)?.remove();
+    document.querySelectorAll(".rose-jade-history-anchor").forEach((element) => element.remove());
+    pane = null;
+    overlay = null;
+    lastLayoutKey = "";
+  }
+
+  function startActiveRuntime() {
+    if (active) return;
+    if (visualProtectionClearTimer) clearTimeout(visualProtectionClearTimer);
+    visualProtectionClearTimer = null;
+    active = true;
+    requestGeneration += 1;
+    selectionGeneration = 0;
+    lastAppliedHistoricResourceSkinId = 0;
+    installNativeReadProjection();
+    installNativeWebsocketProjection();
+    injectStyles();
+    document.documentElement.classList.add(ACTIVE_ROOT_CLASS);
+    observer = new MutationObserver(() => adaptNativeController());
+    observer.observe(document.body, { childList: true, subtree: true });
+    document.addEventListener("pointerdown", handleUserNavigation, true);
+    document.addEventListener("keydown", handleUserNavigationKey, true);
+    pollTimer = setInterval(refreshSelection, POLL_INTERVAL_MS);
+    refreshSelection(true);
+    log("info", "Native classic skin adapter enabled", { phase, gameMode, mapId, queueId });
+  }
+
+  function stopActiveRuntime() {
+    if (!active) return;
+    active = false;
+    document.documentElement.classList.remove(ACTIVE_ROOT_CLASS);
+    requestGeneration += 1;
+    observer?.disconnect();
+    observer = null;
+    document.removeEventListener("pointerdown", handleUserNavigation, true);
+    document.removeEventListener("keydown", handleUserNavigationKey, true);
+    if (pollTimer) clearInterval(pollTimer);
+    pollTimer = null;
+    if (nativeProjectionTimer) clearTimeout(nativeProjectionTimer);
+    nativeProjectionTimer = null;
+    nativeProjectionTargetIndex = -1;
+    nativeProjectionCurrentIndex = -1;
+    drivingNativeProjection = false;
+    cleanupDom();
+    rawChampionId = 0;
+    championId = 0;
+    selectedRawSkinId = 0;
+    selectedResourceSkinId = 0;
+    modeDefaultRawSkinId = 0;
+    catalog = [];
+    catalogLoadedAt = 0;
+    desiredVisualSelection = null;
+    projectedCatalogIndex = -1;
+    clearUserNavigation();
+    visualCarrierProtectionActive = false;
+    pendingHistoricResourceSkinId = 0;
+    lastAppliedHistoricResourceSkinId = 0;
+    cancelHistoricVisualRestore("runtime-stop", true);
+    nativeProjectionComplete = null;
+    randomModeActive = false;
+    projectedVariantRawSkinId = 0;
+    pointerSelectionRawSkinId = 0;
+    pointerSelectionUntil = 0;
+    pointerSelectionCommitted = false;
+    lastVisualCenterRawSkinId = 0;
+    lastVisualProtectionKey = "";
+    lastReadRewriteKey = "";
+    refreshInFlight = false;
+    if (visualProtectionClearTimer) clearTimeout(visualProtectionClearTimer);
+    visualProtectionClearTimer = setTimeout(() => {
+      visualProtectionClearTimer = null;
+      setVisualProtection(null, "runtime-stop");
+    }, 3000);
+    window.dispatchEvent(
+      new CustomEvent("rose-jade-wheel-layout", {
+        detail: { active: false, rootId: ROOT_ID, native: true },
+      })
+    );
+    log("info", "Native classic skin adapter disabled");
+  }
+
+  function reconcileRuntime() {
+    if (isChampSelectPhase() && isJadeClassicContext()) startActiveRuntime();
+    else stopActiveRuntime();
+  }
+
+  async function syncContextFromLcu() {
+    try {
+      const [flowPhase, session] = await Promise.all([
+        fetchJson("/lol-gameflow/v1/gameflow-phase").catch(() => null),
+        fetchJson("/lol-gameflow/v1/session").catch(() => null),
+      ]);
+      if (flowPhase) phase = flowPhase;
+      const queue = session?.gameData?.queue || {};
+      gameMode = queue.gameMode || session?.map?.gameMode || gameMode;
+      mapId = queue.mapId || session?.map?.id || mapId;
+      queueId = queue.id || queueId;
+      reconcileRuntime();
+    } catch (error) {
+      log("debug", "LCU context sync deferred", String(error));
+    }
+  }
+
+  function handlePhaseChange(data) {
+    if (!data || typeof data !== "object") return;
+    phase = data.phase || phase;
+    gameMode = data.gameMode || gameMode;
+    mapId = data.mapId ?? mapId;
+    queueId = data.queueId ?? queueId;
+    reconcileRuntime();
+    if (isChampSelectPhase() && !isJadeClassicContext()) syncContextFromLcu();
+  }
+
+  async function start() {
+    if (typeof document === "undefined" || !document.body) {
+      requestAnimationFrame(start);
+      return;
+    }
+    bridge = await waitForBridge();
+    bridge.subscribe("phase-change", handlePhaseChange);
+    bridge.subscribe("champion-locked", () => {
+      if (active) refreshSelection(true);
+    });
+    bridge.subscribe("historic-state", handleHistoricState);
+    bridge.subscribe("random-mode-state", handleRandomModeState);
+    await syncContextFromLcu();
+    log("info", "Plugin initialized");
+  }
+
+  window.__roseJadeWheelDebug = {
+    refresh: () => refreshSelection(true),
+    state: () => ({
+      active,
+      phase,
+      gameMode,
+      mapId,
+      queueId,
+      championId,
+      rawChampionId,
+      selectedRawSkinId,
+      selectedResourceSkinId,
+      modeSkinCount: catalog.length,
+      nativeCardCount: nativeCards().length,
+      adaptedCardCount: adaptedCards.size,
+      desiredVisualRawSkinId: desiredVisualSelection?.rawSkinId || 0,
+      projectedVariantRawSkinId,
+      pendingUserTargetRawSkinId,
+    }),
+    resourceChampionId,
+    resourceSkinId,
+    jadeSkinId,
+    shouldPatchLcuSelection,
+    getModeSkinData,
+    catalogAssetSnapshot,
+    catalogData: () => catalog.map((entry) => entry.rawSkin),
+    projectResourceSelection,
+  };
+
+  start().catch((error) => log("error", "Plugin initialization failed", String(error)));
+})();

--- a/Pengu Loader/plugins/ROSE-FormsWheel/index.js
+++ b/Pengu Loader/plugins/ROSE-FormsWheel/index.js
@@ -1449,10 +1449,21 @@
       const phase = data.phase;
       const gameMode = data.gameMode;
       const mapId = data.mapId;
+      const classicMode =
+        mapId === 453 ||
+        data.queueId === 3260 ||
+        (typeof gameMode === "string" && gameMode.toUpperCase() === "JADE");
       // Late startup can replay "ChampSelect" after skin-state is already current.
       // Keep the last seen phase so we only reset on real phase transitions.
       const previousPhase = currentPhase;
       currentPhase = phase;
+
+      if (classicMode) {
+        resetFrontendSessionState("classic-plugin-isolation");
+        stopObserver();
+        isAramFromPython = false;
+        return;
+      }
 
       if (phase === "ChampSelect") {
         // Only reset on a real transition into a new Champ Select session.

--- a/Pengu Loader/plugins/ROSE-HistoricMode/index.js
+++ b/Pengu Loader/plugins/ROSE-HistoricMode/index.js
@@ -49,6 +49,7 @@
   let historicFlagImageUrl = null; // HTTP URL from Python
   const pendingHistoricFlagRequest = new Map(); // Track pending requests
   let isInChampSelect = false; // Track if we're in ChampSelect phase
+  let isInClassicMode = false;
   let pythonChromaState = null;
   let customModTargetSkinId = null;
   let customModTargetSkinIds = new Set();
@@ -135,9 +136,17 @@
 
   function handlePhaseChange(data) {
     const wasInChampSelect = isInChampSelect;
+    const classicMode =
+      data.mapId === 453 ||
+      data.queueId === 3260 ||
+      (typeof data.gameMode === "string" && data.gameMode.toUpperCase() === "JADE");
+    isInClassicMode = classicMode;
     // Check if we're entering ChampSelect phase
     isInChampSelect =
-      data.phase === "ChampSelect" || data.phase === "FINALIZATION";
+      !classicMode &&
+      (data.phase === "ChampSelect" || data.phase === "FINALIZATION");
+
+    if (classicMode) removeHistoricSkinName();
 
     if (isInChampSelect && !wasInChampSelect) {
       customModPopupActive = false;
@@ -913,6 +922,10 @@
   }
 
   const handleHistoricSkinNameUpdate = (payload) => {
+    if (isInClassicMode || window.__roseClassicWheelApi?.state?.().active === true) {
+      removeHistoricSkinName();
+      return;
+    }
     // A custom-mod popup owns this same visual layer. Historic-state
     // broadcasts can arrive slightly after the custom-mod selection, so do
     // not let an inactive historic update erase the custom-mod name.

--- a/Pengu Loader/plugins/ROSE-RandomSkin/index.js
+++ b/Pengu Loader/plugins/ROSE-RandomSkin/index.js
@@ -138,8 +138,14 @@
 
   function handlePhaseChange(data) {
     const wasInChampSelect = isInChampSelect;
+    const classicMode =
+      data.mapId === 453 ||
+      data.queueId === 3260 ||
+      (typeof data.gameMode === "string" && data.gameMode.toUpperCase() === "JADE");
     // Check if we're entering ChampSelect phase
-    isInChampSelect = data.phase === "ChampSelect" || data.phase === "FINALIZATION";
+    isInChampSelect =
+      !classicMode &&
+      (data.phase === "ChampSelect" || data.phase === "FINALIZATION");
 
     if (isInChampSelect && !wasInChampSelect) {
       log("debug", "Entered ChampSelect phase - enabling plugin");
@@ -708,4 +714,3 @@
     init();
   }
 })();
-

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Rose includes a suite of JavaScript plugins that extend the League Client UI:
 - **ROSE-HistoricMode**: Access to the last used skin for every champion
 - **ROSE-PartyMode**: Party mode UI — displays a panel in lobby and champion select to enable skin sharing, view connected peers, and see friends' skin selections in real time
 - **ROSE-Jade**: Client customization — regalia borders, backgrounds, banners, icons, titles, and win/loss stats
+- **ROSE-ClassicWheel / Chroma / Historic / Random**: Isolated controls for the native JADE Classic Mode skin catalog
 
 ## How It Works
 

--- a/docs/CLASSIC_MODE_SUPPORT.md
+++ b/docs/CLASSIC_MODE_SUPPORT.md
@@ -2,92 +2,109 @@
 
 ## Overview
 
-Classic Mode support is implemented as an isolated feature for JADE games. The
-regular game-mode flow and its existing plug-ins remain unchanged. Classic-only
-state, persistence, resource resolution, and client plug-ins are kept separate
-so that a Classic selection cannot leak into a regular match.
+Classic Mode support is isolated to JADE sessions. Its catalog, projected
+selection, history, random preference, chroma state, package lookup, and client
+controls do not replace the regular-mode implementations. The regular chroma,
+forms, history, and random plug-ins only add a lifecycle guard that removes
+their controls while JADE is active and restores their normal behavior after
+the session.
 
-## Mode Detection
+## Mode and ID Boundary
 
-Rose normalizes the active mode from live LCU session data. `gameMode == JADE`
-is the strongest signal, with queue `3260` and map `453` used as compatibility
-fallbacks. The normalized mode is stored centrally and is cleared when the
-champ-select session ends or contradicting session data is received.
+Rose derives Classic Mode from live LCU session data. `gameMode == JADE` is the
+primary signal, with queue `3260` and map `453` retained as compatibility
+fallbacks.
 
-## ID and Carrier Model
+Inside Rose, champion and skin IDs match the external `classic/` resource tree,
+for example champion `55` and skin `55301`. JADE's `600` prefix belongs only to
+the LCU transport boundary: `60055` and `60055301` are normalized when read and
+restored only when Rose must write a mode-native value back to LCU. Catalog,
+history, randomization, package lookup, naming, and injection use resource IDs.
 
-Classic Mode exposes several IDs for the same visual choice:
+The active carrier is resolved from the live Classic catalog rather than from a
+per-champion fallback table. Before an LCU write, Rose verifies that the carrier
+belongs to the active champion and is present in the current pickable-skin
+catalog.
 
-- The prime champion ID identifies the regular champion.
-- The mode champion ID identifies the Classic entity.
-- The raw LCU skin ID identifies the mode-native skin selection.
-- The resource skin ID identifies the package in the Classic resource library.
-- The visual skin ID identifies the regular skin being projected locally.
+## Native Carousel and Selection
 
-These ID domains are converted through `utils/core/classic_mode_ids.py` rather
-than inferred at individual call sites.
+`ROSE-ClassicWheel` adapts Riot's native JADE skin carousel. Riot's cards remain
+responsible for layout, focus, animation, arrow interaction, and full champion-
+select splash transitions. ClassicWheel supplies the Classic catalog, enforces
+its finite boundaries, projects history or random targets through native
+navigation, and publishes one normalized selection contract to the other
+Classic controls.
 
-Classic champions use different native carriers. Rose resolves a carrier from
-the current LCU catalog when possible and falls back to the versioned matrix:
+Owned Classic skins continue through the official LCU selection path. For an
+unowned target, Rose keeps a valid owned carrier as the server-visible LCU
+selection and stores the requested visual target separately. Automatic
+navigation may pass through owned cards to obtain the native splash transition,
+but those intermediate cards are not accepted as user selections. The target
+splash remains protected until real user navigation, a context exit, or an
+explicit replacement target releases it.
 
-- Skin0 for champions without a Classic Skin301/302 carrier.
-- Skin301 for the supported Skin301 champions.
-- Skin302 for Kayle.
-
-The carrier belongs to the current mode champion and remains the server-visible
-selection throughout local projection.
-
-## Selection and Ownership
-
-Owned Classic skins continue through the official LCU selection path and are not
-locally injected. For an unowned visual selection, Rose keeps the owned
-mode-native carrier in LCU and stores the requested visual skin separately. The
-unowned projected ID is never written to LCU.
-
-Selection generations reject stale events during the final lock transition.
-This prevents delayed UI events from replacing a newer selection or updating a
-different champion.
+Selection generations prevent delayed carousel or WebSocket events from
+replacing a newer target during the final lock transition. Injection consumes
+the accepted projected selection rather than inferring it again from transient
+card state.
 
 ## Classic Plug-ins
 
-Classic controls are provided by separate plug-ins:
+Classic controls are separate plug-ins:
 
-- `ROSE-ClassicWheel` provides the finite Classic skin carousel.
-- `ROSE-ClassicChroma` provides Classic chroma selection and persistence.
-- `ROSE-ClassicHistoric` provides isolated Classic history state and display.
-- `ROSE-ClassicRandom` provides per-champion Classic randomization.
+- `ROSE-ClassicWheel` provides the finite native carousel adapter and shared
+  selection contract.
+- `ROSE-ClassicChroma` renders variants from the Classic catalog and publishes
+  Classic chroma selections.
+- `ROSE-ClassicHistoric` restores and presents mode-scoped history.
+- `ROSE-ClassicRandom` stores per-champion random state and presents its dice
+  control and selected-card marker.
 
-The regular plug-ins are not modified to contain Classic conditionals. Classic
-controls clean themselves up when champ select ends and do not leave overlays or
-state behind for the next match.
+Classic randomization follows the regular-mode probability model: it selects a
+parent skin first, then chooses between that parent and its eligible chromas.
+The visual target is projected during the stable final-countdown window instead
+of moving the carousel as soon as random mode is enabled.
 
-`ROSE-ClassicWheel` ports Catcat's validated JADE adapter for Riot's native
-skin-card carousel. It is unrelated to `ROSE-CustomWheel`, which manages
-third-party mods. The chroma, history, and random plug-ins port Catcat's
-isolated JADE controls as Classic counterparts to Rose's regular features.
-They preserve the corresponding behavior and bridge contracts, but they are
-not source-level forks of the regular Rose plug-ins.
+Classic-specific Forms are not included because the current resource catalog
+does not contain a confirmed target that requires the regular FormsWheel
+behavior.
 
 ## Resource and Injection Flow
 
-Classic packages are resolved only from the `classic/` resource directory. Rose
-does not fall back to the regular `skins/` directory for a Classic selection.
-The downloader and cleanup logic treat `skins/`, `classic/`, and `resources/`
-as separate resource sets.
+Classic packages resolve only from the isolated `classic/` resource directory;
+Rose does not fall back to regular `skins/` packages for a Classic selection.
+Parent skins and nested chroma packages use the same normalized resource IDs
+published by ClassicWheel.
 
-Classic packages may use a mode-native carrier while targeting a different
-visual skin. The converted package therefore retains the required dependency
-closure and redirects model, weapon, animation, VFX, and related asset links to
-the correct carrier. Package preparation restores the native carrier before
-launch and reuses Rose's existing overlay and injection path.
+Before launching an unowned target, Rose restores the validated mode-native
+carrier and reuses the existing overlay and injection pipeline. The projected
+target, carrier, chroma, history state, selection generation, and final
+injection ID are retained as separate values through this boundary.
 
-Rose uses [Alban1911/LeagueSkins](https://github.com/Alban1911/LeagueSkins)
-as its default resource repository. Classic packages are read from that
+Classic peer selections in Party Mode are normalized into the Classic resource
+namespace before package lookup. This path has passed compilation checks but
+has not received formal live-machine validation.
+
+Rose uses [Alban1911/LeagueSkins](https://github.com/Alban1911/LeagueSkins) as
+its default resource repository. Classic packages are read from that
 repository's isolated `classic/` directory.
 
-## Current Limitations
+## Diagnostics
 
-Classic Mode support is working end to end, but some edge cases may still need
-follow-up validation across client versions and less common skin dependency
-graphs. The resource changes are currently maintained separately from Rose and
-can be proposed to the upstream resource repository in a later PR.
+Classic browser messages use searchable `[CLASSIC:<AREA>]` tags and are routed
+through the plug-in log bridge. Backend checkpoints cover catalog acceptance,
+selection and chroma changes, history and random state, LCU carrier state, game
+start identity, package resolution, and the final injection target. Regular-mode
+messages retain their existing prefixes.
+
+## Deferred Work
+
+Full third-party Mod loading in Classic Mode is still experimental and is not
+part of this stable commit series. The excluded work includes Classic-specific
+skin Mod controls, mode-scoped Mod history, and compatibility handling for map,
+font, announcer, UI, voiceover, loading-screen, VFX, SFX, and other Mod
+categories. Those paths require formal validation before they are proposed.
+
+`ROSE-SettingsPanel` integration for Classic skin Mods is also deferred. The
+regular `ROSE-CustomWheel`, `ROSE-CustomSkinSelector`, and SettingsPanel code
+remain available for regular game modes.

--- a/docs/CLASSIC_MODE_SUPPORT.md
+++ b/docs/CLASSIC_MODE_SUPPORT.md
@@ -97,13 +97,23 @@ selection and chroma changes, history and random state, LCU carrier state, game
 start identity, package resolution, and the final injection target. Regular-mode
 messages retain their existing prefixes.
 
-## Deferred Work
+## Experimental Mod Components
 
-Full third-party Mod loading in Classic Mode is still experimental and is not
-part of this stable commit series. The excluded work includes Classic-specific
-skin Mod controls, mode-scoped Mod history, and compatibility handling for map,
-font, announcer, UI, voiceover, loading-screen, VFX, SFX, and other Mod
-categories. Those paths require formal validation before they are proposed.
+The Classic third-party Mod source and backend contracts are included so the
+mode-specific state model remains complete. `ROSE-ClassicMods` contains the
+full selector and `ROSE-ClassicSkinSelector` contains the selected-card shortcut.
+Their entry points are stored as `index.js_`, Pengu Loader's native disabled
+format, so neither Classic control is loaded or shown by default.
+
+Classic and regular Mod history use separate persistence scopes. Active skin,
+map, font, announcer, UI, voiceover, loading-screen, VFX, SFX, and other Mod
+selections are discarded before they can cross the mode boundary. The regular
+CustomWheel is also hidden during JADE sessions.
+
+Full Classic Mod loading remains experimental and has not received formal
+live-machine validation. The disabled entry points must not be enabled until
+the relevant package categories and their Classic carrier behavior have been
+validated.
 
 `ROSE-SettingsPanel` integration for Classic skin Mods is also deferred. The
 regular `ROSE-CustomWheel`, `ROSE-CustomSkinSelector`, and SettingsPanel code

--- a/docs/CLASSIC_MODE_SUPPORT.md
+++ b/docs/CLASSIC_MODE_SUPPORT.md
@@ -1,0 +1,93 @@
+# Classic Mode Support
+
+## Overview
+
+Classic Mode support is implemented as an isolated feature for JADE games. The
+regular game-mode flow and its existing plug-ins remain unchanged. Classic-only
+state, persistence, resource resolution, and client plug-ins are kept separate
+so that a Classic selection cannot leak into a regular match.
+
+## Mode Detection
+
+Rose normalizes the active mode from live LCU session data. `gameMode == JADE`
+is the strongest signal, with queue `3260` and map `453` used as compatibility
+fallbacks. The normalized mode is stored centrally and is cleared when the
+champ-select session ends or contradicting session data is received.
+
+## ID and Carrier Model
+
+Classic Mode exposes several IDs for the same visual choice:
+
+- The prime champion ID identifies the regular champion.
+- The mode champion ID identifies the Classic entity.
+- The raw LCU skin ID identifies the mode-native skin selection.
+- The resource skin ID identifies the package in the Classic resource library.
+- The visual skin ID identifies the regular skin being projected locally.
+
+These ID domains are converted through `utils/core/classic_mode_ids.py` rather
+than inferred at individual call sites.
+
+Classic champions use different native carriers. Rose resolves a carrier from
+the current LCU catalog when possible and falls back to the versioned matrix:
+
+- Skin0 for champions without a Classic Skin301/302 carrier.
+- Skin301 for the supported Skin301 champions.
+- Skin302 for Kayle.
+
+The carrier belongs to the current mode champion and remains the server-visible
+selection throughout local projection.
+
+## Selection and Ownership
+
+Owned Classic skins continue through the official LCU selection path and are not
+locally injected. For an unowned visual selection, Rose keeps the owned
+mode-native carrier in LCU and stores the requested visual skin separately. The
+unowned projected ID is never written to LCU.
+
+Selection generations reject stale events during the final lock transition.
+This prevents delayed UI events from replacing a newer selection or updating a
+different champion.
+
+## Classic Plug-ins
+
+Classic controls are provided by separate plug-ins:
+
+- `ROSE-ClassicWheel` provides the finite Classic skin carousel.
+- `ROSE-ClassicChroma` provides Classic chroma selection and persistence.
+- `ROSE-ClassicHistoric` provides isolated Classic history state and display.
+- `ROSE-ClassicRandom` provides per-champion Classic randomization.
+
+The regular plug-ins are not modified to contain Classic conditionals. Classic
+controls clean themselves up when champ select ends and do not leave overlays or
+state behind for the next match.
+
+`ROSE-ClassicWheel` ports Catcat's validated JADE adapter for Riot's native
+skin-card carousel. It is unrelated to `ROSE-CustomWheel`, which manages
+third-party mods. The chroma, history, and random plug-ins port Catcat's
+isolated JADE controls as Classic counterparts to Rose's regular features.
+They preserve the corresponding behavior and bridge contracts, but they are
+not source-level forks of the regular Rose plug-ins.
+
+## Resource and Injection Flow
+
+Classic packages are resolved only from the `classic/` resource directory. Rose
+does not fall back to the regular `skins/` directory for a Classic selection.
+The downloader and cleanup logic treat `skins/`, `classic/`, and `resources/`
+as separate resource sets.
+
+Classic packages may use a mode-native carrier while targeting a different
+visual skin. The converted package therefore retains the required dependency
+closure and redirects model, weapon, animation, VFX, and related asset links to
+the correct carrier. Package preparation restores the native carrier before
+launch and reuses Rose's existing overlay and injection path.
+
+Rose uses [Alban1911/LeagueSkins](https://github.com/Alban1911/LeagueSkins)
+as its default resource repository. Classic packages are read from that
+repository's isolated `classic/` directory.
+
+## Current Limitations
+
+Classic Mode support is working end to end, but some edge cases may still need
+follow-up validation across client versions and less common skin dependency
+graphs. The resource changes are currently maintained separately from Rose and
+can be proposed to the upstream resource repository in a later PR.

--- a/injection/core/injector.py
+++ b/injection/core/injector.py
@@ -234,6 +234,10 @@ class SkinInjector:
             except Exception as e:
                 log.warning(f"[INJECT] Extra mods callback failed: {e}")
 
+        if stop_callback and stop_callback():
+            log.info("[INJECT] Injection preparation became stale; overlay skipped")
+            return False
+
         # Create and run overlay
         result = self._mk_run_overlay(mod_names, timeout, stop_callback, injection_manager)
         

--- a/injection/core/injector.py
+++ b/injection/core/injector.py
@@ -106,9 +106,16 @@ class SkinInjector:
         # Check for CSLOL tools
         self.tools_manager.check_tools_available()
     
-    def _resolve_zip(self, zip_arg: str, chroma_id: int = None, skin_name: str = None, champion_name: str = None, champion_id: int = None) -> Optional[Path]:
+    def _resolve_zip(self, zip_arg: str, chroma_id: int = None, skin_name: str = None, champion_name: str = None, champion_id: int = None, game_mode: str = None) -> Optional[Path]:
         """Resolve a ZIP by name or path with fuzzy matching"""
-        return self.zip_resolver.resolve_zip(zip_arg, chroma_id, skin_name, champion_name, champion_id)
+        return self.zip_resolver.resolve_zip(
+            zip_arg,
+            chroma_id,
+            skin_name,
+            champion_name,
+            champion_id,
+            game_mode,
+        )
     
     def _clean_mods_dir(self):
         """Clean the mods directory"""
@@ -146,6 +153,7 @@ class SkinInjector:
         champion_name: str = None,
         champion_id: int = None,
         extra_mods_callback: Optional[Callable[["SkinInjector"], List[str]]] = None,
+        game_mode: Optional[str] = None,
     ) -> bool:
         """Inject a single skin (with optional chroma and party mods)
         
@@ -168,9 +176,21 @@ class SkinInjector:
         if skin_name and skin_name.split()[-1].isdigit():
             base_skin_name = ' '.join(skin_name.split()[:-1])
         
-        zp = self._resolve_zip(skin_name, chroma_id=chroma_id, skin_name=base_skin_name, champion_name=champion_name, champion_id=champion_id)
+        zp = self._resolve_zip(
+            skin_name,
+            chroma_id=chroma_id,
+            skin_name=base_skin_name,
+            champion_name=champion_name,
+            champion_id=champion_id,
+            game_mode=game_mode,
+        )
         if not zp:
-            log.error(f"[INJECT] Skin '{skin_name}' not found in {self.zips_dir}")
+            search_dir = (
+                self.zip_resolver.classic_dir
+                if isinstance(game_mode, str) and game_mode.upper() == "JADE"
+                else self.zips_dir
+            )
+            log.error(f"[INJECT] Skin '{skin_name}' not found in {search_dir}")
             report_issue(
                 "SKIN_ZIP_NOT_FOUND",
                 "error",
@@ -178,8 +198,8 @@ class SkinInjector:
                 details={"skin": skin_name},
                 hint="Download the skin first, or check your skins folder.",
             )
-            avail_zip = list(self.zips_dir.rglob('*.zip'))
-            avail_fantome = list(self.zips_dir.rglob('*.fantome'))
+            avail_zip = list(search_dir.rglob('*.zip'))
+            avail_fantome = list(search_dir.rglob('*.fantome'))
             avail = avail_zip + avail_fantome
             if avail:
                 log.info("[INJECT] Available skins (first 10):")
@@ -188,6 +208,8 @@ class SkinInjector:
             return False
         
         log.debug(f"[INJECT] Using skin file: {zp}")
+        if isinstance(game_mode, str) and game_mode.upper() == "JADE":
+            log.info("[CLASSIC] Using mode-native Classic package: %s", zp)
         
         # Clean mods and overlay directories, then extract new skin
         clean_start = time.time()

--- a/injection/core/manager.py
+++ b/injection/core/manager.py
@@ -181,7 +181,12 @@ class InjectionManager:
             success = self.injector.inject_skin(
                 skin_name,
                 stop_callback=None,
-                injection_manager=self
+                injection_manager=self,
+                game_mode=(
+                    getattr(self.shared_state, "current_game_mode", None)
+                    if self.shared_state
+                    else None
+                ),
             )
 
             if success:
@@ -328,6 +333,11 @@ class InjectionManager:
                 champion_name=champion_name,
                 champion_id=champion_id,
                 extra_mods_callback=extra_mods_callback,
+                game_mode=(
+                    getattr(self.shared_state, "current_game_mode", None)
+                    if self.shared_state
+                    else None
+                ),
             )
             
             if success:

--- a/injection/mods/zip_resolver.py
+++ b/injection/mods/zip_resolver.py
@@ -11,6 +11,8 @@ from typing import Optional
 from utils.core.logging import get_logger, log_success
 from utils.core.classic_mode_ids import (
     is_classic_mode,
+    resource_champion_id,
+    resource_skin_id,
 )
 
 log = get_logger()
@@ -53,6 +55,9 @@ class ZipResolver:
             skin_name: Optional base skin name for chroma lookup
             champion_id: Optional champion ID for path construction.
         """
+        champion_id = resource_champion_id(champion_id) if champion_id else champion_id
+        if chroma_id is not None:
+            chroma_id = resource_skin_id(chroma_id)
         use_classic = is_classic_mode(game_mode)
         source_dir = self.classic_dir if use_classic else self.zips_dir
         log.debug(
@@ -78,17 +83,17 @@ class ZipResolver:
         # Handle ID-based naming convention from random selection
         if zip_arg.startswith('skin_'):
             # Format: skin_{skin_id} - check if this is actually a chroma
-            skin_id = int(zip_arg.split('_')[1])
+            skin_id = resource_skin_id(int(zip_arg.split('_')[1]))
             if not champion_id:
                 log.warning(f"[INJECT] No champion_id provided for skin ID: {skin_id}")
                 return None
             
             # If chroma_id is provided, this is actually a chroma (Swiftplay case)
             if chroma_id is not None:
-                return self._resolve_chroma_by_id(champion_id, chroma_id)
+                return self._resolve_chroma_by_id(champion_id, chroma_id, source_dir)
             
             # This is a base skin - look for {champion_id}/{skin_id}/{skin_id}.zip/.fantome
-            skin_dir = self.zips_dir / str(champion_id) / str(skin_id)
+            skin_dir = source_dir / str(champion_id) / str(skin_id)
             found = _find_by_extensions(skin_dir, str(skin_id))
             if found:
                 log.debug(f"[INJECT] Found skin: {found}")
@@ -97,16 +102,16 @@ class ZipResolver:
                 # Not found as base skin - might be a chroma that was incorrectly labeled as skin_
                 # Try searching for it as a chroma in any base skin directory
                 log.debug(f"[INJECT] Base skin not found, checking if {skin_id} is a chroma...")
-                return self._resolve_chroma_by_id(champion_id, skin_id)
+                return self._resolve_chroma_by_id(champion_id, skin_id, source_dir)
         
         elif zip_arg.startswith('chroma_'):
             # Format: chroma_{chroma_id} - this is a chroma
-            chroma_id = int(zip_arg.split('_')[1])
+            chroma_id = resource_skin_id(int(zip_arg.split('_')[1]))
             if not champion_id:
                 log.warning(f"[INJECT] No champion_id provided for chroma ID: {chroma_id}")
                 return None
             
-            return self._resolve_chroma_by_id(champion_id, chroma_id)
+            return self._resolve_chroma_by_id(champion_id, chroma_id, source_dir)
 
         # For base skins (no chroma_id), we need skin_id
         if chroma_id is None and skin_name:
@@ -121,6 +126,11 @@ class ZipResolver:
 
         # If chroma_id is provided, look in chroma subdirectory structure
         if chroma_id is not None:
+            if use_classic:
+                return self._resolve_chroma_by_id(
+                    champion_id, chroma_id, source_dir
+                )
+
             # Special handling for Elementalist Lux forms (fake IDs 99991-99999)
             if 99991 <= chroma_id <= 99999:
                 return self._resolve_elementalist_lux_form(chroma_id)
@@ -157,9 +167,14 @@ class ZipResolver:
         log.warning(f"[INJECT] Base skin lookup by name not fully implemented for new structure: {zip_arg}")
         return None
     
-    def _resolve_chroma_by_id(self, champion_id: int, chroma_id: int) -> Optional[Path]:
+    def _resolve_chroma_by_id(
+        self,
+        champion_id: int,
+        chroma_id: int,
+        base_dir: Optional[Path] = None,
+    ) -> Optional[Path]:
         """Resolve chroma ZIP by champion ID and chroma ID"""
-        champion_dir = self.zips_dir / str(champion_id)
+        champion_dir = (base_dir or self.zips_dir) / str(champion_id)
         if not champion_dir.exists():
             log.warning(f"[INJECT] Champion directory not found: {champion_dir}")
             return None

--- a/injection/mods/zip_resolver.py
+++ b/injection/mods/zip_resolver.py
@@ -9,6 +9,9 @@ from pathlib import Path
 from typing import Optional
 
 from utils.core.logging import get_logger, log_success
+from utils.core.classic_mode_ids import (
+    is_classic_mode,
+)
 
 log = get_logger()
 
@@ -36,11 +39,12 @@ def _rglob_by_extensions(base: Path, pattern_stem: str) -> Optional[Path]:
 class ZipResolver:
     """Resolves skin and chroma ZIP files from various naming conventions"""
     
-    def __init__(self, zips_dir: Path):
+    def __init__(self, zips_dir: Path, classic_dir: Optional[Path] = None):
         self.zips_dir = zips_dir
+        self.classic_dir = classic_dir or zips_dir.parent / "classic"
         self.zips_dir.mkdir(parents=True, exist_ok=True)
     
-    def resolve_zip(self, zip_arg: str, chroma_id: int = None, skin_name: str = None, champion_name: str = None, champion_id: int = None) -> Optional[Path]:
+    def resolve_zip(self, zip_arg: str, chroma_id: int = None, skin_name: str = None, champion_name: str = None, champion_id: int = None, game_mode: str = None) -> Optional[Path]:
         """Resolve a ZIP by name or path with fuzzy matching, supporting new merged structure
         
         Args:
@@ -49,9 +53,26 @@ class ZipResolver:
             skin_name: Optional base skin name for chroma lookup
             champion_id: Optional champion ID for path construction.
         """
-        log.debug(f"[INJECT] Resolving zip for: '{zip_arg}' (chroma_id: {chroma_id}, skin_name: {skin_name})")
+        use_classic = is_classic_mode(game_mode)
+        source_dir = self.classic_dir if use_classic else self.zips_dir
+        log.debug(
+            "[INJECT] Resolving zip for: %r (chroma_id=%s, skin_name=%s, source=%s)",
+            zip_arg,
+            chroma_id,
+            skin_name,
+            "classic" if use_classic else "skins",
+        )
         cand = Path(zip_arg)
         if cand.exists():
+            if use_classic:
+                try:
+                    cand.resolve().relative_to(self.classic_dir.resolve())
+                except ValueError:
+                    log.warning(
+                        "[CLASSIC] Refusing package outside Classic resource root: %s",
+                        cand,
+                    )
+                    return None
             return cand
 
         # Handle ID-based naming convention from random selection
@@ -294,4 +315,3 @@ class ZipResolver:
             return found
         log.warning(f"[INJECT] Gun Goddess Miss Fortune {form_name} form file not found")
         return None
-

--- a/lcu/core/client.py
+++ b/lcu/core/client.py
@@ -127,6 +127,10 @@ class LCU:
     def set_my_selection_skin(self, skin_id: int) -> bool:
         """Set the selected skin using my-selection endpoint"""
         return self._skin_selection.set_my_selection_skin(skin_id)
+
+    def bind_shared_state(self, shared_state) -> None:
+        """Bind runtime state used by mode-specific LCU write guards."""
+        self._skin_selection.bind_shared_state(shared_state)
     
     # Game mode properties (delegated to game mode handler)
     @property

--- a/lcu/features/lcu_skin_selection.py
+++ b/lcu/features/lcu_skin_selection.py
@@ -43,11 +43,14 @@ class LCUSkinSelection:
             return False
         if not is_classic_skin_id(value):
             return False
-        if value // 1000 != state.classic_mode_champion_id:
+        canonical_skin_id = resource_skin_id(value)
+        if canonical_skin_id // 1000 != state.classic_champion_id:
             return False
-        owned = set(state.owned_skin_ids or ())
-        carrier = state.classic_carrier_lcu_skin_id
-        return value == carrier or value in owned or resource_skin_id(value) in owned
+        owned = {resource_skin_id(item) for item in (state.owned_skin_ids or ())}
+        return (
+            canonical_skin_id == state.classic_default_skin_id
+            or canonical_skin_id in owned
+        )
     
     def set_selected_skin(self, action_id: int, skin_id: int) -> bool:
         """Set the selected skin for a champion select action

--- a/lcu/features/lcu_skin_selection.py
+++ b/lcu/features/lcu_skin_selection.py
@@ -6,6 +6,11 @@ Handles skin selection via LCU API
 """
 
 from config import LCU_API_TIMEOUT_S
+from utils.core.classic_mode_ids import (
+    is_classic_mode,
+    is_classic_skin_id,
+    resource_skin_id,
+)
 from utils.core.logging import get_logger
 
 log = get_logger()
@@ -14,7 +19,7 @@ log = get_logger()
 class LCUSkinSelection:
     """Handles skin selection operations"""
     
-    def __init__(self, api, connection):
+    def __init__(self, api, connection, shared_state=None):
         """Initialize skin selection handler
         
         Args:
@@ -23,6 +28,26 @@ class LCUSkinSelection:
         """
         self.api = api
         self.connection = connection
+        self.shared_state = shared_state
+
+    def bind_shared_state(self, shared_state) -> None:
+        self.shared_state = shared_state
+
+    def _classic_write_allowed(self, skin_id: object) -> bool:
+        state = self.shared_state
+        if state is None or not is_classic_mode(state.current_game_mode):
+            return True
+        try:
+            value = int(skin_id)
+        except (TypeError, ValueError):
+            return False
+        if not is_classic_skin_id(value):
+            return False
+        if value // 1000 != state.classic_mode_champion_id:
+            return False
+        owned = set(state.owned_skin_ids or ())
+        carrier = state.classic_carrier_lcu_skin_id
+        return value == carrier or value in owned or resource_skin_id(value) in owned
     
     def set_selected_skin(self, action_id: int, skin_id: int) -> bool:
         """Set the selected skin for a champion select action
@@ -34,6 +59,10 @@ class LCUSkinSelection:
         Returns:
             True if successful, False otherwise
         """
+        if not self._classic_write_allowed(skin_id):
+            log.error("Refused unsafe Classic Mode LCU skin write: %s", skin_id)
+            return False
+
         if not self.connection.ok:
             self.connection.refresh_if_needed()
             if not self.connection.ok:
@@ -66,6 +95,10 @@ class LCUSkinSelection:
         Returns:
             True if successful, False otherwise
         """
+        if not self._classic_write_allowed(skin_id):
+            log.error("Refused unsafe Classic Mode LCU skin write: %s", skin_id)
+            return False
+
         if not self.connection.ok:
             self.connection.refresh_if_needed()
             if not self.connection.ok:
@@ -88,4 +121,3 @@ class LCUSkinSelection:
         except Exception as e:
             log.warning(f"LCU set_my_selection_skin exception: {e}")
             return False
-

--- a/main/core/initialization.py
+++ b/main/core/initialization.py
@@ -49,6 +49,7 @@ def initialize_core_components(args, injection_threshold: Optional[float] = None
         
         log.info("Initializing shared state...")
         state = SharedState()
+        lcu.bind_shared_state(state)
         log.info("Shared state initialized")
     except Exception as e:
         log.error("=" * 80)
@@ -114,4 +115,3 @@ def initialize_core_components(args, injection_threshold: Optional[float] = None
         sys.exit(1)
     
     return lcu, skin_scraper, state, injection_manager
-

--- a/party/integration/injection_hook.py
+++ b/party/integration/injection_hook.py
@@ -159,6 +159,7 @@ class PartyInjectionHook:
                 skin_name=skin_name,
                 champion_name=None,
                 champion_id=champion_id,
+                game_mode=getattr(self.state, "current_game_mode", None),
             )
 
             if not zip_path or not zip_path.exists():

--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -432,10 +432,24 @@ class MessageHandler:
             random_enabled = is_random_enabled_for_champion(champion_id)
         except Exception:
             random_enabled = False
-        if random_enabled and not self.shared_state.random_mode_active:
-            from ui.handlers.randomization_handler import RandomizationHandler
+        if random_enabled:
+            if not self.shared_state.random_mode_active:
+                from ui.handlers.randomization_handler import RandomizationHandler
 
-            RandomizationHandler(self.shared_state, self.skin_scraper).activate_persisted()
+                RandomizationHandler(
+                    self.shared_state, self.skin_scraper
+                ).activate_persisted()
+            # A persisted Classic random preference owns this selection. A
+            # later catalog refresh must not revive Historic mode as well.
+            if (
+                self.shared_state.historic_mode_active
+                or self.shared_state.historic_skin_id is not None
+            ):
+                self.shared_state.historic_mode_active = False
+                self.shared_state.historic_skin_id = None
+                self.shared_state.classic_history_skin_id = None
+                self.broadcaster.broadcast_historic_state()
+            self.shared_state.historic_first_detection_done = True
             return
         if not self.shared_state.historic_first_detection_done:
             from utils.core.historic import get_historic_skin_for_champion

--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -401,6 +401,29 @@ class MessageHandler:
         self.shared_state.classic_catalog_resource_skin_ids = {
             resource_skin_id(value) for value in raw_ids
         }
+        eligible_values = payload.get("randomEligibleRawSkinIds")
+        if eligible_values is None:
+            existing = {
+                int(value)
+                for value in self.shared_state.classic_random_eligible_resource_skin_ids
+                if int(value) // 1000 == prime_champion_id
+            }
+            if not existing:
+                existing = {resource_skin_id(value) for value in raw_ids}
+            self.shared_state.classic_random_eligible_resource_skin_ids = existing
+        else:
+            try:
+                eligible_raw_ids = {
+                    int(value)
+                    for value in eligible_values
+                    if int(value) in raw_ids
+                    and int(value) // 1000 == raw_champion_id
+                }
+            except (TypeError, ValueError):
+                eligible_raw_ids = set()
+            self.shared_state.classic_random_eligible_resource_skin_ids = {
+                resource_skin_id(value) for value in eligible_raw_ids
+            }
         return True
 
     def _handle_classic_mode_catalog(self, payload: dict) -> None:
@@ -503,20 +526,35 @@ class MessageHandler:
         self.shared_state.selected_skin_id = visual_skin_id
         self.shared_state.classic_selection_generation = incoming_generation
 
+        selection_source = str(payload.get("source") or "")
         if owned:
             self.shared_state.classic_visual_skin_id = None
             self.shared_state.classic_visual_raw_skin_id = None
             self.shared_state.classic_visual_chroma_id = None
+            self.shared_state.selected_chroma_id = None
             if visual_skin_id not in owned_ids:
                 self.shared_state.owned_skin_ids.add(visual_skin_id)
+            if selection_source == "classic-chroma":
+                lcu = getattr(self.skin_scraper, "lcu", None)
+                if lcu is not None:
+                    lcu.set_my_selection_skin(raw_skin_id)
         else:
             self.shared_state.classic_visual_skin_id = visual_skin_id
             self.shared_state.classic_visual_raw_skin_id = raw_skin_id
             lcu = getattr(self.skin_scraper, "lcu", None)
-            if lcu is not None and self.shared_state.selected_lcu_skin_id != carrier:
+            if lcu is not None:
                 lcu.set_my_selection_skin(carrier)
 
         if payload.get("userInitiated") is True:
+            if (
+                self.shared_state.random_mode_active
+                or self.shared_state.classic_random_enabled
+            ):
+                from ui.handlers.randomization_handler import RandomizationHandler
+
+                RandomizationHandler(
+                    self.shared_state, self.skin_scraper
+                ).cancel()
             self.shared_state.historic_mode_active = False
             self.shared_state.historic_skin_id = None
             self.shared_state.classic_history_skin_id = None
@@ -555,6 +593,7 @@ class MessageHandler:
                     for value in self.shared_state.classic_catalog_raw_skin_ids
                 ],
                 "skin": payload.get("chromaName") or f"skin_{visual_skin_id}",
+                "source": "classic-chroma",
                 "userInitiated": True,
                 "selectionGeneration": (
                     self.shared_state.classic_selection_generation + 1
@@ -563,10 +602,11 @@ class MessageHandler:
         )
         self._handle_classic_skin_selection(selection)
         if self.shared_state.last_hovered_skin_id == visual_skin_id:
-            self.shared_state.classic_visual_chroma_id = (
+            selected_chroma_id = (
                 visual_skin_id if int(payload.get("chromaId") or 0) else None
             )
-            self.shared_state.selected_chroma_id = self.shared_state.classic_visual_chroma_id
+            self.shared_state.classic_visual_chroma_id = selected_chroma_id
+            self.shared_state.selected_chroma_id = selected_chroma_id
             self.broadcaster.broadcast_chroma_state()
     
     def _handle_chroma_selection(self, payload: dict) -> None:

--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -137,6 +137,34 @@ class MessageHandler:
         self.mod_storage = mod_storage or ModStorageService()
         self.injection_manager = injection_manager
 
+    def _historic_scope(self) -> str:
+        from utils.core.historic import historic_scope_for_state
+
+        return historic_scope_for_state(self.shared_state)
+
+    def _drop_mismatched_mod_selections(self) -> None:
+        scope = self._historic_scope()
+
+        def matches(value) -> bool:
+            return isinstance(value, dict) and value.get("scope", "regular") == scope
+
+        for attr in (
+            "selected_custom_mod",
+            "selected_map_mod",
+            "selected_font_mod",
+            "selected_announcer_mod",
+            "selected_other_mod",
+        ):
+            value = getattr(self.shared_state, attr, None)
+            if value and not matches(value):
+                setattr(self.shared_state, attr, None)
+
+        selections = getattr(self.shared_state, "selected_other_mods", None)
+        if isinstance(selections, list):
+            self.shared_state.selected_other_mods = [
+                value for value in selections if matches(value)
+            ]
+
     def _is_valid_local_league_path(self, game_path: str) -> bool:
         """Validate a League install path without touching UNC/network paths."""
         if not isinstance(game_path, str):
@@ -1126,6 +1154,7 @@ class MessageHandler:
     
     def _handle_request_skin_mods(self, payload: dict) -> None:
         """Return the list of custom mods for a champion (all skins)"""
+        self._drop_mismatched_mod_selections()
         if not self.mod_storage:
             return
 
@@ -1187,7 +1216,9 @@ class MessageHandler:
         try:
             from utils.core.historic import get_historic_skin_for_champion, is_custom_mod_path, get_custom_mod_path
             if champion_id:
-                historic_value = get_historic_skin_for_champion(champion_id)
+                historic_value = get_historic_skin_for_champion(
+                    champion_id, self._historic_scope()
+                )
                 if historic_value and is_custom_mod_path(historic_value):
                     historic_mod_path = get_custom_mod_path(historic_value)
                     historic_identifier = self._normalize_mod_identifier(historic_mod_path)
@@ -1321,6 +1352,7 @@ class MessageHandler:
     
     def _handle_request_maps(self, payload: dict) -> None:
         """Return the list of maps"""
+        self._drop_mismatched_mod_selections()
         if not self.mod_storage:
             return
         
@@ -1334,7 +1366,7 @@ class MessageHandler:
         historic_map_path = None
         try:
             from utils.core.mod_historic import get_historic_mod
-            historic_map_path = get_historic_mod("map")
+            historic_map_path = get_historic_mod("map", self._historic_scope())
         except Exception:
             pass
         
@@ -1352,6 +1384,7 @@ class MessageHandler:
     
     def _handle_request_fonts(self, payload: dict) -> None:
         """Return the list of fonts"""
+        self._drop_mismatched_mod_selections()
         if not self.mod_storage:
             return
         
@@ -1365,7 +1398,7 @@ class MessageHandler:
         historic_font_path = None
         try:
             from utils.core.mod_historic import get_historic_mod
-            historic_font_path = get_historic_mod("font")
+            historic_font_path = get_historic_mod("font", self._historic_scope())
         except Exception:
             pass
         
@@ -1383,6 +1416,7 @@ class MessageHandler:
     
     def _handle_request_announcers(self, payload: dict) -> None:
         """Return the list of announcers"""
+        self._drop_mismatched_mod_selections()
         if not self.mod_storage:
             return
         
@@ -1396,7 +1430,7 @@ class MessageHandler:
         historic_announcer_path = None
         try:
             from utils.core.mod_historic import get_historic_mod
-            historic_announcer_path = get_historic_mod("announcer")
+            historic_announcer_path = get_historic_mod("announcer", self._historic_scope())
         except Exception:
             pass
         
@@ -1414,6 +1448,7 @@ class MessageHandler:
     
     def _handle_request_others(self, payload: dict) -> None:
         """Return the list of others"""
+        self._drop_mismatched_mod_selections()
         if not self.mod_storage:
             return
         
@@ -1427,7 +1462,7 @@ class MessageHandler:
         historic_other_paths = None
         try:
             from utils.core.mod_historic import get_historic_mod
-            historic_other_paths = get_historic_mod("other")
+            historic_other_paths = get_historic_mod("other", self._historic_scope())
             # Convert to list if it's a single string (legacy format)
             if isinstance(historic_other_paths, str):
                 historic_other_paths = [historic_other_paths]
@@ -1548,11 +1583,14 @@ class MessageHandler:
                     champ_id = self.shared_state.selected_custom_mod.get("champion_id")
                     rel_path = self.shared_state.selected_custom_mod.get("relative_path")
                     if champ_id and rel_path:
-                        historic_value = get_historic_skin_for_champion(int(champ_id))
+                        history_scope = self._historic_scope()
+                        historic_value = get_historic_skin_for_champion(
+                            int(champ_id), history_scope
+                        )
                         if historic_value is not None and is_custom_mod_path(historic_value):
                             historic_path = get_custom_mod_path(historic_value)
                             if historic_path and historic_path.replace("\\", "/") == str(rel_path).replace("\\", "/"):
-                                clear_historic_entry(int(champ_id))
+                                clear_historic_entry(int(champ_id), history_scope)
                                 log.info("[HISTORIC] Cleared saved custom mod for champion %s", champ_id)
                 except Exception as exc:
                     log.debug("[HISTORIC] Failed to clear saved custom mod on deselect: %s", exc)
@@ -1728,6 +1766,7 @@ class MessageHandler:
 
             # The explicitly selected skin/chroma folder is the target.
             self.shared_state.selected_custom_mod = {
+                "scope": self._historic_scope(),
                 "skin_id": int(skin_id),
                 "storage_skin_id": selected_mod.skin_id,
                 "target_skin_ids": sorted(self._get_entry_target_skin_ids(selected_mod)),
@@ -1814,11 +1853,14 @@ class MessageHandler:
             champ_id = self.shared_state.selected_custom_mod.get("champion_id")
             rel_path = self.shared_state.selected_custom_mod.get("relative_path")
             if champ_id and rel_path:
-                historic_value = get_historic_skin_for_champion(int(champ_id))
+                history_scope = self._historic_scope()
+                historic_value = get_historic_skin_for_champion(
+                    int(champ_id), history_scope
+                )
                 if historic_value is not None and is_custom_mod_path(historic_value):
                     historic_path = get_custom_mod_path(historic_value)
                     if historic_path and historic_path.replace("\\", "/") == str(rel_path).replace("\\", "/"):
-                        clear_historic_entry(int(champ_id))
+                        clear_historic_entry(int(champ_id), history_scope)
                         log.info("[Dismiss] Cleared historic entry for champion %s", champ_id)
         except Exception as exc:
             log.debug("[Dismiss] Failed to clear historic entry: %s", exc)
@@ -1847,12 +1889,14 @@ class MessageHandler:
                 or self.shared_state.hovered_champ_id
             )
             historic_value = (
-                get_historic_skin_for_champion(int(champ_id))
+                get_historic_skin_for_champion(
+                    int(champ_id), self._historic_scope()
+                )
                 if champ_id is not None
                 else None
             )
             if champ_id is not None and is_custom_mod_path(historic_value):
-                clear_historic_entry(int(champ_id))
+                clear_historic_entry(int(champ_id), self._historic_scope())
                 log.info("[Dismiss] Cleared custom historic entry for champion %s", champ_id)
         except Exception as exc:
             log.debug("[Dismiss] Failed to clear custom historic entry: %s", exc)
@@ -1886,7 +1930,7 @@ class MessageHandler:
                 # Clear historic mod when deselected
                 try:
                     from utils.core.mod_historic import clear_historic_mod
-                    clear_historic_mod("map")
+                    clear_historic_mod("map", self._historic_scope())
                     log.debug("[MOD_HISTORIC] Cleared historic map mod")
                 except Exception as e:
                     log.debug(f"[MOD_HISTORIC] Failed to clear historic map mod: {e}")
@@ -1955,6 +1999,7 @@ class MessageHandler:
 
             # Store selected map mod in shared state for injection
             self.shared_state.selected_map_mod = {
+                "scope": self._historic_scope(),
                 "mod_name": selected_mod.mod_name,
                 "mod_path": str(selected_mod.path),
                 "mod_folder_name": mod_folder_name,
@@ -1986,7 +2031,7 @@ class MessageHandler:
                 # Clear historic mod when deselected
                 try:
                     from utils.core.mod_historic import clear_historic_mod
-                    clear_historic_mod("font")
+                    clear_historic_mod("font", self._historic_scope())
                     log.debug("[MOD_HISTORIC] Cleared historic font mod")
                 except Exception as e:
                     log.debug(f"[MOD_HISTORIC] Failed to clear historic font mod: {e}")
@@ -2054,6 +2099,7 @@ class MessageHandler:
 
             # Store selected font mod in shared state for injection
             self.shared_state.selected_font_mod = {
+                "scope": self._historic_scope(),
                 "mod_name": selected_mod.mod_name,
                 "mod_path": str(selected_mod.path),
                 "mod_folder_name": mod_folder_name,
@@ -2085,7 +2131,7 @@ class MessageHandler:
                 # Clear historic mod when deselected
                 try:
                     from utils.core.mod_historic import clear_historic_mod
-                    clear_historic_mod("announcer")
+                    clear_historic_mod("announcer", self._historic_scope())
                     log.debug("[MOD_HISTORIC] Cleared historic announcer mod")
                 except Exception as e:
                     log.debug(f"[MOD_HISTORIC] Failed to clear historic announcer mod: {e}")
@@ -2153,6 +2199,7 @@ class MessageHandler:
 
             # Store selected announcer mod in shared state for injection
             self.shared_state.selected_announcer_mod = {
+                "scope": self._historic_scope(),
                 "mod_name": selected_mod.mod_name,
                 "mod_path": str(selected_mod.path),
                 "mod_folder_name": mod_folder_name,
@@ -2211,9 +2258,9 @@ class MessageHandler:
 
                 for cat, paths in by_cat.items():
                     if paths:
-                        write_historic_mod(cat, paths)
+                        write_historic_mod(cat, paths, self._historic_scope())
                     else:
-                        clear_historic_mod(cat)
+                        clear_historic_mod(cat, self._historic_scope())
             except Exception as e:
                 log.debug(f"[MOD_HISTORIC] Failed to update category historic after deselect: {e}")
             return
@@ -2273,6 +2320,7 @@ class MessageHandler:
 
             # Store selected other mod in shared state for injection (add to list)
             mod_info = {
+                "scope": self._historic_scope(),
                 "mod_name": selected_mod.mod_name,
                 "mod_path": str(selected_mod.path),
                 "mod_folder_name": mod_folder_name,
@@ -2311,9 +2359,9 @@ class MessageHandler:
 
                 for cat, paths in by_cat.items():
                     if paths:
-                        write_historic_mod(cat, paths)
+                        write_historic_mod(cat, paths, self._historic_scope())
                     else:
-                        clear_historic_mod(cat)
+                        clear_historic_mod(cat, self._historic_scope())
             except Exception as e:
                 log.debug(f"[MOD_HISTORIC] Failed to update category historic after select: {e}")
 
@@ -2324,6 +2372,7 @@ class MessageHandler:
 
     def _handle_request_category_mods(self, payload: dict) -> None:
         """Return the list of mods for a specific top-level category under %LOCALAPPDATA%\\Rose\\mods."""
+        self._drop_mismatched_mod_selections()
         if not self.mod_storage:
             return
 
@@ -2348,7 +2397,7 @@ class MessageHandler:
         historic_paths = None
         try:
             from utils.core.mod_historic import get_historic_mod
-            historic_paths = get_historic_mod(str(category))
+            historic_paths = get_historic_mod(str(category), self._historic_scope())
             if isinstance(historic_paths, str):
                 historic_paths = [historic_paths]
         except Exception:

--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -176,7 +176,7 @@ class MessageHandler:
         payload_type = payload.get("type")
         
         # Route to appropriate handler
-        if payload_type == "chroma-log":
+        if payload_type in {"chroma-log", "plugin-log"}:
             self._handle_chroma_log(payload)
         elif payload_type == "request-local-preview":
             self._handle_request_local_preview(payload)
@@ -267,11 +267,19 @@ class MessageHandler:
             self._handle_skin_detection(payload)
     
     def _handle_chroma_log(self, payload: dict) -> None:
-        """Handle chroma log message"""
-        source = payload.get("source", "ChromaWheel")
+        """Persist browser plug-in logs without losing their level or source."""
+        source = str(payload.get("source") or "UnknownPlugin")[:64]
         event = payload.get("event") or payload.get("message") or "unknown"
         details = payload.get("data") or payload
-        log.info("[%s] %s | %s", source, event, details)
+        level = str(payload.get("level") or "info").lower()
+        emit = {
+            "debug": log.debug,
+            "info": log.info,
+            "warn": log.warning,
+            "warning": log.warning,
+            "error": log.error,
+        }.get(level, log.info)
+        emit("[PLUGIN:%s] %s | %s", source, event, details)
     
     def _handle_request_local_preview(self, payload: dict) -> None:
         """Handle request for local preview image"""
@@ -424,6 +432,13 @@ class MessageHandler:
             self.shared_state.classic_random_eligible_resource_skin_ids = {
                 resource_skin_id(value) for value in eligible_raw_ids
             }
+        log.info(
+            "[CLASSIC:CATALOG] accepted champion=%s raw_count=%s carrier=%s random_count=%s",
+            prime_champion_id,
+            len(raw_ids),
+            carrier,
+            len(self.shared_state.classic_random_eligible_resource_skin_ids),
+        )
         return True
 
     def _handle_classic_mode_catalog(self, payload: dict) -> None:
@@ -431,6 +446,12 @@ class MessageHandler:
             log.warning("Rejected invalid Classic Mode catalog")
             return
         champion_id = self.shared_state.classic_prime_champion_id
+        log.info(
+            "[CLASSIC:CATALOG] processing champion=%s persisted_random=%s history_checked=%s",
+            champion_id,
+            self.shared_state.random_mode_active,
+            self.shared_state.historic_first_detection_done,
+        )
         try:
             from utils.core.random_preferences import is_random_enabled_for_champion
 
@@ -527,6 +548,7 @@ class MessageHandler:
         self.shared_state.classic_selection_generation = incoming_generation
 
         selection_source = str(payload.get("source") or "")
+        lcu_action = "owned-selection"
         if owned:
             self.shared_state.classic_visual_skin_id = None
             self.shared_state.classic_visual_raw_skin_id = None
@@ -539,11 +561,23 @@ class MessageHandler:
                 if lcu is not None:
                     lcu.set_my_selection_skin(raw_skin_id)
         else:
+            lcu_action = "carrier-fallback"
             self.shared_state.classic_visual_skin_id = visual_skin_id
             self.shared_state.classic_visual_raw_skin_id = raw_skin_id
             lcu = getattr(self.skin_scraper, "lcu", None)
             if lcu is not None:
                 lcu.set_my_selection_skin(carrier)
+
+        log.info(
+            "[CLASSIC:SELECTION] source=%s visual=%s raw=%s owned=%s carrier=%s lcu_action=%s generation=%s",
+            selection_source or "classic-wheel",
+            visual_skin_id,
+            raw_skin_id,
+            owned,
+            carrier,
+            lcu_action,
+            incoming_generation,
+        )
 
         if payload.get("userInitiated") is True:
             if (
@@ -607,6 +641,13 @@ class MessageHandler:
             )
             self.shared_state.classic_visual_chroma_id = selected_chroma_id
             self.shared_state.selected_chroma_id = selected_chroma_id
+            log.info(
+                "[CLASSIC:CHROMA] selected raw=%s visual=%s chroma=%s owned=%s",
+                raw_skin_id,
+                visual_skin_id,
+                selected_chroma_id,
+                self.shared_state.classic_selected_skin_owned,
+            )
             self.broadcaster.broadcast_chroma_state()
     
     def _handle_chroma_selection(self, payload: dict) -> None:

--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -25,14 +25,12 @@ from utils.core.issue_reporter import clear_issues, read_issues_tail
 from utils.core.junction import is_junction, safe_remove_entry, link_or_extract
 from utils.core.classic_mode_ids import (
     CLASSIC_MODE,
-    carrier_skin_number,
     catalog_skin_ids,
     is_classic_mode,
-    is_classic_skin_id,
-    mode_champion_id,
+    mode_skin_id,
     resource_champion_id,
     resource_skin_id,
-    validated_carrier_lcu_skin_id,
+    validated_default_skin_id,
 )
 from utils.core.utilities import get_base_skin_id_for_chroma
 from utils.system.admin_utils import (
@@ -182,9 +180,9 @@ class MessageHandler:
             self._handle_request_local_preview(payload)
         elif payload_type == "request-local-asset":
             self._handle_request_local_asset(payload)
-        elif payload_type in {"classic-mode-catalog", "jade-mode-catalog"}:
+        elif payload_type == "classic-mode-catalog":
             self._handle_classic_mode_catalog(payload)
-        elif payload_type in {"classic-skin-selection", "jade-skin-selection"}:
+        elif payload_type == "classic-skin-selection":
             self._handle_classic_skin_selection(payload)
         elif payload_type == "chroma-selection" and is_classic_mode(
             self.shared_state.current_game_mode
@@ -347,11 +345,7 @@ class MessageHandler:
 
     @staticmethod
     def _classic_schema_supported(payload: dict) -> bool:
-        schema_version = payload.get("schemaVersion")
-        return schema_version == 1 or (
-            schema_version is None
-            and str(payload.get("type") or "").startswith("jade-")
-        )
+        return payload.get("schemaVersion") == 1
 
     def _cache_classic_catalog(self, payload: dict) -> bool:
         if (
@@ -361,83 +355,63 @@ class MessageHandler:
         ):
             return False
         try:
-            raw_champion_id = int(
-                payload.get("modeChampionId")
-                or payload.get("rawChampionId")
+            champion_id = resource_champion_id(
+                payload.get("championId")
                 or 0
-            )
-            prime_champion_id = int(
-                payload.get("primeChampionId")
-                or resource_champion_id(raw_champion_id)
             )
         except (TypeError, ValueError):
             return False
         if (
-            raw_champion_id != mode_champion_id(prime_champion_id)
+            champion_id <= 0
             or (
                 self.shared_state.locked_champ_id is not None
-                and int(self.shared_state.locked_champ_id) != prime_champion_id
+                and int(self.shared_state.locked_champ_id) != champion_id
             )
         ):
             return False
 
         catalog = payload.get("catalog")
-        raw_ids = catalog_skin_ids(catalog, prime_champion_id)
-        if not raw_ids:
+        skin_ids = catalog_skin_ids(catalog, champion_id)
+        if not skin_ids:
             return False
         try:
-            carrier = validated_carrier_lcu_skin_id(
-                prime_champion_id,
+            default_skin_id = validated_default_skin_id(
+                champion_id,
                 catalog,
-                payload.get("carrierLcuSkinId") or payload.get("baseRawSkinId"),
+                payload.get("defaultSkinId"),
             )
         except ValueError:
             return False
-        advertised_number = payload.get("carrierSkinNumber")
-        if advertised_number is not None:
-            try:
-                if int(advertised_number) != carrier_skin_number(carrier):
-                    return False
-            except (TypeError, ValueError):
-                return False
 
-        self.shared_state.classic_prime_champion_id = prime_champion_id
-        self.shared_state.classic_mode_champion_id = raw_champion_id
-        self.shared_state.classic_carrier_lcu_skin_id = carrier
-        self.shared_state.classic_carrier_skin_number = carrier_skin_number(carrier)
-        self.shared_state.classic_catalog_raw_skin_ids = raw_ids
-        self.shared_state.classic_catalog_resource_skin_ids = {
-            resource_skin_id(value) for value in raw_ids
-        }
-        eligible_values = payload.get("randomEligibleRawSkinIds")
+        self.shared_state.classic_champion_id = champion_id
+        self.shared_state.classic_default_skin_id = default_skin_id
+        self.shared_state.classic_catalog_skin_ids = skin_ids
+        eligible_values = payload.get("randomEligibleSkinIds")
         if eligible_values is None:
             existing = {
-                int(value)
-                for value in self.shared_state.classic_random_eligible_resource_skin_ids
-                if int(value) // 1000 == prime_champion_id
+                resource_skin_id(value)
+                for value in self.shared_state.classic_random_eligible_skin_ids
+                if resource_skin_id(value) // 1000 == champion_id
             }
             if not existing:
-                existing = {resource_skin_id(value) for value in raw_ids}
-            self.shared_state.classic_random_eligible_resource_skin_ids = existing
+                existing = set(skin_ids)
+            self.shared_state.classic_random_eligible_skin_ids = existing
         else:
             try:
-                eligible_raw_ids = {
-                    int(value)
+                eligible_skin_ids = {
+                    resource_skin_id(value)
                     for value in eligible_values
-                    if int(value) in raw_ids
-                    and int(value) // 1000 == raw_champion_id
+                    if resource_skin_id(value) in skin_ids
                 }
             except (TypeError, ValueError):
-                eligible_raw_ids = set()
-            self.shared_state.classic_random_eligible_resource_skin_ids = {
-                resource_skin_id(value) for value in eligible_raw_ids
-            }
+                eligible_skin_ids = set()
+            self.shared_state.classic_random_eligible_skin_ids = eligible_skin_ids
         log.info(
-            "[CLASSIC:CATALOG] accepted champion=%s raw_count=%s carrier=%s random_count=%s",
-            prime_champion_id,
-            len(raw_ids),
-            carrier,
-            len(self.shared_state.classic_random_eligible_resource_skin_ids),
+            "[CLASSIC:CATALOG] accepted champion=%s skin_count=%s default=%s random_count=%s",
+            champion_id,
+            len(skin_ids),
+            default_skin_id,
+            len(self.shared_state.classic_random_eligible_skin_ids),
         )
         return True
 
@@ -445,7 +419,7 @@ class MessageHandler:
         if not self._cache_classic_catalog(payload):
             log.warning("Rejected invalid Classic Mode catalog")
             return
-        champion_id = self.shared_state.classic_prime_champion_id
+        champion_id = self.shared_state.classic_champion_id
         log.info(
             "[CLASSIC:CATALOG] processing champion=%s persisted_random=%s history_checked=%s",
             champion_id,
@@ -472,7 +446,7 @@ class MessageHandler:
             if (
                 isinstance(historic_skin_id, int)
                 and historic_skin_id
-                in self.shared_state.classic_catalog_resource_skin_ids
+                in self.shared_state.classic_catalog_skin_ids
             ):
                 self.shared_state.historic_mode_active = True
                 self.shared_state.historic_skin_id = historic_skin_id
@@ -483,14 +457,11 @@ class MessageHandler:
     def _handle_classic_skin_selection(self, payload: dict) -> None:
         """Track a validated local projection without submitting it to LCU."""
         generation_value = payload.get("selectionGeneration")
-        if generation_value is None and str(payload.get("type") or "").startswith("jade-"):
-            incoming_generation = self.shared_state.classic_selection_generation
-        else:
-            try:
-                incoming_generation = int(generation_value)
-            except (TypeError, ValueError):
-                log.warning("Rejected Classic Mode selection without a valid generation")
-                return
+        try:
+            incoming_generation = int(generation_value)
+        except (TypeError, ValueError):
+            log.warning("Rejected Classic Mode selection without a valid generation")
+            return
         current_generation = self.shared_state.classic_selection_generation
         if incoming_generation < current_generation or (
             payload.get("userInitiated") is True
@@ -503,78 +474,71 @@ class MessageHandler:
             )
             return
         try:
-            raw_skin_id = int(payload.get("rawSkinId") or 0)
-            visual_skin_id = int(
-                payload.get("visualSkinId") or payload.get("skinId") or 0
+            skin_id = resource_skin_id(
+                payload.get("skinId")
+                or 0
             )
         except (TypeError, ValueError):
             return
         locked_champion_id = self.shared_state.locked_champ_id
         if (
-            not is_classic_skin_id(raw_skin_id)
-            or resource_skin_id(raw_skin_id) != visual_skin_id
+            skin_id <= 0
             or (
                 locked_champion_id is not None
-                and raw_skin_id // 1000 != mode_champion_id(locked_champion_id)
+                and skin_id // 1000 != int(locked_champion_id)
             )
         ):
             log.warning(
-                "Rejected Classic Mode visual selection resource=%s raw=%s",
-                visual_skin_id,
-                raw_skin_id,
+                "Rejected Classic Mode selection skin=%s",
+                skin_id,
             )
             return
         if not self._cache_classic_catalog(payload):
             log.warning("Rejected Classic Mode selection with invalid catalog")
             return
         if (
-            raw_skin_id not in self.shared_state.classic_catalog_raw_skin_ids
-            or raw_skin_id // 1000 != self.shared_state.classic_mode_champion_id
+            skin_id not in self.shared_state.classic_catalog_skin_ids
+            or skin_id // 1000 != self.shared_state.classic_champion_id
         ):
             log.warning(
                 "Rejected Classic Mode selection outside the validated catalog"
             )
             return
 
-        carrier = self.shared_state.classic_carrier_lcu_skin_id
+        default_skin_id = self.shared_state.classic_default_skin_id
         owned_ids = set(self.shared_state.owned_skin_ids or ())
-        owned = (
-            raw_skin_id == carrier
-            or raw_skin_id in owned_ids
-            or visual_skin_id in owned_ids
-        )
+        owned = skin_id == default_skin_id or skin_id in {
+            resource_skin_id(value) for value in owned_ids
+        }
         self.shared_state.classic_selected_skin_owned = owned
-        self.shared_state.selected_skin_id = visual_skin_id
+        self.shared_state.selected_skin_id = skin_id
         self.shared_state.classic_selection_generation = incoming_generation
 
         selection_source = str(payload.get("source") or "")
         lcu_action = "owned-selection"
         if owned:
             self.shared_state.classic_visual_skin_id = None
-            self.shared_state.classic_visual_raw_skin_id = None
             self.shared_state.classic_visual_chroma_id = None
             self.shared_state.selected_chroma_id = None
-            if visual_skin_id not in owned_ids:
-                self.shared_state.owned_skin_ids.add(visual_skin_id)
+            if skin_id not in owned_ids:
+                self.shared_state.owned_skin_ids.add(skin_id)
             if selection_source == "classic-chroma":
                 lcu = getattr(self.skin_scraper, "lcu", None)
                 if lcu is not None:
-                    lcu.set_my_selection_skin(raw_skin_id)
+                    lcu.set_my_selection_skin(mode_skin_id(skin_id))
         else:
-            lcu_action = "carrier-fallback"
-            self.shared_state.classic_visual_skin_id = visual_skin_id
-            self.shared_state.classic_visual_raw_skin_id = raw_skin_id
+            lcu_action = "default-fallback"
+            self.shared_state.classic_visual_skin_id = skin_id
             lcu = getattr(self.skin_scraper, "lcu", None)
             if lcu is not None:
-                lcu.set_my_selection_skin(carrier)
+                lcu.set_my_selection_skin(mode_skin_id(default_skin_id))
 
         log.info(
-            "[CLASSIC:SELECTION] source=%s visual=%s raw=%s owned=%s carrier=%s lcu_action=%s generation=%s",
+            "[CLASSIC:SELECTION] source=%s skin=%s owned=%s default=%s lcu_action=%s generation=%s",
             selection_source or "classic-wheel",
-            visual_skin_id,
-            raw_skin_id,
+            skin_id,
             owned,
-            carrier,
+            default_skin_id,
             lcu_action,
             incoming_generation,
         )
@@ -595,19 +559,19 @@ class MessageHandler:
             self.shared_state.historic_first_detection_done = True
             self.broadcaster.broadcast_historic_state()
 
-        skin_name = str(payload.get("skin") or f"skin_{visual_skin_id}").strip()
+        skin_name = str(payload.get("skin") or f"skin_{skin_id}").strip()
         self.skin_processor.last_skin_name = skin_name
         self.skin_processor.process_skin_name(skin_name, self.broadcaster)
-        self.shared_state.ui_skin_id = visual_skin_id
-        self.shared_state.last_hovered_skin_id = visual_skin_id
+        self.shared_state.ui_skin_id = skin_id
+        self.shared_state.last_hovered_skin_id = skin_id
         self.shared_state.last_hovered_skin_key = skin_name
         self.shared_state.ui_last_text = skin_name
-        self.broadcaster.broadcast_skin_state(skin_name, visual_skin_id)
+        self.broadcaster.broadcast_skin_state(skin_name, skin_id)
 
     def _handle_classic_chroma_selection(self, payload: dict) -> None:
-        raw_skin_id = payload.get("rawSkinId")
+        selected_skin_id = payload.get("skinId")
         try:
-            visual_skin_id = resource_skin_id(raw_skin_id)
+            skin_id = resource_skin_id(selected_skin_id)
         except (TypeError, ValueError):
             return
         selection = dict(payload)
@@ -616,17 +580,14 @@ class MessageHandler:
                 "type": "classic-skin-selection",
                 "schemaVersion": 1,
                 "mode": CLASSIC_MODE,
-                "primeChampionId": self.shared_state.classic_prime_champion_id,
-                "modeChampionId": self.shared_state.classic_mode_champion_id,
-                "carrierLcuSkinId": self.shared_state.classic_carrier_lcu_skin_id,
-                "carrierSkinNumber": self.shared_state.classic_carrier_skin_number,
-                "visualSkinId": visual_skin_id,
-                "skinId": visual_skin_id,
+                "championId": self.shared_state.classic_champion_id,
+                "defaultSkinId": self.shared_state.classic_default_skin_id,
+                "skinId": skin_id,
                 "catalog": [
                     {"id": value}
-                    for value in self.shared_state.classic_catalog_raw_skin_ids
+                    for value in self.shared_state.classic_catalog_skin_ids
                 ],
-                "skin": payload.get("chromaName") or f"skin_{visual_skin_id}",
+                "skin": payload.get("chromaName") or f"skin_{skin_id}",
                 "source": "classic-chroma",
                 "userInitiated": True,
                 "selectionGeneration": (
@@ -635,16 +596,16 @@ class MessageHandler:
             }
         )
         self._handle_classic_skin_selection(selection)
-        if self.shared_state.last_hovered_skin_id == visual_skin_id:
+        if self.shared_state.last_hovered_skin_id == skin_id:
             selected_chroma_id = (
-                visual_skin_id if int(payload.get("chromaId") or 0) else None
+                skin_id if int(payload.get("chromaId") or 0) else None
             )
             self.shared_state.classic_visual_chroma_id = selected_chroma_id
             self.shared_state.selected_chroma_id = selected_chroma_id
             log.info(
                 "[CLASSIC:CHROMA] selected raw=%s visual=%s chroma=%s owned=%s",
-                raw_skin_id,
-                visual_skin_id,
+                selected_skin_id,
+                skin_id,
                 selected_chroma_id,
                 self.shared_state.classic_selected_skin_owned,
             )

--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -486,6 +486,11 @@ class MessageHandler:
 
         if payload.get("userInitiated") is True:
             self.shared_state.classic_selection_generation += 1
+            self.shared_state.historic_mode_active = False
+            self.shared_state.historic_skin_id = None
+            self.shared_state.classic_history_skin_id = None
+            self.shared_state.historic_first_detection_done = True
+            self.broadcaster.broadcast_historic_state()
 
         skin_name = str(payload.get("skin") or f"skin_{visual_skin_id}").strip()
         self.skin_processor.last_skin_name = skin_name

--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -406,6 +406,19 @@ class MessageHandler:
     def _handle_classic_mode_catalog(self, payload: dict) -> None:
         if not self._cache_classic_catalog(payload):
             log.warning("Rejected invalid Classic Mode catalog")
+            return
+        champion_id = self.shared_state.classic_prime_champion_id
+        try:
+            from utils.core.random_preferences import is_random_enabled_for_champion
+
+            random_enabled = is_random_enabled_for_champion(champion_id)
+        except Exception:
+            random_enabled = False
+        if random_enabled and not self.shared_state.random_mode_active:
+            from ui.handlers.randomization_handler import RandomizationHandler
+
+            RandomizationHandler(self.shared_state, self.skin_scraper).activate_persisted()
+            return
 
     def _handle_classic_skin_selection(self, payload: dict) -> None:
         """Track a validated local projection without submitting it to LCU."""

--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -28,6 +28,7 @@ from utils.core.classic_mode_ids import (
     carrier_skin_number,
     catalog_skin_ids,
     is_classic_mode,
+    is_classic_skin_id,
     mode_champion_id,
     resource_champion_id,
     resource_skin_id,
@@ -183,6 +184,8 @@ class MessageHandler:
             self._handle_request_local_asset(payload)
         elif payload_type in {"classic-mode-catalog", "jade-mode-catalog"}:
             self._handle_classic_mode_catalog(payload)
+        elif payload_type in {"classic-skin-selection", "jade-skin-selection"}:
+            self._handle_classic_skin_selection(payload)
         elif payload_type == "chroma-selection":
             self._handle_chroma_selection(payload)
         elif payload_type == "dice-button-click":
@@ -399,6 +402,66 @@ class MessageHandler:
     def _handle_classic_mode_catalog(self, payload: dict) -> None:
         if not self._cache_classic_catalog(payload):
             log.warning("Rejected invalid Classic Mode catalog")
+
+    def _handle_classic_skin_selection(self, payload: dict) -> None:
+        """Track a validated local projection without submitting it to LCU."""
+        if not self._cache_classic_catalog(payload):
+            log.warning("Rejected Classic Mode selection with invalid catalog")
+            return
+        try:
+            raw_skin_id = int(payload.get("rawSkinId") or 0)
+            visual_skin_id = int(
+                payload.get("visualSkinId") or payload.get("skinId") or 0
+            )
+        except (TypeError, ValueError):
+            return
+        if (
+            not is_classic_skin_id(raw_skin_id)
+            or raw_skin_id not in self.shared_state.classic_catalog_raw_skin_ids
+            or raw_skin_id // 1000 != self.shared_state.classic_mode_champion_id
+            or resource_skin_id(raw_skin_id) != visual_skin_id
+        ):
+            log.warning(
+                "Rejected Classic Mode visual selection resource=%s raw=%s",
+                visual_skin_id,
+                raw_skin_id,
+            )
+            return
+
+        carrier = self.shared_state.classic_carrier_lcu_skin_id
+        owned_ids = set(self.shared_state.owned_skin_ids or ())
+        owned = (
+            raw_skin_id == carrier
+            or raw_skin_id in owned_ids
+            or visual_skin_id in owned_ids
+        )
+        self.shared_state.classic_selected_skin_owned = owned
+        self.shared_state.selected_skin_id = visual_skin_id
+
+        if owned:
+            self.shared_state.classic_visual_skin_id = None
+            self.shared_state.classic_visual_raw_skin_id = None
+            self.shared_state.classic_visual_chroma_id = None
+            if visual_skin_id not in owned_ids:
+                self.shared_state.owned_skin_ids.add(visual_skin_id)
+        else:
+            self.shared_state.classic_visual_skin_id = visual_skin_id
+            self.shared_state.classic_visual_raw_skin_id = raw_skin_id
+            lcu = getattr(self.skin_scraper, "lcu", None)
+            if lcu is not None and self.shared_state.selected_lcu_skin_id != carrier:
+                lcu.set_my_selection_skin(carrier)
+
+        if payload.get("userInitiated") is True:
+            self.shared_state.classic_selection_generation += 1
+
+        skin_name = str(payload.get("skin") or f"skin_{visual_skin_id}").strip()
+        self.skin_processor.last_skin_name = skin_name
+        self.skin_processor.process_skin_name(skin_name, self.broadcaster)
+        self.shared_state.ui_skin_id = visual_skin_id
+        self.shared_state.last_hovered_skin_id = visual_skin_id
+        self.shared_state.last_hovered_skin_key = skin_name
+        self.shared_state.ui_last_text = skin_name
+        self.broadcaster.broadcast_skin_state(skin_name, visual_skin_id)
 
     def _handle_chroma_selection(self, payload: dict) -> None:
         """Handle chroma selection from JavaScript"""

--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -438,9 +438,6 @@ class MessageHandler:
 
     def _handle_classic_skin_selection(self, payload: dict) -> None:
         """Track a validated local projection without submitting it to LCU."""
-        if not self._cache_classic_catalog(payload):
-            log.warning("Rejected Classic Mode selection with invalid catalog")
-            return
         generation_value = payload.get("selectionGeneration")
         if generation_value is None and str(payload.get("type") or "").startswith("jade-"):
             incoming_generation = self.shared_state.classic_selection_generation
@@ -468,11 +465,14 @@ class MessageHandler:
             )
         except (TypeError, ValueError):
             return
+        locked_champion_id = self.shared_state.locked_champ_id
         if (
             not is_classic_skin_id(raw_skin_id)
-            or raw_skin_id not in self.shared_state.classic_catalog_raw_skin_ids
-            or raw_skin_id // 1000 != self.shared_state.classic_mode_champion_id
             or resource_skin_id(raw_skin_id) != visual_skin_id
+            or (
+                locked_champion_id is not None
+                and raw_skin_id // 1000 != mode_champion_id(locked_champion_id)
+            )
         ):
             log.warning(
                 "Rejected Classic Mode visual selection resource=%s raw=%s",
@@ -480,6 +480,18 @@ class MessageHandler:
                 raw_skin_id,
             )
             return
+        if not self._cache_classic_catalog(payload):
+            log.warning("Rejected Classic Mode selection with invalid catalog")
+            return
+        if (
+            raw_skin_id not in self.shared_state.classic_catalog_raw_skin_ids
+            or raw_skin_id // 1000 != self.shared_state.classic_mode_champion_id
+        ):
+            log.warning(
+                "Rejected Classic Mode selection outside the validated catalog"
+            )
+            return
+
         carrier = self.shared_state.classic_carrier_lcu_skin_id
         owned_ids = set(self.shared_state.owned_skin_ids or ())
         owned = (

--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -186,6 +186,10 @@ class MessageHandler:
             self._handle_classic_mode_catalog(payload)
         elif payload_type in {"classic-skin-selection", "jade-skin-selection"}:
             self._handle_classic_skin_selection(payload)
+        elif payload_type == "chroma-selection" and is_classic_mode(
+            self.shared_state.current_game_mode
+        ):
+            self._handle_classic_chroma_selection(payload)
         elif payload_type == "chroma-selection":
             self._handle_chroma_selection(payload)
         elif payload_type == "dice-button-click":
@@ -463,6 +467,40 @@ class MessageHandler:
         self.shared_state.ui_last_text = skin_name
         self.broadcaster.broadcast_skin_state(skin_name, visual_skin_id)
 
+    def _handle_classic_chroma_selection(self, payload: dict) -> None:
+        raw_skin_id = payload.get("rawSkinId")
+        try:
+            visual_skin_id = resource_skin_id(raw_skin_id)
+        except (TypeError, ValueError):
+            return
+        selection = dict(payload)
+        selection.update(
+            {
+                "type": "classic-skin-selection",
+                "schemaVersion": 1,
+                "mode": CLASSIC_MODE,
+                "primeChampionId": self.shared_state.classic_prime_champion_id,
+                "modeChampionId": self.shared_state.classic_mode_champion_id,
+                "carrierLcuSkinId": self.shared_state.classic_carrier_lcu_skin_id,
+                "carrierSkinNumber": self.shared_state.classic_carrier_skin_number,
+                "visualSkinId": visual_skin_id,
+                "skinId": visual_skin_id,
+                "catalog": [
+                    {"id": value}
+                    for value in self.shared_state.classic_catalog_raw_skin_ids
+                ],
+                "skin": payload.get("chromaName") or f"skin_{visual_skin_id}",
+                "userInitiated": True,
+            }
+        )
+        self._handle_classic_skin_selection(selection)
+        if self.shared_state.last_hovered_skin_id == visual_skin_id:
+            self.shared_state.classic_visual_chroma_id = (
+                visual_skin_id if int(payload.get("chromaId") or 0) else None
+            )
+            self.shared_state.selected_chroma_id = self.shared_state.classic_visual_chroma_id
+            self.broadcaster.broadcast_chroma_state()
+    
     def _handle_chroma_selection(self, payload: dict) -> None:
         """Handle chroma selection from JavaScript"""
         chroma_id = payload.get("chromaId") or payload.get("skinId")

--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -23,6 +23,16 @@ from injection.mods.storage import ModStorageService
 from utils.core.paths import get_user_data_dir, get_asset_path, get_injection_dir, open_folder_in_explorer
 from utils.core.issue_reporter import clear_issues, read_issues_tail
 from utils.core.junction import is_junction, safe_remove_entry, link_or_extract
+from utils.core.classic_mode_ids import (
+    CLASSIC_MODE,
+    carrier_skin_number,
+    catalog_skin_ids,
+    is_classic_mode,
+    mode_champion_id,
+    resource_champion_id,
+    resource_skin_id,
+    validated_carrier_lcu_skin_id,
+)
 from utils.core.utilities import get_base_skin_id_for_chroma
 from utils.system.admin_utils import (
     is_admin,
@@ -171,6 +181,8 @@ class MessageHandler:
             self._handle_request_local_preview(payload)
         elif payload_type == "request-local-asset":
             self._handle_request_local_asset(payload)
+        elif payload_type in {"classic-mode-catalog", "jade-mode-catalog"}:
+            self._handle_classic_mode_catalog(payload)
         elif payload_type == "chroma-selection":
             self._handle_chroma_selection(payload)
         elif payload_type == "dice-button-click":
@@ -317,7 +329,77 @@ class MessageHandler:
                     log.debug(f"[SkinMonitor] Local asset not found: {asset_path}")
             except Exception as e:
                 log.debug(f"[SkinMonitor] Failed to get local asset: {e}")
-    
+
+    @staticmethod
+    def _classic_schema_supported(payload: dict) -> bool:
+        schema_version = payload.get("schemaVersion")
+        return schema_version == 1 or (
+            schema_version is None
+            and str(payload.get("type") or "").startswith("jade-")
+        )
+
+    def _cache_classic_catalog(self, payload: dict) -> bool:
+        if (
+            not self._classic_schema_supported(payload)
+            or not is_classic_mode(self.shared_state.current_game_mode)
+            or str(payload.get("mode") or CLASSIC_MODE).upper() != CLASSIC_MODE
+        ):
+            return False
+        try:
+            raw_champion_id = int(
+                payload.get("modeChampionId")
+                or payload.get("rawChampionId")
+                or 0
+            )
+            prime_champion_id = int(
+                payload.get("primeChampionId")
+                or resource_champion_id(raw_champion_id)
+            )
+        except (TypeError, ValueError):
+            return False
+        if (
+            raw_champion_id != mode_champion_id(prime_champion_id)
+            or (
+                self.shared_state.locked_champ_id is not None
+                and int(self.shared_state.locked_champ_id) != prime_champion_id
+            )
+        ):
+            return False
+
+        catalog = payload.get("catalog")
+        raw_ids = catalog_skin_ids(catalog, prime_champion_id)
+        if not raw_ids:
+            return False
+        try:
+            carrier = validated_carrier_lcu_skin_id(
+                prime_champion_id,
+                catalog,
+                payload.get("carrierLcuSkinId") or payload.get("baseRawSkinId"),
+            )
+        except ValueError:
+            return False
+        advertised_number = payload.get("carrierSkinNumber")
+        if advertised_number is not None:
+            try:
+                if int(advertised_number) != carrier_skin_number(carrier):
+                    return False
+            except (TypeError, ValueError):
+                return False
+
+        self.shared_state.classic_prime_champion_id = prime_champion_id
+        self.shared_state.classic_mode_champion_id = raw_champion_id
+        self.shared_state.classic_carrier_lcu_skin_id = carrier
+        self.shared_state.classic_carrier_skin_number = carrier_skin_number(carrier)
+        self.shared_state.classic_catalog_raw_skin_ids = raw_ids
+        self.shared_state.classic_catalog_resource_skin_ids = {
+            resource_skin_id(value) for value in raw_ids
+        }
+        return True
+
+    def _handle_classic_mode_catalog(self, payload: dict) -> None:
+        if not self._cache_classic_catalog(payload):
+            log.warning("Rejected invalid Classic Mode catalog")
+
     def _handle_chroma_selection(self, payload: dict) -> None:
         """Handle chroma selection from JavaScript"""
         chroma_id = payload.get("chromaId") or payload.get("skinId")

--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -441,6 +441,26 @@ class MessageHandler:
         if not self._cache_classic_catalog(payload):
             log.warning("Rejected Classic Mode selection with invalid catalog")
             return
+        generation_value = payload.get("selectionGeneration")
+        if generation_value is None and str(payload.get("type") or "").startswith("jade-"):
+            incoming_generation = self.shared_state.classic_selection_generation
+        else:
+            try:
+                incoming_generation = int(generation_value)
+            except (TypeError, ValueError):
+                log.warning("Rejected Classic Mode selection without a valid generation")
+                return
+        current_generation = self.shared_state.classic_selection_generation
+        if incoming_generation < current_generation or (
+            payload.get("userInitiated") is True
+            and incoming_generation <= current_generation
+        ):
+            log.info(
+                "Rejected stale Classic Mode selection generation=%s current=%s",
+                incoming_generation,
+                current_generation,
+            )
+            return
         try:
             raw_skin_id = int(payload.get("rawSkinId") or 0)
             visual_skin_id = int(
@@ -460,7 +480,6 @@ class MessageHandler:
                 raw_skin_id,
             )
             return
-
         carrier = self.shared_state.classic_carrier_lcu_skin_id
         owned_ids = set(self.shared_state.owned_skin_ids or ())
         owned = (
@@ -470,6 +489,7 @@ class MessageHandler:
         )
         self.shared_state.classic_selected_skin_owned = owned
         self.shared_state.selected_skin_id = visual_skin_id
+        self.shared_state.classic_selection_generation = incoming_generation
 
         if owned:
             self.shared_state.classic_visual_skin_id = None
@@ -485,7 +505,6 @@ class MessageHandler:
                 lcu.set_my_selection_skin(carrier)
 
         if payload.get("userInitiated") is True:
-            self.shared_state.classic_selection_generation += 1
             self.shared_state.historic_mode_active = False
             self.shared_state.historic_skin_id = None
             self.shared_state.classic_history_skin_id = None
@@ -525,6 +544,9 @@ class MessageHandler:
                 ],
                 "skin": payload.get("chromaName") or f"skin_{visual_skin_id}",
                 "userInitiated": True,
+                "selectionGeneration": (
+                    self.shared_state.classic_selection_generation + 1
+                ),
             }
         )
         self._handle_classic_skin_selection(selection)

--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -419,6 +419,22 @@ class MessageHandler:
 
             RandomizationHandler(self.shared_state, self.skin_scraper).activate_persisted()
             return
+        if not self.shared_state.historic_first_detection_done:
+            from utils.core.historic import get_historic_skin_for_champion
+
+            historic_skin_id = get_historic_skin_for_champion(
+                champion_id, "classic"
+            )
+            if (
+                isinstance(historic_skin_id, int)
+                and historic_skin_id
+                in self.shared_state.classic_catalog_resource_skin_ids
+            ):
+                self.shared_state.historic_mode_active = True
+                self.shared_state.historic_skin_id = historic_skin_id
+                self.shared_state.classic_history_skin_id = historic_skin_id
+                self.broadcaster.broadcast_historic_state()
+            self.shared_state.historic_first_detection_done = True
 
     def _handle_classic_skin_selection(self, payload: dict) -> None:
         """Track a validated local projection without submitting it to LCU."""

--- a/state/core/shared_state.py
+++ b/state/core/shared_state.py
@@ -68,15 +68,11 @@ class SharedState:
     current_game_mode: Optional[str] = None  # Current game mode (ARAM, CLASSIC, SWIFT_PLAY, etc.)
     current_map_id: Optional[int] = None  # Current map ID (12 = ARAM, 11 = SR)
     current_queue_id: Optional[int] = None  # Current queue ID (2400 = ARAM: Mayhem, etc.)
-    classic_prime_champion_id: Optional[int] = None
-    classic_mode_champion_id: Optional[int] = None
-    classic_carrier_lcu_skin_id: Optional[int] = None
-    classic_carrier_skin_number: Optional[int] = None
-    classic_catalog_raw_skin_ids: set = field(default_factory=set)
-    classic_catalog_resource_skin_ids: set = field(default_factory=set)
-    classic_random_eligible_resource_skin_ids: set = field(default_factory=set)
+    classic_champion_id: Optional[int] = None
+    classic_default_skin_id: Optional[int] = None
+    classic_catalog_skin_ids: set = field(default_factory=set)
+    classic_random_eligible_skin_ids: set = field(default_factory=set)
     classic_visual_skin_id: Optional[int] = None
-    classic_visual_raw_skin_id: Optional[int] = None
     classic_visual_chroma_id: Optional[int] = None
     classic_selected_skin_owned: bool = False
     classic_history_skin_id: Optional[int] = None
@@ -127,15 +123,11 @@ class SharedState:
     def clear_classic_mode(self) -> None:
         """Clear state that must never leak into a regular-mode session."""
         self.selected_lcu_skin_id = None
-        self.classic_prime_champion_id = None
-        self.classic_mode_champion_id = None
-        self.classic_carrier_lcu_skin_id = None
-        self.classic_carrier_skin_number = None
-        self.classic_catalog_raw_skin_ids.clear()
-        self.classic_catalog_resource_skin_ids.clear()
-        self.classic_random_eligible_resource_skin_ids.clear()
+        self.classic_champion_id = None
+        self.classic_default_skin_id = None
+        self.classic_catalog_skin_ids.clear()
+        self.classic_random_eligible_skin_ids.clear()
         self.classic_visual_skin_id = None
-        self.classic_visual_raw_skin_id = None
         self.classic_visual_chroma_id = None
         self.classic_selected_skin_owned = False
         self.classic_history_skin_id = None

--- a/state/core/shared_state.py
+++ b/state/core/shared_state.py
@@ -74,6 +74,7 @@ class SharedState:
     classic_carrier_skin_number: Optional[int] = None
     classic_catalog_raw_skin_ids: set = field(default_factory=set)
     classic_catalog_resource_skin_ids: set = field(default_factory=set)
+    classic_random_eligible_resource_skin_ids: set = field(default_factory=set)
     classic_visual_skin_id: Optional[int] = None
     classic_visual_raw_skin_id: Optional[int] = None
     classic_visual_chroma_id: Optional[int] = None
@@ -132,6 +133,7 @@ class SharedState:
         self.classic_carrier_skin_number = None
         self.classic_catalog_raw_skin_ids.clear()
         self.classic_catalog_resource_skin_ids.clear()
+        self.classic_random_eligible_resource_skin_ids.clear()
         self.classic_visual_skin_id = None
         self.classic_visual_raw_skin_id = None
         self.classic_visual_chroma_id = None

--- a/state/core/shared_state.py
+++ b/state/core/shared_state.py
@@ -72,7 +72,10 @@ class SharedState:
     classic_mode_champion_id: Optional[int] = None
     classic_carrier_lcu_skin_id: Optional[int] = None
     classic_carrier_skin_number: Optional[int] = None
+    classic_catalog_raw_skin_ids: set = field(default_factory=set)
+    classic_catalog_resource_skin_ids: set = field(default_factory=set)
     classic_visual_skin_id: Optional[int] = None
+    classic_visual_raw_skin_id: Optional[int] = None
     classic_visual_chroma_id: Optional[int] = None
     classic_selected_skin_owned: bool = False
     classic_history_skin_id: Optional[int] = None
@@ -127,7 +130,10 @@ class SharedState:
         self.classic_mode_champion_id = None
         self.classic_carrier_lcu_skin_id = None
         self.classic_carrier_skin_number = None
+        self.classic_catalog_raw_skin_ids.clear()
+        self.classic_catalog_resource_skin_ids.clear()
         self.classic_visual_skin_id = None
+        self.classic_visual_raw_skin_id = None
         self.classic_visual_chroma_id = None
         self.classic_selected_skin_owned = False
         self.classic_history_skin_id = None

--- a/state/core/shared_state.py
+++ b/state/core/shared_state.py
@@ -21,6 +21,7 @@ class SharedState:
     last_hovered_skin_id: Optional[int] = None
     last_hovered_skin_slug: Optional[str] = None
     selected_skin_id: Optional[int] = None  # Skin ID selected in LCU (owned skin)
+    selected_lcu_skin_id: Optional[int] = None  # Raw mode-specific LCU skin ID
     owned_skin_ids: set = field(default_factory=set)  # All owned skin IDs from LCU inventory
     processed_action_ids: set = field(default_factory=set)
     stop: bool = False
@@ -67,6 +68,16 @@ class SharedState:
     current_game_mode: Optional[str] = None  # Current game mode (ARAM, CLASSIC, SWIFT_PLAY, etc.)
     current_map_id: Optional[int] = None  # Current map ID (12 = ARAM, 11 = SR)
     current_queue_id: Optional[int] = None  # Current queue ID (2400 = ARAM: Mayhem, etc.)
+    classic_prime_champion_id: Optional[int] = None
+    classic_mode_champion_id: Optional[int] = None
+    classic_carrier_lcu_skin_id: Optional[int] = None
+    classic_carrier_skin_number: Optional[int] = None
+    classic_visual_skin_id: Optional[int] = None
+    classic_visual_chroma_id: Optional[int] = None
+    classic_selected_skin_owned: bool = False
+    classic_history_skin_id: Optional[int] = None
+    classic_random_enabled: bool = False
+    classic_selection_generation: int = 0
     chroma_panel_skin_name: Optional[str] = None  # Base skin name when panel was opened (to avoid re-detecting same skin)
     is_swiftplay_mode: bool = False  # Flag to indicate if we're in Swiftplay mode
 
@@ -108,3 +119,17 @@ class SharedState:
     party_mode_enabled: bool = False
     party_token: Optional[str] = None  # Our party token for sharing
     party_manager = None  # Reference to PartyManager instance
+
+    def clear_classic_mode(self) -> None:
+        """Clear state that must never leak into a regular-mode session."""
+        self.selected_lcu_skin_id = None
+        self.classic_prime_champion_id = None
+        self.classic_mode_champion_id = None
+        self.classic_carrier_lcu_skin_id = None
+        self.classic_carrier_skin_number = None
+        self.classic_visual_skin_id = None
+        self.classic_visual_chroma_id = None
+        self.classic_selected_skin_owned = False
+        self.classic_history_skin_id = None
+        self.classic_random_enabled = False
+        self.classic_selection_generation = 0

--- a/threads/handlers/champ_select_reset.py
+++ b/threads/handlers/champ_select_reset.py
@@ -32,6 +32,7 @@ def perform_champ_select_reset(state, lcu) -> bool:
     state.ui_last_text_generation = -1
     state.ui_last_text_timestamp = 0.0
     state.selected_skin_id = None
+    state.clear_classic_mode()
     try:
         state.owned_skin_ids.clear()
     except Exception:

--- a/threads/handlers/champ_thread.py
+++ b/threads/handlers/champ_thread.py
@@ -8,6 +8,7 @@ import time
 import threading
 from lcu import LCU
 from state import SharedState
+from utils.core.classic_mode_ids import resource_champion_id
 from utils.core.logging import get_logger
 from ui.chroma.selector import get_chroma_selector
 from config import CHAMP_POLL_INTERVAL
@@ -129,10 +130,15 @@ class ChampThread(threading.Thread):
                 continue
             
             cid = self.lcu.hovered_champion_id
+            if cid is not None:
+                try:
+                    cid = resource_champion_id(cid) or None
+                except (TypeError, ValueError):
+                    cid = None
             if cid is None:
                 sel = self.lcu.my_selection or {}
                 try: 
-                    cid = int(sel.get("selectedChampionId") or 0) or None
+                    cid = resource_champion_id(sel.get("selectedChampionId") or 0) or None
                 except Exception: 
                     cid = None
             
@@ -151,7 +157,7 @@ class ChampThread(threading.Thread):
                 for rnd in actions:
                     for act in rnd:
                         if act.get("actorCellId") == my_cell and act.get("type") == "pick" and act.get("completed"):
-                            ch = int(act.get("championId") or 0)
+                            ch = resource_champion_id(act.get("championId") or 0)
                             if ch > 0: 
                                 locked = ch
                 if locked:

--- a/threads/handlers/champion_lock_handler.py
+++ b/threads/handlers/champion_lock_handler.py
@@ -12,6 +12,7 @@ from typing import Optional
 from lcu import LCU, compute_locked
 from state import SharedState
 from ui.chroma.selector import get_chroma_selector
+from utils.core.classic_mode_ids import resource_champion_id
 from utils.core.logging import get_logger, log_status, log_event
 
 log = get_logger()
@@ -47,7 +48,10 @@ class ChampionLockHandler:
             self.last_locked_champion_id = None
             self.state.reset_last_locked = False
 
-        new_locks = compute_locked(sess)
+        new_locks = {
+            cell_id: resource_champion_id(champion_id)
+            for cell_id, champion_id in compute_locked(sess).items()
+        }
         prev_cells = set(self.state.locks_by_cell.keys())
         curr_cells = set(new_locks.keys())
         added = sorted(list(curr_cells - prev_cells))
@@ -268,4 +272,3 @@ class ChampionLockHandler:
                     self.state.ui_skin_thread._broadcast_champion_locked(True)
             except Exception as e:
                 log.debug(f"[lock:champ] Failed to broadcast champion lock state: {e}")
-

--- a/threads/handlers/game_mode_detector.py
+++ b/threads/handlers/game_mode_detector.py
@@ -10,6 +10,7 @@ import traceback
 from lcu import LCU
 from lcu.core.lockfile import SWIFTPLAY_MODES, SWIFTPLAY_QUEUE_ID
 from state import SharedState
+from utils.core.classic_mode_ids import is_classic_mode, normalize_game_mode
 from utils.core.logging import get_logger
 
 log = get_logger()
@@ -39,6 +40,7 @@ class GameModeDetector:
                 if old_swiftplay_mode:
                     log.info(f"[WS] Swiftplay mode flag reset: {old_swiftplay_mode} → False")
                 self.state.is_swiftplay_mode = False
+                self._clear_mode_context()
                 return
 
             # Get game session data
@@ -48,6 +50,7 @@ class GameModeDetector:
                 if old_swiftplay_mode:
                     log.info(f"[WS] Swiftplay mode flag reset: {old_swiftplay_mode} → False")
                 self.state.is_swiftplay_mode = False
+                self._clear_mode_context()
                 return
 
             # Extract game mode and map ID
@@ -64,6 +67,12 @@ class GameModeDetector:
                     map_id = queue.get("mapId")
                     queue_id = queue.get("queueId")
 
+            map_data = session.get("map") or {}
+            if game_mode is None:
+                game_mode = map_data.get("gameMode")
+            if map_id is None:
+                map_id = map_data.get("id", map_data.get("mapId"))
+
             # Second try: session.queueId
             if queue_id is None:
                 queue_id = session.get("queueId")
@@ -74,10 +83,14 @@ class GameModeDetector:
                 if champ_session and isinstance(champ_session, dict):
                     queue_id = champ_session.get("queueId")
 
-            # Store in shared state
+            game_mode = normalize_game_mode(game_mode, queue_id, map_id)
+
+            # Store one normalized decision in shared state.
             self.state.current_game_mode = game_mode
             self.state.current_map_id = map_id
             self.state.current_queue_id = queue_id
+            if not is_classic_mode(game_mode):
+                self.state.clear_classic_mode()
 
             # Compute is_swiftplay_mode without intermediate False visible to other threads
             # Explicit queue ID 480 check for Swiftplay (may have queue_id without gameMode)
@@ -111,3 +124,8 @@ class GameModeDetector:
             log.warning(f"[WS] Error detecting game mode: {e}")
             log.warning(f"[WS] Traceback: {traceback.format_exc()}")
 
+    def _clear_mode_context(self):
+        self.state.current_game_mode = None
+        self.state.current_map_id = None
+        self.state.current_queue_id = None
+        self.state.clear_classic_mode()

--- a/threads/handlers/injection_trigger.py
+++ b/threads/handlers/injection_trigger.py
@@ -623,7 +623,7 @@ class InjectionTrigger:
                 and not has_any_mods
             ):
                 log.info(
-                    "[CLASSIC] Officially owned skin selected; skipping local skin injection"
+                    "[CLASSIC:INJECT] Officially owned skin selected; skipping local skin injection"
                 )
                 if self.injection_manager:
                     self.injection_manager.resume_if_suspended()
@@ -654,7 +654,7 @@ class InjectionTrigger:
                 if target_is_owned:
                     self._force_owned_skin(effective_skin_id)
                     log.info(
-                        "[INJECT] Custom mod targets owned skin %s; "
+                        "[CLASSIC:INJECT] Custom mod targets owned skin %s; "
                         "keeping the real owned skin and injecting the mod only",
                         effective_skin_id,
                     )
@@ -671,7 +671,7 @@ class InjectionTrigger:
 
                     if carrier_name:
                         log.info(
-                            "[INJECT] Custom mod targets unowned skin %s; "
+                            "[CLASSIC:INJECT] Custom mod targets unowned skin %s; "
                             "injecting carrier %s + custom mod",
                             target_skin_id,
                             carrier_name,
@@ -683,7 +683,7 @@ class InjectionTrigger:
                         )
                     else:
                         log.info(
-                            "[INJECT] Custom mod targets the champion base skin %s; "
+                            "[CLASSIC:INJECT] Custom mod targets the champion base skin %s; "
                             "injecting custom mod only",
                             target_skin_id,
                         )

--- a/threads/handlers/injection_trigger.py
+++ b/threads/handlers/injection_trigger.py
@@ -18,7 +18,7 @@ from utils.core.logging import get_logger, log_action
 from utils.core.junction import is_junction, safe_remove_entry, link_or_extract
 from utils.core.paths import get_injection_dir
 from utils.core.utilities import is_default_skin
-from utils.core.classic_mode_ids import is_classic_mode
+from utils.core.classic_mode_ids import is_classic_mode, mode_skin_id
 from injection.config.base_skin_tracker import start_tracking as _start_skin_tracking
 
 log = get_logger()
@@ -877,12 +877,13 @@ class InjectionTrigger:
             champ_id = self.state.locked_champ_id or self.state.hovered_champ_id
             if champ_id:
                 if is_classic_mode(getattr(self.state, "current_game_mode", None)):
-                    base_skin_id = getattr(
-                        self.state, "classic_carrier_lcu_skin_id", None
+                    default_skin_id = getattr(
+                        self.state, "classic_default_skin_id", None
                     )
-                    if not base_skin_id:
-                        log.warning("[CLASSIC] No validated carrier available; aborting injection")
+                    if not default_skin_id:
+                        log.warning("[CLASSIC] No native default available; aborting injection")
                         return
+                    base_skin_id = mode_skin_id(default_skin_id)
                 else:
                     base_skin_id = champ_id * 1000
                 
@@ -1504,12 +1505,13 @@ class InjectionTrigger:
             if champion_id and base_skin_name:
                 # Injecting base skin ZIP for unowned skin - force base skin
                 if is_classic_mode(current_mode):
-                    base_skin_id = getattr(
-                        self.state, "classic_carrier_lcu_skin_id", None
+                    default_skin_id = getattr(
+                        self.state, "classic_default_skin_id", None
                     )
-                    if not base_skin_id:
-                        log.warning("[CLASSIC] No validated carrier available; overlay skipped")
+                    if not default_skin_id:
+                        log.warning("[CLASSIC] No native default available; overlay skipped")
                         return
+                    base_skin_id = mode_skin_id(default_skin_id)
                 else:
                     base_skin_id = champion_id * 1000
                 self._force_base_skin(base_skin_id)

--- a/threads/handlers/injection_trigger.py
+++ b/threads/handlers/injection_trigger.py
@@ -968,7 +968,12 @@ class InjectionTrigger:
                 return has_been_in_progress and phase not in ("InProgress", "Reconnect", "GameStart")
             
             # Inject skin in a separate thread
-            log.info(f"[INJECT] Starting injection: {name}")
+            prefix = (
+                "[CLASSIC:INJECT]"
+                if is_classic_mode(getattr(self.state, "current_game_mode", None))
+                else "[INJECT]"
+            )
+            log.info(f"{prefix} Starting injection target: {name}")
             
             champ_id_for_history = self.state.locked_champ_id
             classic_generation = getattr(
@@ -1107,7 +1112,12 @@ class InjectionTrigger:
     
     def _force_base_skin(self, base_skin_id: int):
         """Force base skin selection via LCU"""
-        log.info(f"[INJECT] Forcing base skin (skinId={base_skin_id})")
+        prefix = (
+            "[CLASSIC:INJECT]"
+            if is_classic_mode(getattr(self.state, "current_game_mode", None))
+            else "[INJECT]"
+        )
+        log.info(f"{prefix} Forcing carrier skin (skinId={base_skin_id})")
 
         # Temporarily skip base skin handling in client
         self.state.ui_skin_thread._broadcast_skip_base_skin()

--- a/threads/handlers/injection_trigger.py
+++ b/threads/handlers/injection_trigger.py
@@ -18,7 +18,11 @@ from utils.core.logging import get_logger, log_action
 from utils.core.junction import is_junction, safe_remove_entry, link_or_extract
 from utils.core.paths import get_injection_dir
 from utils.core.utilities import is_default_skin
-from utils.core.classic_mode_ids import is_classic_mode, mode_skin_id
+from utils.core.classic_mode_ids import (
+    is_classic_mode,
+    mode_skin_id,
+    resource_skin_id,
+)
 from injection.config.base_skin_tracker import start_tracking as _start_skin_tracking
 
 log = get_logger()
@@ -151,9 +155,51 @@ class InjectionTrigger:
             log.error("=" * LOG_SEPARATOR_WIDTH)
             return
         
-        # Check if custom mod is selected for this skin (before logging)
-        ui_skin_id = self.state.last_hovered_skin_id
         locked_champ_id = self.state.locked_champ_id or self.state.hovered_champ_id
+        # In Classic Mode the LCU selection is a legal carrier, while the Rose
+        # selection is the skin that must actually be injected. Never let a
+        # carrier or another owned native skin replace that target at game start.
+        ui_skin_id = self.state.last_hovered_skin_id
+        if is_classic_mode(getattr(self.state, "current_game_mode", None)):
+            classic_visual_skin_id = getattr(
+                self.state, "classic_visual_skin_id", None
+            )
+            classic_history_skin_id = getattr(self.state, "historic_skin_id", None)
+            for classic_target in (classic_visual_skin_id, classic_history_skin_id):
+                if (
+                    classic_target is not None
+                    and self._skin_matches_champion(classic_target, locked_champ_id)
+                ):
+                    try:
+                        ui_skin_id = int(classic_target)
+                    except (TypeError, ValueError):
+                        continue
+                    break
+
+        owned_skin_ids = {
+            resource_skin_id(value)
+            for value in (getattr(self.state, "owned_skin_ids", None) or ())
+        }
+        classic_target_owned = bool(
+            ui_skin_id is not None
+            and (
+                ui_skin_id == getattr(self.state, "classic_default_skin_id", None)
+                or ui_skin_id in owned_skin_ids
+            )
+        )
+        if is_classic_mode(getattr(self.state, "current_game_mode", None)):
+            log.info(
+                "[CLASSIC:INJECT] target resolved "
+                "last_hovered=%s visual=%s historic=%s selected=%s target=%s owned=%s",
+                self.state.last_hovered_skin_id,
+                getattr(self.state, "classic_visual_skin_id", None),
+                getattr(self.state, "historic_skin_id", None),
+                getattr(self.state, "selected_skin_id", None),
+                ui_skin_id,
+                classic_target_owned,
+            )
+
+        # Check if custom mod is selected for this skin (before logging)
         if not self._skin_matches_champion(ui_skin_id, locked_champ_id):
             log.warning(
                 "[INJECT] Refusing to inject skin %s for champion %s: champion mismatch",
@@ -619,7 +665,7 @@ class InjectionTrigger:
 
             if (
                 is_classic_mode(getattr(self.state, "current_game_mode", None))
-                and getattr(self.state, "classic_selected_skin_owned", False)
+                and classic_target_owned
                 and not has_any_mods
             ):
                 log.info(
@@ -642,9 +688,7 @@ class InjectionTrigger:
                 # carrier's skin0 paths and prevent a mod targeting the actual
                 # owned skin (for example Spirit Blossom Sett) from applying.
                 if is_classic_mode(getattr(self.state, "current_game_mode", None)):
-                    target_is_owned = getattr(
-                        self.state, "classic_selected_skin_owned", False
-                    )
+                    target_is_owned = classic_target_owned
                 else:
                     target_is_owned = (
                         effective_skin_id in owned_skin_ids
@@ -719,9 +763,7 @@ class InjectionTrigger:
                 
                 # Check if skin needs to be injected (if unowned, inject base skin ZIP along with map/font/announcer/other mods)
                 if is_classic_mode(getattr(self.state, "current_game_mode", None)):
-                    is_skin_owned = getattr(
-                        self.state, "classic_selected_skin_owned", False
-                    )
+                    is_skin_owned = classic_target_owned
                 else:
                     is_skin_owned = (
                         ui_skin_id is not None and (

--- a/threads/handlers/injection_trigger.py
+++ b/threads/handlers/injection_trigger.py
@@ -51,6 +51,27 @@ class InjectionTrigger:
         self.injection_manager = injection_manager
         self.skin_scraper = skin_scraper
 
+    def _drop_mismatched_mod_selections(self, scope: str) -> None:
+        def matches(value) -> bool:
+            return isinstance(value, dict) and value.get("scope", "regular") == scope
+
+        for attr in (
+            "selected_custom_mod",
+            "selected_map_mod",
+            "selected_font_mod",
+            "selected_announcer_mod",
+            "selected_other_mod",
+        ):
+            value = getattr(self.state, attr, None)
+            if value and not matches(value):
+                setattr(self.state, attr, None)
+
+        selections = getattr(self.state, "selected_other_mods", None)
+        if isinstance(selections, list):
+            self.state.selected_other_mods = [
+                value for value in selections if matches(value)
+            ]
+
     def _get_compatible_skin_ids(self, skin_id: int | str) -> set[int]:
         """Return a requested skin plus its explicitly known chroma base."""
         try:
@@ -154,6 +175,11 @@ class InjectionTrigger:
             log.error(f"   Loadout Timer: #{ticker_id}")
             log.error("=" * LOG_SEPARATOR_WIDTH)
             return
+
+        from utils.core.historic import historic_scope_for_state
+
+        history_scope = historic_scope_for_state(self.state)
+        self._drop_mismatched_mod_selections(history_scope)
         
         locked_champ_id = self.state.locked_champ_id or self.state.hovered_champ_id
         # In Classic Mode the LCU selection is a legal carrier, while the Rose
@@ -395,6 +421,7 @@ class InjectionTrigger:
                             ):
                                 target_skin_id = next(iter(sorted(target_skin_ids)), int(champion_id) * 1000)
                             self.state.selected_custom_mod = {
+                                "scope": history_scope,
                                 "skin_id": int(target_skin_id),
                                 "storage_skin_id": selected_mod_entry.skin_id,
                                 "target_skin_ids": sorted(target_skin_ids),
@@ -426,7 +453,7 @@ class InjectionTrigger:
                     from injection.mods.storage import ModStorageService
 
                     mod_storage = ModStorageService()
-                    historic_mods = load_mod_historic()
+                    historic_mods = load_mod_historic(history_scope)
                     
                     # Helper function to auto-select a historic mod
                     def auto_select_historic_mod(mod_type: str, category_attr: str):
@@ -549,10 +576,10 @@ class InjectionTrigger:
                                     from utils.core.mod_historic import write_historic_mod
                                     if valid_other_mods:
                                         valid_paths = [mod["relative_path"] for mod in valid_other_mods]
-                                        write_historic_mod("other", valid_paths)
+                                        write_historic_mod("other", valid_paths, history_scope)
                                     else:
                                         from utils.core.mod_historic import clear_historic_mod
-                                        clear_historic_mod("other")
+                                        clear_historic_mod("other", history_scope)
                                 except Exception as e:
                                     log.debug(f"[HISTORIC] Failed to update historic other mods: {e}")
                             
@@ -593,7 +620,7 @@ class InjectionTrigger:
                                 # Clear the historic mod entry since the mod no longer exists
                                 try:
                                     from utils.core.mod_historic import clear_historic_mod
-                                    clear_historic_mod(mod_type)
+                                    clear_historic_mod(mod_type, history_scope)
                                     log.debug(f"[HISTORIC] Cleared historic {mod_type} mod entry")
                                 except Exception as e:
                                     log.debug(f"[HISTORIC] Failed to clear historic {mod_type} mod entry: {e}")
@@ -622,6 +649,7 @@ class InjectionTrigger:
                             
                             # Store selected mod in shared state
                             setattr(self.state, selected_attr, {
+                                "scope": history_scope,
                                 "mod_name": selected_mod_entry.mod_name,
                                 "mod_path": str(selected_mod_entry.path),
                                 "mod_folder_name": mod_folder_name,
@@ -1044,25 +1072,25 @@ class InjectionTrigger:
                                     return False
                             
                             # Check and clean map mod
-                            historic_map_path = get_historic_mod("map")
+                            historic_map_path = get_historic_mod("map", history_scope)
                             if historic_map_path and not mod_file_exists(historic_map_path):
-                                clear_historic_mod("map")
+                                clear_historic_mod("map", history_scope)
                                 log.info(f"[MOD_HISTORIC] Cleaned missing map mod from historic: {historic_map_path}")
                             
                             # Check and clean font mod
-                            historic_font_path = get_historic_mod("font")
+                            historic_font_path = get_historic_mod("font", history_scope)
                             if historic_font_path and not mod_file_exists(historic_font_path):
-                                clear_historic_mod("font")
+                                clear_historic_mod("font", history_scope)
                                 log.info(f"[MOD_HISTORIC] Cleaned missing font mod from historic: {historic_font_path}")
                             
                             # Check and clean announcer mod
-                            historic_announcer_path = get_historic_mod("announcer")
+                            historic_announcer_path = get_historic_mod("announcer", history_scope)
                             if historic_announcer_path and not mod_file_exists(historic_announcer_path):
-                                clear_historic_mod("announcer")
+                                clear_historic_mod("announcer", history_scope)
                                 log.info(f"[MOD_HISTORIC] Cleaned missing announcer mod from historic: {historic_announcer_path}")
                             
                             # Check and clean other mods
-                            historic_other_paths = get_historic_mod("other")
+                            historic_other_paths = get_historic_mod("other", history_scope)
                             if historic_other_paths:
                                 if isinstance(historic_other_paths, str):
                                     historic_other_paths = [historic_other_paths]
@@ -1074,11 +1102,11 @@ class InjectionTrigger:
                                 if len(cleaned_paths) != len(historic_other_paths):
                                     from utils.core.mod_historic import write_historic_mod
                                     if cleaned_paths:
-                                        write_historic_mod("other", cleaned_paths)
+                                        write_historic_mod("other", cleaned_paths, history_scope)
                                         removed_count = len(historic_other_paths) - len(cleaned_paths)
                                         log.info(f"[MOD_HISTORIC] Cleaned {removed_count} missing other mod(s) from historic")
                                     else:
-                                        clear_historic_mod("other")
+                                        clear_historic_mod("other", history_scope)
                                         log.info(f"[MOD_HISTORIC] Cleared historic other mods (all were missing)")
                         except Exception as e:
                             log.debug(f"[MOD_HISTORIC] Failed to clean up missing mods from historic: {e}")
@@ -1281,6 +1309,9 @@ class InjectionTrigger:
                 or self.state.hovered_champ_id
             )
             current_mode = getattr(self.state, "current_game_mode", None)
+            from utils.core.historic import historic_scope_for_state
+
+            history_scope = historic_scope_for_state(self.state)
             classic_generation = getattr(
                 self.state, "classic_selection_generation", None
             )
@@ -1601,28 +1632,28 @@ class InjectionTrigger:
                 
                 # Clean up map mod if it was missing
                 if missing_map_mod_path:
-                    historic_map_path = get_historic_mod("map")
+                    historic_map_path = get_historic_mod("map", history_scope)
                     if historic_map_path and normalize_path(historic_map_path) == normalize_path(missing_map_mod_path):
-                        clear_historic_mod("map")
+                        clear_historic_mod("map", history_scope)
                         log.info(f"[MOD_HISTORIC] Cleaned missing map mod from historic: {missing_map_mod_path}")
                 
                 # Clean up font mod if it was missing
                 if missing_font_mod_path:
-                    historic_font_path = get_historic_mod("font")
+                    historic_font_path = get_historic_mod("font", history_scope)
                     if historic_font_path and normalize_path(historic_font_path) == normalize_path(missing_font_mod_path):
-                        clear_historic_mod("font")
+                        clear_historic_mod("font", history_scope)
                         log.info(f"[MOD_HISTORIC] Cleaned missing font mod from historic: {missing_font_mod_path}")
                 
                 # Clean up announcer mod if it was missing
                 if missing_announcer_mod_path:
-                    historic_announcer_path = get_historic_mod("announcer")
+                    historic_announcer_path = get_historic_mod("announcer", history_scope)
                     if historic_announcer_path and normalize_path(historic_announcer_path) == normalize_path(missing_announcer_mod_path):
-                        clear_historic_mod("announcer")
+                        clear_historic_mod("announcer", history_scope)
                         log.info(f"[MOD_HISTORIC] Cleaned missing announcer mod from historic: {missing_announcer_mod_path}")
                 
                 # Clean up other mods (can be multiple) - same pattern as above
                 if missing_other_mod_paths:
-                    historic_other_paths = get_historic_mod("other")
+                    historic_other_paths = get_historic_mod("other", history_scope)
                     if historic_other_paths:
                         # Convert to list if needed
                         if isinstance(historic_other_paths, str):
@@ -1641,11 +1672,11 @@ class InjectionTrigger:
                         # Update historic if paths were removed
                         if len(cleaned_paths) != len(historic_other_paths):
                             if cleaned_paths:
-                                write_historic_mod("other", cleaned_paths)
+                                write_historic_mod("other", cleaned_paths, history_scope)
                                 removed_count = len(historic_other_paths) - len(cleaned_paths)
                                 log.info(f"[MOD_HISTORIC] Cleaned {removed_count} missing other mod(s) from historic")
                             else:
-                                clear_historic_mod("other")
+                                clear_historic_mod("other", history_scope)
                                 log.info(f"[MOD_HISTORIC] Cleared historic other mods (all were missing)")
             except Exception as e:
                 log.debug(f"[MOD_HISTORIC] Failed to clean up missing mods from historic: {e}")
@@ -1711,19 +1742,19 @@ class InjectionTrigger:
                     # Store map mod if selected
                     selected_map_mod = getattr(self.state, 'selected_map_mod', None)
                     if selected_map_mod and selected_map_mod.get("relative_path"):
-                        write_historic_mod("map", selected_map_mod["relative_path"])
+                        write_historic_mod("map", selected_map_mod["relative_path"], history_scope)
                         log.debug(f"[MOD_HISTORIC] Stored map mod: {selected_map_mod['relative_path']}")
                     
                     # Store font mod if selected
                     selected_font_mod = getattr(self.state, 'selected_font_mod', None)
                     if selected_font_mod and selected_font_mod.get("relative_path"):
-                        write_historic_mod("font", selected_font_mod["relative_path"])
+                        write_historic_mod("font", selected_font_mod["relative_path"], history_scope)
                         log.debug(f"[MOD_HISTORIC] Stored font mod: {selected_font_mod['relative_path']}")
                     
                     # Store announcer mod if selected
                     selected_announcer_mod = getattr(self.state, 'selected_announcer_mod', None)
                     if selected_announcer_mod and selected_announcer_mod.get("relative_path"):
-                        write_historic_mod("announcer", selected_announcer_mod["relative_path"])
+                        write_historic_mod("announcer", selected_announcer_mod["relative_path"], history_scope)
                         log.debug(f"[MOD_HISTORIC] Stored announcer mod: {selected_announcer_mod['relative_path']}")
                     
                     # Store other mods if selected (store all for historic)
@@ -1737,7 +1768,7 @@ class InjectionTrigger:
                         # Store all mods for historic (list format)
                         other_mod_paths = [mod.get("relative_path") for mod in selected_other_mods if mod.get("relative_path")]
                         if other_mod_paths:
-                            write_historic_mod("other", other_mod_paths)
+                            write_historic_mod("other", other_mod_paths, history_scope)
                             log.debug(f"[MOD_HISTORIC] Stored {len(other_mod_paths)} other mod(s): {', '.join(other_mod_paths)}")
                 except Exception as e:
                     log.debug(f"[MOD_HISTORIC] Failed to store mod selections: {e}")

--- a/threads/handlers/injection_trigger.py
+++ b/threads/handlers/injection_trigger.py
@@ -1515,7 +1515,12 @@ class InjectionTrigger:
                 # Store mod selections in historic before clearing
                 try:
                     from utils.core.mod_historic import write_historic_mod
-                    from utils.core.historic import write_historic_entry, write_historic_target
+                    from utils.core.historic import (
+                        historic_scope_for_state,
+                        write_historic_entry,
+                        write_historic_target,
+                    )
+                    history_scope = historic_scope_for_state(self.state)
                     
                     # Store custom skin mod in historic if selected
                     selected_custom_mod = getattr(self.state, 'selected_custom_mod', None)
@@ -1524,10 +1529,14 @@ class InjectionTrigger:
                         if champion_id:
                             # Store custom mod path with "path:" prefix
                             custom_mod_path = f"path:{selected_custom_mod['relative_path']}"
-                            write_historic_entry(int(champion_id), custom_mod_path)
+                            write_historic_entry(
+                                int(champion_id), custom_mod_path, history_scope
+                            )
                             target_skin_id = selected_custom_mod.get("skin_id")
                             if target_skin_id:
-                                write_historic_target(int(champion_id), int(target_skin_id))
+                                write_historic_target(
+                                    int(champion_id), int(target_skin_id), history_scope
+                                )
                             log.debug(f"[HISTORIC] Stored custom mod path for champion {champion_id}: {selected_custom_mod['relative_path']}")
                     elif base_skin_name:
                         # Store base skin ID in historic if injecting base skin with mods (no custom mod)
@@ -1541,7 +1550,9 @@ class InjectionTrigger:
                             
                             champion_id = self.state.locked_champ_id or self.state.hovered_champ_id
                             if champion_id is not None and injected_id is not None:
-                                write_historic_entry(int(champion_id), int(injected_id))
+                                write_historic_entry(
+                                    int(champion_id), int(injected_id), history_scope
+                                )
                                 log.info(f"[HISTORIC] Stored last injected ID {injected_id} for champion {champion_id}")
                         except Exception as e:
                             log.debug(f"[HISTORIC] Failed to store base skin entry: {e}")
@@ -1593,4 +1604,3 @@ class InjectionTrigger:
             log.error(f"[INJECT] Error injecting custom mod: {e}")
             import traceback
             log.error(f"[INJECT] Traceback: {traceback.format_exc()}")
-

--- a/threads/handlers/injection_trigger.py
+++ b/threads/handlers/injection_trigger.py
@@ -241,12 +241,18 @@ class InjectionTrigger:
                     from utils.core.historic import (
                         get_historic_skin_for_champion,
                         get_historic_target_for_champion,
+                        historic_scope_for_state,
                         is_custom_mod_path,
                         get_custom_mod_path,
                     )
 
                     champ_id = self.state.locked_champ_id or self.state.hovered_champ_id
-                    historic_value = get_historic_skin_for_champion(champ_id) if champ_id else None
+                    history_scope = historic_scope_for_state(self.state)
+                    historic_value = (
+                        get_historic_skin_for_champion(champ_id, history_scope)
+                        if champ_id
+                        else None
+                    )
                     if historic_value and is_custom_mod_path(historic_value):
                         historic_custom_mod_path = get_custom_mod_path(historic_value)
 
@@ -332,7 +338,7 @@ class InjectionTrigger:
                             current_skin_id = effective_skin_id or ui_skin_id
                             target_skin_id = current_skin_id
                             historic_target_skin_id = get_historic_target_for_champion(
-                                int(champion_id)
+                                int(champion_id), history_scope
                             )
                             if historic_target_skin_id in target_skin_ids:
                                 target_skin_id = int(historic_target_skin_id)

--- a/threads/handlers/injection_trigger.py
+++ b/threads/handlers/injection_trigger.py
@@ -18,6 +18,7 @@ from utils.core.logging import get_logger, log_action
 from utils.core.junction import is_junction, safe_remove_entry, link_or_extract
 from utils.core.paths import get_injection_dir
 from utils.core.utilities import is_default_skin
+from utils.core.classic_mode_ids import is_classic_mode
 from injection.config.base_skin_tracker import start_tracking as _start_skin_tracking
 
 log = get_logger()
@@ -615,6 +616,18 @@ class InjectionTrigger:
             target_skin_id = selected_custom_mod.get("skin_id", ui_skin_id) if selected_custom_mod else ui_skin_id
             has_other_mods = selected_map_mod or selected_font_mod or selected_announcer_mod or (selected_other_mods and len(selected_other_mods) > 0)
             has_any_mods = has_custom_skin_mod or has_other_mods
+
+            if (
+                is_classic_mode(getattr(self.state, "current_game_mode", None))
+                and getattr(self.state, "classic_selected_skin_owned", False)
+                and not has_any_mods
+            ):
+                log.info(
+                    "[CLASSIC] Officially owned skin selected; skipping local skin injection"
+                )
+                if self.injection_manager:
+                    self.injection_manager.resume_if_suspended()
+                return
             
             # If custom skin mod is selected, inject it
             if has_custom_skin_mod:
@@ -628,10 +641,15 @@ class InjectionTrigger:
                 # using it for an owned skin can move the overlay onto the
                 # carrier's skin0 paths and prevent a mod targeting the actual
                 # owned skin (for example Spirit Blossom Sett) from applying.
-                target_is_owned = (
-                    effective_skin_id in owned_skin_ids
-                    or ui_skin_id in owned_skin_ids
-                )
+                if is_classic_mode(getattr(self.state, "current_game_mode", None)):
+                    target_is_owned = getattr(
+                        self.state, "classic_selected_skin_owned", False
+                    )
+                else:
+                    target_is_owned = (
+                        effective_skin_id in owned_skin_ids
+                        or ui_skin_id in owned_skin_ids
+                    )
 
                 if target_is_owned:
                     self._force_owned_skin(effective_skin_id)
@@ -700,12 +718,17 @@ class InjectionTrigger:
                 mod_types_str = "/".join(selected_mod_types) if selected_mod_types else "Map/Font/Announcer/Other"
                 
                 # Check if skin needs to be injected (if unowned, inject base skin ZIP along with map/font/announcer/other mods)
-                is_skin_owned = (
-                    ui_skin_id is not None and (
-                        is_default_skin(ui_skin_id)
-                        or ui_skin_id in (owned_skin_ids or set())
+                if is_classic_mode(getattr(self.state, "current_game_mode", None)):
+                    is_skin_owned = getattr(
+                        self.state, "classic_selected_skin_owned", False
                     )
-                )
+                else:
+                    is_skin_owned = (
+                        ui_skin_id is not None and (
+                            is_default_skin(ui_skin_id)
+                            or ui_skin_id in (owned_skin_ids or set())
+                        )
+                    )
                 base_skin_name_for_injection = None
                 if not is_skin_owned and ui_skin_id != 0:
                     # Skin is unowned, need to inject base skin ZIP along with map/font/announcer/other mods
@@ -722,14 +745,24 @@ class InjectionTrigger:
             # historic mode is not active — if historic is active, the skin resolver
             # already overrides to the saved skin and injection should proceed normally)
             historic_active = getattr(self.state, 'historic_mode_active', False)
-            if ui_skin_id is not None and is_default_skin(ui_skin_id) and not historic_active:
+            if (
+                ui_skin_id is not None
+                and is_default_skin(ui_skin_id)
+                and not historic_active
+                and not is_classic_mode(getattr(self.state, "current_game_mode", None))
+            ):
                 log.info(f"[INJECT] skipping injection for default skin (skinId={ui_skin_id}) - no mods selected")
                 if self.injection_manager:
                     self.injection_manager.resume_if_suspended()
                 champ_id = self.state.locked_champ_id or self.state.hovered_champ_id
                 if champ_id:
-                    from utils.core.historic import clear_historic_entry
-                    clear_historic_entry(int(champ_id))
+                    from utils.core.historic import (
+                        clear_historic_entry,
+                        historic_scope_for_state,
+                    )
+                    clear_historic_entry(
+                        int(champ_id), historic_scope_for_state(self.state)
+                    )
                     log.info(f"[HISTORIC] Cleared historic entry for champion {champ_id} (default skin played)")
 
             # Force owned skins/chromas via LCU

--- a/threads/handlers/injection_trigger.py
+++ b/threads/handlers/injection_trigger.py
@@ -1227,6 +1227,24 @@ class InjectionTrigger:
                 or self.state.locked_champ_id
                 or self.state.hovered_champ_id
             )
+            current_mode = getattr(self.state, "current_game_mode", None)
+            classic_generation = getattr(
+                self.state, "classic_selection_generation", None
+            )
+
+            def classic_preparation_is_stale() -> bool:
+                return bool(
+                    is_classic_mode(current_mode)
+                    and (
+                        not is_classic_mode(
+                            getattr(self.state, "current_game_mode", None)
+                        )
+                        or getattr(
+                            self.state, "classic_selection_generation", None
+                        )
+                        != classic_generation
+                    )
+                )
             
             # Clean mods directory first (before extracting base skin and custom mod)
             injector._clean_mods_dir()
@@ -1260,7 +1278,8 @@ class InjectionTrigger:
                         base_skin_name,
                         skin_name=base_skin_name,
                         champion_name=champion_name,
-                        champion_id=champion_id
+                        champion_id=champion_id,
+                        game_mode=current_mode,
                     )
                     if not zp or not zp.exists():
                         log.error(
@@ -1473,6 +1492,10 @@ class InjectionTrigger:
                 log.warning("[INJECT] No mods available to inject (skin, map, font, announcer, or other)")
                 return
 
+            if classic_preparation_is_stale():
+                log.info("[CLASSIC] Custom mod preparation became stale; overlay skipped")
+                return
+
             log.info(f"[INJECT] Injecting mods: {', '.join(mod_names_list)}" + (f" for skin {skin_id}" if skin_id else ""))
 
             # Force base skin selection via LCU before injecting (only if injecting base skin ZIP)
@@ -1480,7 +1503,15 @@ class InjectionTrigger:
             champion_id = self.state.locked_champ_id or self.state.hovered_champ_id
             if champion_id and base_skin_name:
                 # Injecting base skin ZIP for unowned skin - force base skin
-                base_skin_id = champion_id * 1000
+                if is_classic_mode(current_mode):
+                    base_skin_id = getattr(
+                        self.state, "classic_carrier_lcu_skin_id", None
+                    )
+                    if not base_skin_id:
+                        log.warning("[CLASSIC] No validated carrier available; overlay skipped")
+                        return
+                else:
+                    base_skin_id = champion_id * 1000
                 self._force_base_skin(base_skin_id)
             
             # Create callback to check if game ended
@@ -1488,6 +1519,8 @@ class InjectionTrigger:
 
             def game_ended_callback():
                 nonlocal has_been_in_progress
+                if classic_preparation_is_stale():
+                    return True
                 phase = self.state.phase
                 if phase == "InProgress":
                     has_been_in_progress = True

--- a/threads/handlers/injection_trigger.py
+++ b/threads/handlers/injection_trigger.py
@@ -874,6 +874,8 @@ class InjectionTrigger:
             log.info(f"[INJECT] Starting injection: {name}")
             
             champ_id_for_history = self.state.locked_champ_id
+            from utils.core.historic import historic_scope_for_state
+            history_scope = historic_scope_for_state(self.state)
 
             def run_injection():
                 try:
@@ -906,7 +908,9 @@ class InjectionTrigger:
                             champ_id = champ_id_for_history
                             if champ_id is not None and injected_id is not None:
                                 from utils.core.historic import write_historic_entry
-                                write_historic_entry(int(champ_id), int(injected_id))
+                                write_historic_entry(
+                                    int(champ_id), int(injected_id), history_scope
+                                )
                                 log.info(f"[HISTORIC] Stored last injected ID {injected_id} for champion {champ_id}")
                         except Exception as e:
                             log.debug(f"[HISTORIC] Failed to store historic entry: {e}")

--- a/threads/handlers/injection_trigger.py
+++ b/threads/handlers/injection_trigger.py
@@ -872,10 +872,19 @@ class InjectionTrigger:
     def _inject_unowned_skin(self, name: str, cname: str):
         """Inject unowned skin/chroma"""
         try:
-            # Force base skin selection via LCU before injecting
+            # Keep the server-visible Classic carrier selected. Regular modes
+            # continue to use the champion base skin as before.
             champ_id = self.state.locked_champ_id or self.state.hovered_champ_id
             if champ_id:
-                base_skin_id = champ_id * 1000
+                if is_classic_mode(getattr(self.state, "current_game_mode", None)):
+                    base_skin_id = getattr(
+                        self.state, "classic_carrier_lcu_skin_id", None
+                    )
+                    if not base_skin_id:
+                        log.warning("[CLASSIC] No validated carrier available; aborting injection")
+                        return
+                else:
+                    base_skin_id = champ_id * 1000
                 
                 # Read actual current selection from LCU session
                 actual_lcu_skin_id = None
@@ -901,6 +910,12 @@ class InjectionTrigger:
 
             def game_ended_callback():
                 nonlocal has_been_in_progress
+                if (
+                    is_classic_mode(getattr(self.state, "current_game_mode", None))
+                    and getattr(self.state, "classic_selection_generation", None)
+                    != classic_generation
+                ):
+                    return True
                 phase = self.state.phase
                 if phase == "InProgress":
                     has_been_in_progress = True
@@ -913,11 +928,21 @@ class InjectionTrigger:
             log.info(f"[INJECT] Starting injection: {name}")
             
             champ_id_for_history = self.state.locked_champ_id
+            classic_generation = getattr(
+                self.state, "classic_selection_generation", None
+            )
             from utils.core.historic import historic_scope_for_state
             history_scope = historic_scope_for_state(self.state)
 
             def run_injection():
                 try:
+                    if (
+                        is_classic_mode(getattr(self.state, "current_game_mode", None))
+                        and getattr(self.state, "classic_selection_generation", None)
+                        != classic_generation
+                    ):
+                        log.info("[CLASSIC] Skipping stale injection preparation")
+                        return
                     if not self.lcu.ok:
                         log.warning(f"[INJECT] LCU not available, skipping injection")
                         return

--- a/threads/handlers/phase_handler.py
+++ b/threads/handlers/phase_handler.py
@@ -232,6 +232,13 @@ class PhaseHandler:
     
     def _reset_state(self):
         """Reset state for phase exit"""
+        from utils.core.classic_mode_ids import is_classic_mode
+
+        if is_classic_mode(self.state.current_game_mode):
+            self.state.current_game_mode = None
+            self.state.current_map_id = None
+            self.state.current_queue_id = None
+            self.state.clear_classic_mode()
         self.state.hovered_champ_id = None
         self.state.locked_champ_id = None
         self.state.locked_champ_timestamp = 0.0
@@ -244,4 +251,3 @@ class PhaseHandler:
         # via cleanup_swiftplay_exit() which also handles the associated
         # tracking/mods state atomically.  Clearing the flag alone would
         # leave orphaned swiftplay_extracted_mods / swiftplay_skin_tracking.
-

--- a/threads/utilities/skin_name_resolver.py
+++ b/threads/utilities/skin_name_resolver.py
@@ -141,6 +141,23 @@ class SkinNameResolver:
             else:
                 log.error(f"[RANDOM] No random skin ID available for injection")
                 return None
+
+        # Classic Mode keeps a server-valid carrier selected in the LCU for
+        # unowned skins. Resolve the injected archive from Rose's projected
+        # target instead of that carrier/native selection.
+        classic_visual_skin_id = getattr(
+            self.state, "classic_visual_skin_id", None
+        )
+        if classic_visual_skin_id:
+            from utils.core.classic_mode_ids import is_classic_mode
+
+            if is_classic_mode(getattr(self.state, "current_game_mode", None)):
+                name = f"skin_{int(classic_visual_skin_id)}"
+                log.info(
+                    "[CLASSIC:INJECT] Using projected Classic skin for injection: %s",
+                    classic_visual_skin_id,
+                )
+                return name
         
         # Normal hovered skin
         skin_id = getattr(self.state, 'last_hovered_skin_id', None)
@@ -208,4 +225,3 @@ class SkinNameResolver:
             return final_label
         except Exception:
             return raw or ""
-

--- a/threads/websocket/websocket_event_handler.py
+++ b/threads/websocket/websocket_event_handler.py
@@ -316,6 +316,7 @@ class WebSocketEventHandler:
         except (TypeError, ValueError):
             return
 
+        previous_lcu_skin_id = self.state.selected_lcu_skin_id
         self.state.selected_lcu_skin_id = raw_skin_id
         if not is_classic_mode(self.state.current_game_mode):
             self.state.selected_skin_id = raw_skin_id
@@ -364,6 +365,15 @@ class WebSocketEventHandler:
                 raw_skin_id == self.state.classic_carrier_lcu_skin_id
                 or raw_skin_id in owned
                 or selected_resource_id in owned
+            )
+        if previous_lcu_skin_id != raw_skin_id:
+            log.info(
+                "[CLASSIC:LCU] observed raw=%s resource=%s projected=%s owned=%s carrier=%s",
+                raw_skin_id,
+                selected_resource_id,
+                projected_raw_skin_id or "none",
+                self.state.classic_selected_skin_owned,
+                self.state.classic_carrier_lcu_skin_id,
             )
         self.state.selected_skin_id = selected_resource_id
         try:

--- a/threads/websocket/websocket_event_handler.py
+++ b/threads/websocket/websocket_event_handler.py
@@ -235,6 +235,32 @@ class WebSocketEventHandler:
     def _handle_in_progress_entry(self):
         """Handle entering InProgress phase"""
         from utils.core.logging import log_section
+
+        if is_classic_mode(getattr(self.state, "current_game_mode", None)):
+            classic_target = (
+                getattr(self.state, "classic_visual_skin_id", None)
+                or getattr(self.state, "historic_skin_id", None)
+                or getattr(self.state, "selected_skin_id", None)
+            )
+            log_section(
+                log,
+                "Classic Game Starting",
+                "",
+                {
+                    "TargetSkinID": classic_target,
+                    "LCUSkinID": getattr(self.state, "selected_lcu_skin_id", None),
+                    "CarrierSkinID": getattr(self.state, "classic_default_skin_id", None),
+                    "HistoricMode": getattr(self.state, "historic_mode_active", False),
+                },
+            )
+            log.info(
+                "[CLASSIC:INJECT] game starting target=%s lcu=%s carrier=%s historic=%s",
+                classic_target,
+                getattr(self.state, "selected_lcu_skin_id", None),
+                getattr(self.state, "classic_default_skin_id", None),
+                getattr(self.state, "historic_mode_active", False),
+            )
+            return
         
         if self.state.last_hovered_skin_key:
             log_section(log, f"Game Starting - Last Detected Skin: {self.state.last_hovered_skin_key.upper()}", "", {

--- a/threads/websocket/websocket_event_handler.py
+++ b/threads/websocket/websocket_event_handler.py
@@ -356,11 +356,15 @@ class WebSocketEventHandler:
 
         selected_resource_id = resource_skin_id(raw_skin_id)
         owned = set(self.state.owned_skin_ids or ())
-        self.state.classic_selected_skin_owned = (
-            raw_skin_id == self.state.classic_carrier_lcu_skin_id
-            or raw_skin_id in owned
-            or selected_resource_id in owned
+        projected_raw_skin_id = getattr(
+            self.state, "classic_visual_raw_skin_id", None
         )
+        if projected_raw_skin_id is None:
+            self.state.classic_selected_skin_owned = (
+                raw_skin_id == self.state.classic_carrier_lcu_skin_id
+                or raw_skin_id in owned
+                or selected_resource_id in owned
+            )
         self.state.selected_skin_id = selected_resource_id
         try:
             _on_skin_confirmed(selected_resource_id)

--- a/threads/websocket/websocket_event_handler.py
+++ b/threads/websocket/websocket_event_handler.py
@@ -13,12 +13,11 @@ from config import INTERESTING_PHASES
 from lcu import LCU, compute_locked
 from state import SharedState
 from utils.core.classic_mode_ids import (
-    carrier_skin_number,
     is_classic_mode,
     is_classic_skin_id,
     resource_champion_id,
     resource_skin_id,
-    resolve_carrier_lcu_skin_id,
+    resolve_default_skin_id,
 )
 from utils.core.logging import get_logger, log_status, log_event
 from injection.config.base_skin_tracker import (
@@ -330,14 +329,13 @@ class WebSocketEventHandler:
             log.warning("Ignoring invalid Classic Mode skin ID: %s", raw_skin_id)
             return
 
-        mode_champion = raw_skin_id // 1000
-        prime_champion = resource_champion_id(mode_champion)
+        champion_id = resource_champion_id(raw_skin_id // 1000)
         locked_champion = self.state.locked_champ_id
-        if locked_champion and int(locked_champion) != prime_champion:
-            log.debug("Ignoring stale Classic Mode selection for champion %s", prime_champion)
+        if locked_champion and int(locked_champion) != champion_id:
+            log.debug("Ignoring stale Classic Mode selection for champion %s", champion_id)
             return
 
-        if self.state.classic_mode_champion_id != mode_champion:
+        if self.state.classic_champion_id != champion_id:
             try:
                 catalog_ids = self.lcu.get(
                     "/lol-lobby-team-builder/champ-select/v1/pickable-skin-ids"
@@ -345,38 +343,46 @@ class WebSocketEventHandler:
             except Exception:
                 catalog_ids = None
             try:
-                carrier = resolve_carrier_lcu_skin_id(prime_champion, catalog_ids)
+                default_skin_id = resolve_default_skin_id(
+                    champion_id, catalog_ids, raw_skin_id
+                )
             except ValueError as exc:
-                log.warning("Cannot resolve Classic Mode carrier: %s", exc)
+                log.warning("Cannot resolve Classic Mode default: %s", exc)
                 self.state.clear_classic_mode()
                 return
-            self.state.classic_prime_champion_id = prime_champion
-            self.state.classic_mode_champion_id = mode_champion
-            self.state.classic_carrier_lcu_skin_id = carrier
-            self.state.classic_carrier_skin_number = carrier_skin_number(carrier)
+            self.state.classic_champion_id = champion_id
+            self.state.classic_default_skin_id = default_skin_id
 
-        selected_resource_id = resource_skin_id(raw_skin_id)
-        owned = set(self.state.owned_skin_ids or ())
-        projected_raw_skin_id = getattr(
-            self.state, "classic_visual_raw_skin_id", None
-        )
-        if projected_raw_skin_id is None:
+        selected_skin_id = resource_skin_id(raw_skin_id)
+        owned = {resource_skin_id(value) for value in (self.state.owned_skin_ids or ())}
+        projected_skin_id = self.state.classic_visual_skin_id
+        if projected_skin_id is None:
             self.state.classic_selected_skin_owned = (
-                raw_skin_id == self.state.classic_carrier_lcu_skin_id
-                or raw_skin_id in owned
-                or selected_resource_id in owned
+                selected_skin_id == self.state.classic_default_skin_id
+                or selected_skin_id in owned
             )
         if previous_lcu_skin_id != raw_skin_id:
             log.info(
-                "[CLASSIC:LCU] observed raw=%s resource=%s projected=%s owned=%s carrier=%s",
+                "[CLASSIC:LCU] observed raw=%s skin=%s projected=%s owned=%s default=%s",
                 raw_skin_id,
-                selected_resource_id,
-                projected_raw_skin_id or "none",
+                selected_skin_id,
+                projected_skin_id or "none",
                 self.state.classic_selected_skin_owned,
-                self.state.classic_carrier_lcu_skin_id,
+                self.state.classic_default_skin_id,
             )
-        self.state.selected_skin_id = selected_resource_id
+        if (
+            projected_skin_id is not None
+            and selected_skin_id == self.state.classic_default_skin_id
+        ):
+            log.debug(
+                "[CLASSIC:LCU] Preserving visual skin %s while LCU stays on default %s",
+                projected_skin_id,
+                selected_skin_id,
+            )
+            return
+
+        self.state.selected_skin_id = selected_skin_id
         try:
-            _on_skin_confirmed(selected_resource_id)
+            _on_skin_confirmed(selected_skin_id)
         except Exception:
             pass

--- a/threads/websocket/websocket_event_handler.py
+++ b/threads/websocket/websocket_event_handler.py
@@ -12,6 +12,14 @@ from typing import Optional
 from config import INTERESTING_PHASES
 from lcu import LCU, compute_locked
 from state import SharedState
+from utils.core.classic_mode_ids import (
+    carrier_skin_number,
+    is_classic_mode,
+    is_classic_skin_id,
+    resource_champion_id,
+    resource_skin_id,
+    resolve_carrier_lcu_skin_id,
+)
 from utils.core.logging import get_logger, log_status, log_event
 from injection.config.base_skin_tracker import (
     on_skin_confirmed as _on_skin_confirmed,
@@ -302,15 +310,59 @@ class WebSocketEventHandler:
             self.timer_manager.maybe_start_timer(sess)
 
     def _update_selected_skin(self, raw_skin_id) -> None:
-        """Track a skin selected by the local player."""
+        """Track server and resource IDs without conflating local projection."""
         try:
             raw_skin_id = int(raw_skin_id)
         except (TypeError, ValueError):
             return
 
         self.state.selected_lcu_skin_id = raw_skin_id
-        self.state.selected_skin_id = raw_skin_id
+        if not is_classic_mode(self.state.current_game_mode):
+            self.state.selected_skin_id = raw_skin_id
+            try:
+                _on_skin_confirmed(raw_skin_id)
+            except Exception:
+                pass
+            return
+
+        if not is_classic_skin_id(raw_skin_id):
+            log.warning("Ignoring invalid Classic Mode skin ID: %s", raw_skin_id)
+            return
+
+        mode_champion = raw_skin_id // 1000
+        prime_champion = resource_champion_id(mode_champion)
+        locked_champion = self.state.locked_champ_id
+        if locked_champion and int(locked_champion) != prime_champion:
+            log.debug("Ignoring stale Classic Mode selection for champion %s", prime_champion)
+            return
+
+        if self.state.classic_mode_champion_id != mode_champion:
+            try:
+                catalog_ids = self.lcu.get(
+                    "/lol-lobby-team-builder/champ-select/v1/pickable-skin-ids"
+                )
+            except Exception:
+                catalog_ids = None
+            try:
+                carrier = resolve_carrier_lcu_skin_id(prime_champion, catalog_ids)
+            except ValueError as exc:
+                log.warning("Cannot resolve Classic Mode carrier: %s", exc)
+                self.state.clear_classic_mode()
+                return
+            self.state.classic_prime_champion_id = prime_champion
+            self.state.classic_mode_champion_id = mode_champion
+            self.state.classic_carrier_lcu_skin_id = carrier
+            self.state.classic_carrier_skin_number = carrier_skin_number(carrier)
+
+        selected_resource_id = resource_skin_id(raw_skin_id)
+        owned = set(self.state.owned_skin_ids or ())
+        self.state.classic_selected_skin_owned = (
+            raw_skin_id == self.state.classic_carrier_lcu_skin_id
+            or raw_skin_id in owned
+            or selected_resource_id in owned
+        )
+        self.state.selected_skin_id = selected_resource_id
         try:
-            _on_skin_confirmed(raw_skin_id)
+            _on_skin_confirmed(selected_resource_id)
         except Exception:
             pass

--- a/threads/websocket/websocket_event_handler.py
+++ b/threads/websocket/websocket_event_handler.py
@@ -262,21 +262,13 @@ class WebSocketEventHandler:
         """Handle champion select session event"""
         sess = payload.get("data") or {}
         self.state.local_cell_id = sess.get("localPlayerCellId", self.state.local_cell_id)
-        
-        # Track selected skin ID from myTeam
+
+        raw_selected_skin = None
         if self.state.local_cell_id is not None:
             my_team = sess.get("myTeam") or []
             for player in my_team:
                 if player.get("cellId") == self.state.local_cell_id:
-                    selected_skin = player.get("selectedSkinId")
-                    if selected_skin is not None:
-                        skin_int = int(selected_skin)
-                        self.state.selected_skin_id = skin_int
-                        # Check if this confirms a pending base skin force
-                        try:
-                            _on_skin_confirmed(skin_int)
-                        except Exception:
-                            pass
+                    raw_selected_skin = player.get("selectedSkinId")
                     break
         
         # Visible players (distinct cellIds)
@@ -301,8 +293,24 @@ class WebSocketEventHandler:
         # Lock counter: diff cellId → championId
         if self.champion_lock_handler:
             self.champion_lock_handler.handle_session_locks(sess)
+
+        if raw_selected_skin is not None:
+            self._update_selected_skin(raw_selected_skin)
         
         # Timer
         if self.timer_manager:
             self.timer_manager.maybe_start_timer(sess)
 
+    def _update_selected_skin(self, raw_skin_id) -> None:
+        """Track a skin selected by the local player."""
+        try:
+            raw_skin_id = int(raw_skin_id)
+        except (TypeError, ValueError):
+            return
+
+        self.state.selected_lcu_skin_id = raw_skin_id
+        self.state.selected_skin_id = raw_skin_id
+        try:
+            _on_skin_confirmed(raw_skin_id)
+        except Exception:
+            pass

--- a/ui/core/user_interface.py
+++ b/ui/core/user_interface.py
@@ -17,6 +17,7 @@ from ui.handlers.historic_mode_handler import HistoricModeHandler
 from ui.handlers.randomization_handler import RandomizationHandler
 from ui.handlers.skin_display_handler import SkinDisplayHandler
 from ui.core.lifecycle_manager import UILifecycleManager
+from utils.core.classic_mode_ids import is_classic_mode
 
 log = get_logger()
 
@@ -111,8 +112,14 @@ class UserInterface:
                 new_base_skin_id = None
                 prev_base_skin_id = None
             
-            # Cancel randomization if skin changed and random mode is active
-            if self.state.random_mode_active and not self.randomization_handler.randomization_in_progress:
+            # Classic selection is projected through LCU during history/random
+            # transitions; only its explicit selection message represents a
+            # user change. Keep the regular-mode cancellation behavior intact.
+            if (
+                self.state.random_mode_active
+                and not is_classic_mode(getattr(self.state, "current_game_mode", None))
+                and not self.randomization_handler.randomization_in_progress
+            ):
                 self.randomization_handler.cancel()
             
             # Always reset randomization flags if skin changed

--- a/ui/handlers/historic_mode_handler.py
+++ b/ui/handlers/historic_mode_handler.py
@@ -22,10 +22,13 @@ def historic_custom_mod_affects_skin(state: SharedState, *skin_ids: object) -> b
         from utils.core.historic import (
             get_custom_mod_path,
             get_historic_skin_for_champion,
+            historic_scope_for_state,
             is_custom_mod_path,
         )
 
-        historic_value = get_historic_skin_for_champion(int(champion_id))
+        historic_value = get_historic_skin_for_champion(
+            int(champion_id), historic_scope_for_state(state)
+        )
         if not is_custom_mod_path(historic_value):
             return False
 
@@ -116,9 +119,13 @@ class HistoricModeHandler:
         try:
             from utils.core.historic import (
                 get_historic_skin_for_champion,
+                historic_scope_for_state,
                 is_custom_mod_path,
             )
-            historic_value = get_historic_skin_for_champion(self.state.locked_champ_id)
+            historic_value = get_historic_skin_for_champion(
+                self.state.locked_champ_id,
+                historic_scope_for_state(self.state),
+            )
             custom_mod_applies = historic_custom_mod_affects_skin(self.state, skin_id)
 
             if historic_value is not None and (
@@ -181,4 +188,3 @@ class HistoricModeHandler:
                     self.state.ui_skin_thread._broadcast_historic_state()
             except Exception as e:
                 log.debug(f"[UI] Failed to broadcast historic state on deactivation: {e}")
-

--- a/ui/handlers/randomization_handler.py
+++ b/ui/handlers/randomization_handler.py
@@ -122,13 +122,20 @@ class RandomizationHandler:
             log.debug("[UI] Randomization was cancelled, aborting start")
             self._randomization_in_progress = False
             return
+
+        classic_mode = is_classic_mode(getattr(self.state, "current_game_mode", None))
+        if classic_mode:
+            self.state.historic_first_detection_done = True
+            self.state.classic_history_skin_id = None
         
         # Disable HistoricMode if active
         try:
-            if getattr(self.state, 'historic_mode_active', False):
+            historic_mode_active = getattr(self.state, 'historic_mode_active', False)
+            if historic_mode_active or classic_mode:
                 self.state.historic_mode_active = False
                 self.state.historic_skin_id = None
-                log.info("[HISTORIC] Historic mode DISABLED due to RandomMode activation")
+                if historic_mode_active:
+                    log.info("[HISTORIC] Historic mode DISABLED due to RandomMode activation")
                 # Broadcast state to JavaScript
                 try:
                     if self.state and hasattr(self.state, 'ui_skin_thread') and self.state.ui_skin_thread:
@@ -156,12 +163,6 @@ class RandomizationHandler:
                 self.state.classic_selected_skin_owned = selected_owned
                 self.state.classic_visual_skin_id = None if selected_owned else random_skin_id
                 self.state.classic_visual_raw_skin_id = None if selected_owned else raw_skin_id
-                if selected_owned:
-                    lcu = getattr(self.skin_scraper, "lcu", None)
-                    if lcu is not None and getattr(
-                        self.state, "selected_lcu_skin_id", None
-                    ) != raw_skin_id:
-                        lcu.set_my_selection_skin(raw_skin_id)
                 self.state.ui_skin_id = random_skin_id
                 self.state.last_hovered_skin_id = random_skin_id
                 self.state.last_hovered_skin_key = random_skin_name
@@ -230,7 +231,13 @@ class RandomizationHandler:
             candidates = sorted({
                 int(value)
                 for value in (
-                    getattr(self.state, "classic_catalog_resource_skin_ids", None) or ()
+                    getattr(
+                        self.state,
+                        "classic_random_eligible_resource_skin_ids",
+                        None,
+                    )
+                    or getattr(self.state, "classic_catalog_resource_skin_ids", None)
+                    or ()
                 )
                 if int(value) > 0
                 and int(value) // 1000 == int(champion_id or 0)

--- a/ui/handlers/randomization_handler.py
+++ b/ui/handlers/randomization_handler.py
@@ -165,8 +165,15 @@ class RandomizationHandler:
                     random_skin_id == self.state.classic_default_skin_id
                     or random_skin_id in owned_ids
                 )
+                selected_chroma = (
+                    random_skin_id
+                    if random_skin_id in self.skin_scraper.cache.chroma_id_map
+                    else None
+                )
                 self.state.classic_selected_skin_owned = selected_owned
                 self.state.classic_visual_skin_id = None if selected_owned else random_skin_id
+                self.state.classic_visual_chroma_id = selected_chroma
+                self.state.selected_chroma_id = selected_chroma
                 self.state.ui_skin_id = random_skin_id
                 self.state.last_hovered_skin_id = random_skin_id
                 self.state.last_hovered_skin_key = random_skin_name
@@ -241,7 +248,7 @@ class RandomizationHandler:
         base_champion_skin_id = champion_id * 1000 if champion_id else None
 
         if is_classic_mode(getattr(self.state, "current_game_mode", None)):
-            candidates = sorted({
+            eligible_ids = {
                 int(value)
                 for value in (
                     getattr(
@@ -258,15 +265,23 @@ class RandomizationHandler:
                 and int(value) != int(
                     getattr(self.state, "classic_default_skin_id", 0) or 0
                 )
-            })
+            }
+            chroma_id_map = self.skin_scraper.cache.chroma_id_map
+            candidates = sorted(
+                value for value in eligible_ids if value not in chroma_id_map
+            )
             if not candidates:
                 return None
             selected_id = random.choice(candidates)
             skin_data = self.skin_scraper.cache.get_skin_by_id(selected_id) or {}
-            return (
-                skin_data.get("skinName") or f"skin_{selected_id}",
-                selected_id,
+            selected_name = skin_data.get("skinName") or f"skin_{selected_id}"
+            options = [(selected_name, selected_id)]
+            options.extend(
+                (chroma.get("name") or selected_name, chroma["id"])
+                for chroma in self.skin_scraper.get_chromas_for_skin(selected_id) or ()
+                if chroma.get("id") in eligible_ids
             )
+            return random.choice(options)
 
         if not self.skin_scraper.cache.skins:
             log.warning("[UI] No skins available for random selection")

--- a/ui/handlers/randomization_handler.py
+++ b/ui/handlers/randomization_handler.py
@@ -157,18 +157,22 @@ class RandomizationHandler:
                 if champion_id:
                     set_random_enabled_for_champion(champion_id, True)
                 self.state.classic_random_enabled = True
-                raw_skin_id = mode_skin_id(random_skin_id)
-                owned_ids = set(getattr(self.state, "owned_skin_ids", None) or ())
-                selected_owned = raw_skin_id in owned_ids or random_skin_id in owned_ids
+                owned_ids = {
+                    resource_skin_id(value)
+                    for value in (getattr(self.state, "owned_skin_ids", None) or ())
+                }
+                selected_owned = (
+                    random_skin_id == self.state.classic_default_skin_id
+                    or random_skin_id in owned_ids
+                )
                 self.state.classic_selected_skin_owned = selected_owned
                 self.state.classic_visual_skin_id = None if selected_owned else random_skin_id
-                self.state.classic_visual_raw_skin_id = None if selected_owned else raw_skin_id
                 self.state.ui_skin_id = random_skin_id
                 self.state.last_hovered_skin_id = random_skin_id
                 self.state.last_hovered_skin_key = random_skin_name
             if classic_mode:
                 log.info(
-                    "[CLASSIC:RANDOM] selected name=%s resource=%s raw=%s owned=%s deferred_projection=true",
+                    "[CLASSIC:RANDOM] selected name=%s skin=%s lcu=%s owned=%s deferred_projection=true",
                     random_skin_name,
                     random_skin_id,
                     mode_skin_id(random_skin_id),
@@ -242,17 +246,17 @@ class RandomizationHandler:
                 for value in (
                     getattr(
                         self.state,
-                        "classic_random_eligible_resource_skin_ids",
+                        "classic_random_eligible_skin_ids",
                         None,
                     )
-                    or getattr(self.state, "classic_catalog_resource_skin_ids", None)
+                    or getattr(self.state, "classic_catalog_skin_ids", None)
                     or ()
                 )
                 if int(value) > 0
                 and int(value) // 1000 == int(champion_id or 0)
                 and int(value) != base_champion_skin_id
-                and int(value) != resource_skin_id(
-                    getattr(self.state, "classic_carrier_lcu_skin_id", 0) or 0
+                and int(value) != int(
+                    getattr(self.state, "classic_default_skin_id", 0) or 0
                 )
             })
             if not candidates:

--- a/ui/handlers/randomization_handler.py
+++ b/ui/handlers/randomization_handler.py
@@ -166,7 +166,16 @@ class RandomizationHandler:
                 self.state.ui_skin_id = random_skin_id
                 self.state.last_hovered_skin_id = random_skin_id
                 self.state.last_hovered_skin_key = random_skin_name
-            log.info(f"[UI] Random skin selected: {random_skin_name} (ID: {random_skin_id})")
+            if classic_mode:
+                log.info(
+                    "[CLASSIC:RANDOM] selected name=%s resource=%s raw=%s owned=%s deferred_projection=true",
+                    random_skin_name,
+                    random_skin_id,
+                    mode_skin_id(random_skin_id),
+                    self.state.classic_selected_skin_owned,
+                )
+            else:
+                log.info(f"[UI] Random skin selected: {random_skin_name} (ID: {random_skin_id})")
             
             # Broadcast random mode state to JavaScript
             try:

--- a/ui/handlers/randomization_handler.py
+++ b/ui/handlers/randomization_handler.py
@@ -9,6 +9,7 @@ import random
 from typing import Optional, Tuple
 from state import SharedState
 from utils.core.logging import get_logger
+from utils.core.classic_mode_ids import is_classic_mode, resource_skin_id
 from utils.core.utilities import is_base_skin
 
 log = get_logger()
@@ -42,6 +43,10 @@ class RandomizationHandler:
         
         log.info("[UI] Starting random skin selection")
         self._randomization_started = True
+
+        if is_classic_mode(getattr(self.state, "current_game_mode", None)):
+            self._start_randomization()
+            return True
         
         # Force champion's base skin first
         champion_id = self.skin_scraper.cache.champion_id if self.skin_scraper and self.skin_scraper.cache else None
@@ -69,6 +74,10 @@ class RandomizationHandler:
         if not self.state.locked_champ_id:
             log.warning("[UI] Cannot force base skin - no locked champion")
             return False
+
+        if is_classic_mode(getattr(self.state, "current_game_mode", None)):
+            self._start_randomization()
+            return True
         
         # Set flag to prevent cancellation during randomization
         self._randomization_in_progress = True
@@ -165,20 +174,46 @@ class RandomizationHandler:
         # Clear randomization flags
         self._randomization_in_progress = False
         self._randomization_started = False
-    
+
     def select_random_skin(self) -> Optional[Tuple[str, int]]:
         """Select a random skin from available skins (excluding base skin)
         
         Returns:
             Tuple of (skin_name, skin_id) or None if no skin available
         """
-        if not self.skin_scraper or not self.skin_scraper.cache.skins:
+        if not self.skin_scraper or not self.skin_scraper.cache:
             log.warning("[UI] No skins available for random selection")
             return None
         
         # Filter out the champion's base skin and actual chromas
         champion_id = self.skin_scraper.cache.champion_id
         base_champion_skin_id = champion_id * 1000 if champion_id else None
+
+        if is_classic_mode(getattr(self.state, "current_game_mode", None)):
+            candidates = sorted({
+                int(value)
+                for value in (
+                    getattr(self.state, "classic_catalog_resource_skin_ids", None) or ()
+                )
+                if int(value) > 0
+                and int(value) // 1000 == int(champion_id or 0)
+                and int(value) != base_champion_skin_id
+                and int(value) != resource_skin_id(
+                    getattr(self.state, "classic_carrier_lcu_skin_id", 0) or 0
+                )
+            })
+            if not candidates:
+                return None
+            selected_id = random.choice(candidates)
+            skin_data = self.skin_scraper.cache.get_skin_by_id(selected_id) or {}
+            return (
+                skin_data.get("skinName") or f"skin_{selected_id}",
+                selected_id,
+            )
+
+        if not self.skin_scraper.cache.skins:
+            log.warning("[UI] No skins available for random selection")
+            return None
         
         chroma_id_map = self.skin_scraper.cache.chroma_id_map if self.skin_scraper and self.skin_scraper.cache else None
         available_skins = [
@@ -295,4 +330,3 @@ class RandomizationHandler:
                             self.state.ui_skin_thread._broadcast_random_mode_state()
                     except Exception as e:
                         log.debug(f"[UI] Failed to broadcast random mode state on skin change: {e}")
-

--- a/ui/handlers/randomization_handler.py
+++ b/ui/handlers/randomization_handler.py
@@ -9,7 +9,11 @@ import random
 from typing import Optional, Tuple
 from state import SharedState
 from utils.core.logging import get_logger
-from utils.core.classic_mode_ids import is_classic_mode, resource_skin_id
+from utils.core.classic_mode_ids import is_classic_mode, mode_skin_id, resource_skin_id
+from utils.core.random_preferences import (
+    is_random_enabled_for_champion,
+    set_random_enabled_for_champion,
+)
 from utils.core.utilities import is_base_skin
 
 log = get_logger()
@@ -141,6 +145,16 @@ class RandomizationHandler:
             self.state.random_skin_name = random_skin_name
             self.state.random_skin_id = random_skin_id
             self.state.random_mode_active = True
+            if is_classic_mode(getattr(self.state, "current_game_mode", None)):
+                champion_id = getattr(self.state, "locked_champ_id", None)
+                if champion_id:
+                    set_random_enabled_for_champion(champion_id, True)
+                self.state.classic_random_enabled = True
+                self.state.classic_visual_skin_id = random_skin_id
+                self.state.classic_visual_raw_skin_id = mode_skin_id(random_skin_id)
+                self.state.ui_skin_id = random_skin_id
+                self.state.last_hovered_skin_id = random_skin_id
+                self.state.last_hovered_skin_key = random_skin_name
             log.info(f"[UI] Random skin selected: {random_skin_name} (ID: {random_skin_id})")
             
             # Broadcast random mode state to JavaScript
@@ -163,6 +177,11 @@ class RandomizationHandler:
         self.state.random_skin_name = None
         self.state.random_skin_id = None
         self.state.random_mode_active = False
+        if is_classic_mode(getattr(self.state, "current_game_mode", None)):
+            champion_id = getattr(self.state, "locked_champ_id", None)
+            if champion_id:
+                set_random_enabled_for_champion(champion_id, False)
+            self.state.classic_random_enabled = False
         
         # Broadcast random mode state to JavaScript
         try:
@@ -175,6 +194,14 @@ class RandomizationHandler:
         self._randomization_in_progress = False
         self._randomization_started = False
 
+    def activate_persisted(self) -> bool:
+        champion_id = getattr(self.state, "locked_champ_id", None)
+        if not champion_id or not is_random_enabled_for_champion(champion_id):
+            return False
+        self._randomization_started = True
+        self._start_randomization()
+        return bool(self.state.random_mode_active)
+    
     def select_random_skin(self) -> Optional[Tuple[str, int]]:
         """Select a random skin from available skins (excluding base skin)
         

--- a/ui/handlers/randomization_handler.py
+++ b/ui/handlers/randomization_handler.py
@@ -150,8 +150,18 @@ class RandomizationHandler:
                 if champion_id:
                     set_random_enabled_for_champion(champion_id, True)
                 self.state.classic_random_enabled = True
-                self.state.classic_visual_skin_id = random_skin_id
-                self.state.classic_visual_raw_skin_id = mode_skin_id(random_skin_id)
+                raw_skin_id = mode_skin_id(random_skin_id)
+                owned_ids = set(getattr(self.state, "owned_skin_ids", None) or ())
+                selected_owned = raw_skin_id in owned_ids or random_skin_id in owned_ids
+                self.state.classic_selected_skin_owned = selected_owned
+                self.state.classic_visual_skin_id = None if selected_owned else random_skin_id
+                self.state.classic_visual_raw_skin_id = None if selected_owned else raw_skin_id
+                if selected_owned:
+                    lcu = getattr(self.skin_scraper, "lcu", None)
+                    if lcu is not None and getattr(
+                        self.state, "selected_lcu_skin_id", None
+                    ) != raw_skin_id:
+                        lcu.set_my_selection_skin(raw_skin_id)
                 self.state.ui_skin_id = random_skin_id
                 self.state.last_hovered_skin_id = random_skin_id
                 self.state.last_hovered_skin_key = random_skin_name

--- a/utils/core/classic_mode_ids.py
+++ b/utils/core/classic_mode_ids.py
@@ -1,7 +1,7 @@
-"""Classic Mode identity and carrier helpers.
+"""Classic Mode ID conversion at the LCU boundary.
 
-LCU exposes Classic champions in a virtual 60000+ namespace.  Rose keeps
-those server-facing IDs separate from the regular IDs used by skin packages.
+Rose stores the same champion and skin IDs used by the external ``classic``
+resource tree.  JADE's ``600`` prefix is added only for LCU reads and writes.
 """
 
 from __future__ import annotations
@@ -13,29 +13,9 @@ CLASSIC_MODE = "JADE"
 CLASSIC_QUEUE_ID = 3260
 CLASSIC_MAP_ID = 453
 CLASSIC_CHAMPION_OFFSET = 60_000
-CLASSIC_CHAMPION_MIN = 60_001
-CLASSIC_CHAMPION_MAX = 60_999
-CLASSIC_CARRIER_MANIFEST_VERSION = 1
-
-# Captured from the 2026-08-03 Classic champion catalog. Runtime catalog data
-# is authoritative; this versioned matrix is used only while it is unavailable.
-CLASSIC_CARRIER_LCU_SKIN_IDS = {
-    1: 60001301, 2: 60002000, 4: 60004301, 9: 60009301,
-    10: 60010302, 11: 60011301, 12: 60012301, 13: 60013301,
-    14: 60014301, 15: 60015000, 16: 60016301, 17: 60017301,
-    18: 60018301, 19: 60019301, 20: 60020301, 21: 60021000,
-    22: 60022000, 23: 60023000, 24: 60024301, 25: 60025301,
-    26: 60026000, 27: 60027000, 28: 60028301, 29: 60029301,
-    30: 60030301, 31: 60031000, 32: 60032000, 33: 60033000,
-    34: 60034000, 35: 60035000, 36: 60036301, 37: 60037000,
-    38: 60038301, 40: 60040000, 41: 60041301, 42: 60042000,
-    44: 60044301, 45: 60045000, 53: 60053000, 54: 60054000,
-    55: 60055301, 59: 60059000, 62: 60062000, 63: 60063000,
-    64: 60064301, 67: 60067000, 72: 60072301, 74: 60074301,
-    75: 60075301, 76: 60076301, 79: 60079000, 80: 60080301,
-    81: 60081301, 86: 60086301, 89: 60089000, 90: 60090000,
-    96: 60096000, 99: 60099000, 103: 60103301, 117: 60117000,
-}
+CLASSIC_SKIN_OFFSET = CLASSIC_CHAMPION_OFFSET * 1000
+CLASSIC_CHAMPION_MIN = CLASSIC_CHAMPION_OFFSET + 1
+CLASSIC_CHAMPION_MAX = CLASSIC_CHAMPION_OFFSET + 999
 
 
 def normalize_game_mode(game_mode: object, queue_id: object, map_id: object) -> Optional[str]:
@@ -75,13 +55,13 @@ def is_classic_skin_id(skin_id: object) -> bool:
 
 
 def resource_champion_id(champion_id: object) -> int:
-    """Convert a mode champion ID to the regular package champion ID."""
+    """Return the champion folder ID used below the external classic root."""
     value = int(champion_id or 0)
     return value - CLASSIC_CHAMPION_OFFSET if is_classic_champion_id(value) else value
 
 
 def mode_champion_id(champion_id: object) -> int:
-    """Convert a regular champion ID to the Classic LCU champion ID."""
+    """Add JADE's champion prefix for an LCU request."""
     value = int(champion_id or 0)
     if is_classic_champion_id(value):
         return value
@@ -91,51 +71,32 @@ def mode_champion_id(champion_id: object) -> int:
 
 
 def resource_skin_id(skin_id: object) -> int:
-    """Convert a raw Classic LCU skin ID to the package resource skin ID."""
+    """Strip JADE's prefix from an LCU skin ID."""
     value = int(skin_id or 0)
-    champion_id, skin_number = divmod(value, 1000)
-    if is_classic_champion_id(champion_id):
-        return resource_champion_id(champion_id) * 1000 + skin_number
-    return value
+    return value - CLASSIC_SKIN_OFFSET if is_classic_skin_id(value) else value
 
 
 def mode_skin_id(skin_id: object) -> int:
-    """Convert a package resource skin ID to the raw Classic LCU skin ID."""
+    """Add JADE's prefix to a resource skin ID for an LCU request."""
     value = int(skin_id or 0)
     if is_classic_skin_id(value):
         return value
-    champion_id, skin_number = divmod(value, 1000)
-    return mode_champion_id(champion_id) * 1000 + skin_number
-
-
-def fallback_carrier_lcu_skin_id(champion_id: object) -> int:
-    """Return the versioned fallback carrier for a supported champion."""
-    prime_id = resource_champion_id(champion_id)
-    try:
-        return CLASSIC_CARRIER_LCU_SKIN_IDS[prime_id]
-    except KeyError as exc:
-        raise ValueError(f"Unsupported Classic champion ID: {champion_id!r}") from exc
-
-
-def carrier_skin_number(carrier_lcu_skin_id: object) -> int:
-    """Return Skin0/Skin301/Skin302 from a validated raw carrier ID."""
-    value = int(carrier_lcu_skin_id or 0)
-    if not is_classic_skin_id(value) or value % 1000 not in {0, 301, 302}:
-        raise ValueError(f"Invalid Classic carrier skin ID: {carrier_lcu_skin_id!r}")
-    return value % 1000
+    champion_id = value // 1000
+    if champion_id <= 0 or champion_id >= 1000:
+        raise ValueError(f"Invalid skin ID: {skin_id!r}")
+    return value + CLASSIC_SKIN_OFFSET
 
 
 def catalog_skin_ids(catalog: object, champion_id: object) -> set[int]:
-    """Return raw skin IDs belonging to one Classic mode champion."""
+    """Return canonical resource IDs from a Classic catalog payload."""
     if not isinstance(catalog, list) or not (1 <= len(catalog) <= 256):
         return set()
-    expected_champion = mode_champion_id(champion_id)
+    expected_champion = resource_champion_id(champion_id)
     result = set()
     for entry in catalog:
-        if not isinstance(entry, dict):
-            continue
+        value = entry.get("id", entry.get("skinId", 0)) if isinstance(entry, dict) else entry
         try:
-            skin_id = int(entry.get("id", entry.get("skinId", 0)) or 0)
+            skin_id = resource_skin_id(value)
         except (TypeError, ValueError):
             continue
         if skin_id > 0 and skin_id // 1000 == expected_champion:
@@ -143,42 +104,47 @@ def catalog_skin_ids(catalog: object, champion_id: object) -> set[int]:
     return result
 
 
-def validated_carrier_lcu_skin_id(
+def resolve_default_skin_id(
     champion_id: object,
-    catalog: object,
-    advertised_carrier: object = None,
+    catalog: Optional[Iterable[object]] = None,
+    advertised_default: object = None,
 ) -> int:
-    """Validate a live carrier, otherwise use the versioned fallback."""
-    raw_ids = catalog_skin_ids(catalog, champion_id)
+    """Resolve the canonical default from live LCU data, never a hero table."""
+    champion = resource_champion_id(champion_id)
     try:
-        advertised = int(advertised_carrier or 0)
+        advertised = resource_skin_id(advertised_default)
     except (TypeError, ValueError):
         advertised = 0
-    if advertised in raw_ids:
-        try:
-            carrier_skin_number(advertised)
-            return advertised
-        except ValueError:
-            pass
-    return resolve_carrier_lcu_skin_id(champion_id, raw_ids)
+    if advertised > 0 and advertised // 1000 == champion:
+        return advertised
 
-
-def resolve_carrier_lcu_skin_id(
-    champion_id: object,
-    catalog_skin_ids: Optional[Iterable[object]] = None,
-) -> int:
-    """Resolve a champion-owned carrier from catalog data, then the manifest."""
-    prime_id = resource_champion_id(champion_id)
-    expected_mode_champion = mode_champion_id(prime_id)
-    fallback = fallback_carrier_lcu_skin_id(prime_id)
     candidates = set()
-    for skin_id in catalog_skin_ids or ():
+    for value in catalog or ():
+        if isinstance(value, dict):
+            value = value.get("id", value.get("skinId", 0))
         try:
-            value = int(skin_id)
+            candidate = resource_skin_id(value)
         except (TypeError, ValueError):
             continue
-        if value // 1000 == expected_mode_champion and value % 1000 in {0, 301, 302}:
-            candidates.add(value)
-    if fallback in candidates:
-        return fallback
-    return fallback if not candidates else min(candidates, key=lambda value: (value % 1000 == 0, value))
+        if candidate > 0 and candidate // 1000 == champion:
+            candidates.add(candidate)
+    if not candidates:
+        raise ValueError(f"Classic default is unavailable for champion {champion!r}")
+    return min(candidates, key=lambda value: (value % 1000 != 0, value))
+
+
+def validated_default_skin_id(
+    champion_id: object,
+    catalog: object,
+    advertised_default: object = None,
+) -> int:
+    """Validate a frontend default against its canonical catalog."""
+    candidates = catalog_skin_ids(catalog, champion_id)
+    if advertised_default is None:
+        raise ValueError("Classic default was not advertised")
+    default_skin_id = resolve_default_skin_id(
+        champion_id, candidates, advertised_default
+    )
+    if default_skin_id not in candidates:
+        raise ValueError("Classic default is outside the active catalog")
+    return default_skin_id

--- a/utils/core/classic_mode_ids.py
+++ b/utils/core/classic_mode_ids.py
@@ -1,0 +1,146 @@
+"""Classic Mode identity and carrier helpers.
+
+LCU exposes Classic champions in a virtual 60000+ namespace.  Rose keeps
+those server-facing IDs separate from the regular IDs used by skin packages.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+
+CLASSIC_MODE = "JADE"
+CLASSIC_QUEUE_ID = 3260
+CLASSIC_MAP_ID = 453
+CLASSIC_CHAMPION_OFFSET = 60_000
+CLASSIC_CHAMPION_MIN = 60_001
+CLASSIC_CHAMPION_MAX = 60_999
+CLASSIC_CARRIER_MANIFEST_VERSION = 1
+
+# Captured from the 2026-08-03 Classic champion catalog. Runtime catalog data
+# is authoritative; this versioned matrix is used only while it is unavailable.
+CLASSIC_CARRIER_LCU_SKIN_IDS = {
+    1: 60001301, 2: 60002000, 4: 60004301, 9: 60009301,
+    10: 60010302, 11: 60011301, 12: 60012301, 13: 60013301,
+    14: 60014301, 15: 60015000, 16: 60016301, 17: 60017301,
+    18: 60018301, 19: 60019301, 20: 60020301, 21: 60021000,
+    22: 60022000, 23: 60023000, 24: 60024301, 25: 60025301,
+    26: 60026000, 27: 60027000, 28: 60028301, 29: 60029301,
+    30: 60030301, 31: 60031000, 32: 60032000, 33: 60033000,
+    34: 60034000, 35: 60035000, 36: 60036301, 37: 60037000,
+    38: 60038301, 40: 60040000, 41: 60041301, 42: 60042000,
+    44: 60044301, 45: 60045000, 53: 60053000, 54: 60054000,
+    55: 60055301, 59: 60059000, 62: 60062000, 63: 60063000,
+    64: 60064301, 67: 60067000, 72: 60072301, 74: 60074301,
+    75: 60075301, 76: 60076301, 79: 60079000, 80: 60080301,
+    81: 60081301, 86: 60086301, 89: 60089000, 90: 60090000,
+    96: 60096000, 99: 60099000, 103: 60103301, 117: 60117000,
+}
+
+
+def normalize_game_mode(game_mode: object, queue_id: object, map_id: object) -> Optional[str]:
+    """Return the strongest normalized mode signal available from LCU."""
+    if isinstance(game_mode, str) and game_mode.strip():
+        return game_mode.strip().upper()
+    try:
+        if int(queue_id) == CLASSIC_QUEUE_ID:
+            return CLASSIC_MODE
+    except (TypeError, ValueError):
+        pass
+    try:
+        if int(map_id) == CLASSIC_MAP_ID:
+            return CLASSIC_MODE
+    except (TypeError, ValueError):
+        pass
+    return None
+
+
+def is_classic_mode(game_mode: object) -> bool:
+    return isinstance(game_mode, str) and game_mode.upper() == CLASSIC_MODE
+
+
+def is_classic_champion_id(champion_id: object) -> bool:
+    try:
+        value = int(champion_id)
+    except (TypeError, ValueError):
+        return False
+    return CLASSIC_CHAMPION_MIN <= value <= CLASSIC_CHAMPION_MAX
+
+
+def is_classic_skin_id(skin_id: object) -> bool:
+    try:
+        return is_classic_champion_id(int(skin_id) // 1000)
+    except (TypeError, ValueError):
+        return False
+
+
+def resource_champion_id(champion_id: object) -> int:
+    """Convert a mode champion ID to the regular package champion ID."""
+    value = int(champion_id or 0)
+    return value - CLASSIC_CHAMPION_OFFSET if is_classic_champion_id(value) else value
+
+
+def mode_champion_id(champion_id: object) -> int:
+    """Convert a regular champion ID to the Classic LCU champion ID."""
+    value = int(champion_id or 0)
+    if is_classic_champion_id(value):
+        return value
+    if value <= 0 or value >= 1000:
+        raise ValueError(f"Invalid champion ID: {champion_id!r}")
+    return value + CLASSIC_CHAMPION_OFFSET
+
+
+def resource_skin_id(skin_id: object) -> int:
+    """Convert a raw Classic LCU skin ID to the package resource skin ID."""
+    value = int(skin_id or 0)
+    champion_id, skin_number = divmod(value, 1000)
+    if is_classic_champion_id(champion_id):
+        return resource_champion_id(champion_id) * 1000 + skin_number
+    return value
+
+
+def mode_skin_id(skin_id: object) -> int:
+    """Convert a package resource skin ID to the raw Classic LCU skin ID."""
+    value = int(skin_id or 0)
+    if is_classic_skin_id(value):
+        return value
+    champion_id, skin_number = divmod(value, 1000)
+    return mode_champion_id(champion_id) * 1000 + skin_number
+
+
+def fallback_carrier_lcu_skin_id(champion_id: object) -> int:
+    """Return the versioned fallback carrier for a supported champion."""
+    prime_id = resource_champion_id(champion_id)
+    try:
+        return CLASSIC_CARRIER_LCU_SKIN_IDS[prime_id]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported Classic champion ID: {champion_id!r}") from exc
+
+
+def carrier_skin_number(carrier_lcu_skin_id: object) -> int:
+    """Return Skin0/Skin301/Skin302 from a validated raw carrier ID."""
+    value = int(carrier_lcu_skin_id or 0)
+    if not is_classic_skin_id(value) or value % 1000 not in {0, 301, 302}:
+        raise ValueError(f"Invalid Classic carrier skin ID: {carrier_lcu_skin_id!r}")
+    return value % 1000
+
+
+def resolve_carrier_lcu_skin_id(
+    champion_id: object,
+    catalog_skin_ids: Optional[Iterable[object]] = None,
+) -> int:
+    """Resolve a champion-owned carrier from catalog data, then the manifest."""
+    prime_id = resource_champion_id(champion_id)
+    expected_mode_champion = mode_champion_id(prime_id)
+    fallback = fallback_carrier_lcu_skin_id(prime_id)
+    candidates = set()
+    for skin_id in catalog_skin_ids or ():
+        try:
+            value = int(skin_id)
+        except (TypeError, ValueError):
+            continue
+        if value // 1000 == expected_mode_champion and value % 1000 in {0, 301, 302}:
+            candidates.add(value)
+    if fallback in candidates:
+        return fallback
+    return fallback if not candidates else min(candidates, key=lambda value: (value % 1000 == 0, value))

--- a/utils/core/classic_mode_ids.py
+++ b/utils/core/classic_mode_ids.py
@@ -125,6 +125,44 @@ def carrier_skin_number(carrier_lcu_skin_id: object) -> int:
     return value % 1000
 
 
+def catalog_skin_ids(catalog: object, champion_id: object) -> set[int]:
+    """Return raw skin IDs belonging to one Classic mode champion."""
+    if not isinstance(catalog, list) or not (1 <= len(catalog) <= 256):
+        return set()
+    expected_champion = mode_champion_id(champion_id)
+    result = set()
+    for entry in catalog:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            skin_id = int(entry.get("id", entry.get("skinId", 0)) or 0)
+        except (TypeError, ValueError):
+            continue
+        if skin_id > 0 and skin_id // 1000 == expected_champion:
+            result.add(skin_id)
+    return result
+
+
+def validated_carrier_lcu_skin_id(
+    champion_id: object,
+    catalog: object,
+    advertised_carrier: object = None,
+) -> int:
+    """Validate a live carrier, otherwise use the versioned fallback."""
+    raw_ids = catalog_skin_ids(catalog, champion_id)
+    try:
+        advertised = int(advertised_carrier or 0)
+    except (TypeError, ValueError):
+        advertised = 0
+    if advertised in raw_ids:
+        try:
+            carrier_skin_number(advertised)
+            return advertised
+        except ValueError:
+            pass
+    return resolve_carrier_lcu_skin_id(champion_id, raw_ids)
+
+
 def resolve_carrier_lcu_skin_id(
     champion_id: object,
     catalog_skin_ids: Optional[Iterable[object]] = None,

--- a/utils/core/historic.py
+++ b/utils/core/historic.py
@@ -23,15 +23,41 @@ def _historic_file_path() -> Path:
     return data_dir / "historic.json"
 
 
+def _classic_historic_file_path() -> Path:
+    return get_user_data_dir() / "historic_classic.json"
+
+
 def _historic_target_file_path() -> Path:
     data_dir = get_user_data_dir()
     return data_dir / "historic_targets.json"
 
 
-def load_historic_target_map() -> Dict[str, int]:
+def _classic_historic_target_file_path() -> Path:
+    return get_user_data_dir() / "historic_targets_classic.json"
+
+
+def historic_scope_for_state(state) -> str:
+    from utils.core.classic_mode_ids import is_classic_mode
+
+    return "classic" if is_classic_mode(getattr(state, "current_game_mode", None)) else "regular"
+
+
+def _historic_path(scope: str) -> Path:
+    return _classic_historic_file_path() if scope == "classic" else _historic_file_path()
+
+
+def _historic_target_path(scope: str) -> Path:
+    return (
+        _classic_historic_target_file_path()
+        if scope == "classic"
+        else _historic_target_file_path()
+    )
+
+
+def load_historic_target_map(scope: str = "regular") -> Dict[str, int]:
     """Load the exact last skin/chroma target for custom history entries."""
     try:
-        p = _historic_target_file_path()
+        p = _historic_target_path(scope)
         if not p.exists():
             return {}
         with p.open("r", encoding="utf-8") as f:
@@ -52,19 +78,23 @@ def load_historic_target_map() -> Dict[str, int]:
         return {}
 
 
-def get_historic_target_for_champion(champion_id: int) -> Optional[int]:
+def get_historic_target_for_champion(
+    champion_id: int, scope: str = "regular"
+) -> Optional[int]:
     """Return the exact last selected skin/chroma target for a champion."""
-    return load_historic_target_map().get(str(int(champion_id)))
+    return load_historic_target_map(scope).get(str(int(champion_id)))
 
 
-def write_historic_target(champion_id: int, target_skin_id: int) -> None:
+def write_historic_target(
+    champion_id: int, target_skin_id: int, scope: str = "regular"
+) -> None:
     """Persist the exact last selected skin/chroma target for a champion."""
     try:
         target_id = int(target_skin_id)
         if target_id <= 0:
             return
-        p = _historic_target_file_path()
-        targets = load_historic_target_map()
+        p = _historic_target_path(scope)
+        targets = load_historic_target_map(scope)
         targets[str(int(champion_id))] = target_id
         p.parent.mkdir(parents=True, exist_ok=True)
         with p.open("w", encoding="utf-8") as f:
@@ -73,11 +103,11 @@ def write_historic_target(champion_id: int, target_skin_id: int) -> None:
         pass
 
 
-def clear_historic_target(champion_id: int) -> None:
+def clear_historic_target(champion_id: int, scope: str = "regular") -> None:
     """Remove the exact last selected skin/chroma target for a champion."""
     try:
-        p = _historic_target_file_path()
-        targets = load_historic_target_map()
+        p = _historic_target_path(scope)
+        targets = load_historic_target_map(scope)
         if str(int(champion_id)) not in targets:
             return
         targets.pop(str(int(champion_id)), None)

--- a/utils/core/historic.py
+++ b/utils/core/historic.py
@@ -118,14 +118,14 @@ def clear_historic_target(champion_id: int, scope: str = "regular") -> None:
         pass
 
 
-def load_historic_map() -> Dict[str, Union[int, str]]:
+def load_historic_map(scope: str = "regular") -> Dict[str, Union[int, str]]:
     """Load the historic mapping. Returns empty dict if missing or invalid.
     
     Returns:
         Dict mapping champion IDs to either skin/chroma IDs (int) or custom mod paths (str with "path:" prefix)
     """
     try:
-        p = _historic_file_path()
+        p = _historic_path(scope)
         if not p.exists():
             return {}
         with p.open("r", encoding="utf-8") as f:
@@ -148,26 +148,32 @@ def load_historic_map() -> Dict[str, Union[int, str]]:
         return {}
 
 
-def get_historic_skin_for_champion(champion_id: int) -> Optional[Union[int, str]]:
+def get_historic_skin_for_champion(
+    champion_id: int, scope: str = "regular"
+) -> Optional[Union[int, str]]:
     """Get historic entry for a champion.
     
     Returns:
         Integer skin/chroma ID, or string custom mod path (with "path:" prefix), or None
     """
-    m = load_historic_map()
+    m = load_historic_map(scope)
     key = str(int(champion_id))
     return m.get(key)
 
 
-def write_historic_entry(champion_id: int, skin_or_chroma_id: Union[int, str]) -> None:
+def write_historic_entry(
+    champion_id: int,
+    skin_or_chroma_id: Union[int, str],
+    scope: str = "regular",
+) -> None:
     """Write or overwrite the entry for the champion ID.
     
     Args:
         champion_id: Champion ID
         skin_or_chroma_id: Either an integer skin/chroma ID, or a string custom mod path (with "path:" prefix)
     """
-    p = _historic_file_path()
-    m = load_historic_map()
+    p = _historic_path(scope)
+    m = load_historic_map(scope)
     m[str(int(champion_id))] = skin_or_chroma_id
     try:
         p.parent.mkdir(parents=True, exist_ok=True)
@@ -178,11 +184,11 @@ def write_historic_entry(champion_id: int, skin_or_chroma_id: Union[int, str]) -
         pass
 
 
-def clear_historic_entry(champion_id: int) -> None:
+def clear_historic_entry(champion_id: int, scope: str = "regular") -> None:
     """Remove the historic entry for a champion if it exists."""
     try:
-        p = _historic_file_path()
-        m = load_historic_map()
+        p = _historic_path(scope)
+        m = load_historic_map(scope)
         key = str(int(champion_id))
         if key in m:
             m.pop(key, None)
@@ -192,7 +198,7 @@ def clear_historic_entry(champion_id: int) -> None:
     except Exception:
         # Best-effort; ignore errors
         pass
-    clear_historic_target(champion_id)
+    clear_historic_target(champion_id, scope)
 
 
 def is_custom_mod_path(value: Union[int, str]) -> bool:

--- a/utils/core/mod_historic.py
+++ b/utils/core/mod_historic.py
@@ -69,12 +69,15 @@ def _dedupe_keep_order(items: Iterable[str]) -> List[str]:
     return out
 
 
-def _mod_historic_file_path() -> Path:
+def _mod_historic_file_path(scope: str = "regular") -> Path:
     data_dir = get_user_data_dir()
-    return data_dir / "mod_historic.json"
+    filename = (
+        "mod_historic_classic.json" if scope == "classic" else "mod_historic.json"
+    )
+    return data_dir / filename
 
 
-def load_mod_historic() -> Dict[str, Union[str, List[str]]]:
+def load_mod_historic(scope: str = "regular") -> Dict[str, Union[str, List[str]]]:
     """Load the mod historic mapping. Returns empty dict if missing or invalid.
 
     Normalized shape returned:
@@ -85,7 +88,7 @@ def load_mod_historic() -> Dict[str, Union[str, List[str]]]:
     If the file is legacy-only, this function will best-effort migrate it to the new shape.
     """
     try:
-        p = _mod_historic_file_path()
+        p = _mod_historic_file_path(scope)
         if not p.exists():
             return {}
         with p.open("r", encoding="utf-8") as f:
@@ -155,14 +158,16 @@ def load_mod_historic() -> Dict[str, Union[str, List[str]]]:
         return {}
 
 
-def get_historic_mod(mod_type: str) -> Union[Optional[str], Optional[List[str]]]:
+def get_historic_mod(
+    mod_type: str, scope: str = "regular"
+) -> Union[Optional[str], Optional[List[str]]]:
     """Get historic mod for a specific type.
 
     - "map"/"font"/"announcer": returns str|None
     - category keys ("ui"/"voiceover"/"loading_screen"/"vfx"/"sfx"/"others"): returns list[str]|None
     - legacy "other": returns combined list across category keys (best-effort compat)
     """
-    m = load_mod_historic()
+    m = load_mod_historic(scope)
     value = m.get(mod_type)
     if mod_type in _CATEGORY_KEYS:
         if isinstance(value, list) and value:
@@ -180,15 +185,19 @@ def get_historic_mod(mod_type: str) -> Union[Optional[str], Optional[List[str]]]
     return value if isinstance(value, str) else None
 
 
-def write_historic_mod(mod_type: str, relative_path: Union[str, List[str]]) -> None:
+def write_historic_mod(
+    mod_type: str,
+    relative_path: Union[str, List[str]],
+    scope: str = "regular",
+) -> None:
     """Write or overwrite the entry for the mod type.
     
     Args:
         mod_type: "map"/"font"/"announcer" or a category key (ui/voiceover/loading_screen/vfx/sfx/others).
         relative_path: For category keys, can be a list of relative paths. For single-select keys, must be a string.
     """
-    p = _mod_historic_file_path()
-    m = load_mod_historic()
+    p = _mod_historic_file_path(scope)
+    m = load_mod_historic(scope)
     
     # Normalize legacy "other" writes into per-category keys
     if mod_type == "other":
@@ -228,14 +237,14 @@ def write_historic_mod(mod_type: str, relative_path: Union[str, List[str]]) -> N
         pass
 
 
-def clear_historic_mod(mod_type: str) -> None:
+def clear_historic_mod(mod_type: str, scope: str = "regular") -> None:
     """Clear the historic entry for a specific mod type.
     
     Args:
         mod_type: One of "map", "font", "announcer", "other"
     """
-    p = _mod_historic_file_path()
-    m = load_mod_historic()
+    p = _mod_historic_file_path(scope)
+    m = load_mod_historic(scope)
     if mod_type == "other":
         # Backward compat: clear all category keys
         changed = False
@@ -260,4 +269,3 @@ def clear_historic_mod(mod_type: str) -> None:
     except Exception:
         # Silently ignore write errors; feature is best-effort
         pass
-

--- a/utils/core/random_preferences.py
+++ b/utils/core/random_preferences.py
@@ -1,0 +1,47 @@
+"""Persist the Classic per-champion random-skin toggle separately."""
+
+from __future__ import annotations
+
+import json
+
+from utils.core.paths import get_user_data_dir
+
+
+def _preferences_path():
+    return get_user_data_dir() / "classic_random_skin_champions.json"
+
+
+def load_random_champions() -> set[int]:
+    try:
+        data = json.loads(_preferences_path().read_text(encoding="utf-8"))
+        values = data.get("champions", []) if isinstance(data, dict) else []
+        return {int(value) for value in values if int(value) > 0}
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return set()
+
+
+def is_random_enabled_for_champion(champion_id: int) -> bool:
+    try:
+        return int(champion_id) in load_random_champions()
+    except (TypeError, ValueError):
+        return False
+
+
+def set_random_enabled_for_champion(champion_id: int, enabled: bool) -> None:
+    try:
+        champion_id = int(champion_id)
+        if champion_id <= 0:
+            return
+        champions = load_random_champions()
+        if enabled:
+            champions.add(champion_id)
+        else:
+            champions.discard(champion_id)
+        path = _preferences_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"champions": sorted(champions)}, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+    except (OSError, TypeError, ValueError):
+        pass

--- a/utils/download/repo_downloader.py
+++ b/utils/download/repo_downloader.py
@@ -40,7 +40,7 @@ class RepoDownloader:
     def __init__(
         self,
         target_dir: Path = None,
-        repo_url: str = "https://github.com/Alban1911/LeagueSkins",
+        repo_url: str = "https://github.com/ccccxp/LeagueSkins",
         progress_callback: Optional[ProgressCallback] = None,
     ):
         self.repo_url = repo_url
@@ -54,8 +54,9 @@ class RepoDownloader:
 
         # Version tracking
         self.version_file = self.target_dir / '.skin_version'
-        self.api_base = "https://api.github.com/repos/Alban1911/LeagueSkins"
-        self.raw_base = "https://raw.githubusercontent.com/Alban1911/LeagueSkins/main"
+        repo_slug = repo_url.rstrip('/').removeprefix("https://github.com/")
+        self.api_base = f"https://api.github.com/repos/{repo_slug}"
+        self.raw_base = f"https://raw.githubusercontent.com/{repo_slug}/main"
 
         # If changed files exceed this, use full ZIP instead of individual downloads
         self.incremental_file_threshold = 200

--- a/utils/download/repo_downloader.py
+++ b/utils/download/repo_downloader.py
@@ -40,7 +40,7 @@ class RepoDownloader:
     def __init__(
         self,
         target_dir: Path = None,
-        repo_url: str = "https://github.com/ccccxp/LeagueSkins",
+        repo_url: str = "https://github.com/Alban1911/LeagueSkins",
         progress_callback: Optional[ProgressCallback] = None,
     ):
         self.repo_url = repo_url

--- a/utils/download/repo_downloader.py
+++ b/utils/download/repo_downloader.py
@@ -466,9 +466,10 @@ class RepoDownloader:
         progress_start: float = 70.0,
         progress_end: float = 100.0,
         extract_skins: bool = True,
+        extract_classic: bool = True,
         extract_resources: bool = True,
     ) -> bool:
-        """Extract skins, previews, and resources folder from the LeagueSkins repository ZIP"""
+        """Extract regular skins, Classic skins, and shared resources."""
         try:
             log.info("Extracting skins, previews, and resources folder from LeagueSkins repository ZIP...")
 
@@ -491,6 +492,17 @@ class RepoDownloader:
                                 zip_count += 1
                             elif file_info.filename.endswith('.png'):
                                 png_count += 1
+
+                classic_files = []
+                classic_count = 0
+                if extract_classic:
+                    for file_info in zip_ref.filelist:
+                        if (file_info.filename.startswith('LeagueSkins-main/classic/') and
+                            file_info.filename != 'LeagueSkins-main/classic/' and
+                            not file_info.filename.endswith('/')):
+                            classic_files.append(file_info)
+                            if file_info.filename.endswith(('.zip', '.fantome')):
+                                classic_count += 1
                 
                 # Find all files in the resources/ directory (entire folder)
                 resources_files = []
@@ -505,8 +517,8 @@ class RepoDownloader:
                             resources_files.append(file_info)
                             resources_count += 1
                 
-                if not skins_files and not resources_files:
-                    log.error("No skins or resources folder found in repository ZIP")
+                if not skins_files and not classic_files and not resources_files:
+                    log.error("No skins, classic, or resources folder found in repository ZIP")
                     return False
                 
                 if extract_skins and not skins_files:
@@ -515,16 +527,22 @@ class RepoDownloader:
                 if extract_resources and not resources_files:
                     log.warning("No resources folder found in repository ZIP, but resources extraction was requested")
                 
-                log.info(f"Found {zip_count} skin archive files, {png_count} preview .png files, and {resources_count} resource files in repository")
+                log.info(
+                    f"Found {zip_count} regular skin archives, {classic_count} Classic archives, "
+                    f"{png_count} previews, and {resources_count} resource files in repository"
+                )
                 
                 # Extract all skins and resource files with byte-level progress tracking
                 extracted_zip_count = 0
                 extracted_png_count = 0
                 extracted_resources_count = 0
+                extracted_classic_count = 0
                 skipped_skin_count = 0
+                skipped_classic_count = 0
                 skipped_resources_count = 0
 
                 entries: List[Tuple[str, zipfile.ZipInfo]] = [("skin", info) for info in skins_files]
+                entries.extend(("classic", info) for info in classic_files)
                 entries.extend(("resource", info) for info in resources_files)
 
                 def _info_size(info: zipfile.ZipInfo) -> int:
@@ -538,6 +556,7 @@ class RepoDownloader:
                 from utils.core.paths import get_user_data_dir
                 # Place the entire resources folder as resources
                 mapping_target_dir = get_user_data_dir() / "resources"
+                classic_target_dir = self.target_dir.parent / "classic"
 
                 # Reserve 5% of progress range for cleanup operations
                 cleanup_reserve = 5.0
@@ -558,7 +577,12 @@ class RepoDownloader:
                         if file_info.is_dir():
                             continue
 
-                        label = "Extracting skins..." if entry_type == "skin" else "Extracting skin ID mapping..."
+                        if entry_type == "skin":
+                            label = "Extracting skins..."
+                        elif entry_type == "classic":
+                            label = "Extracting Classic skins..."
+                        else:
+                            label = "Extracting skin ID mapping..."
                         relative_path = file_info.filename.replace('LeagueSkins-main/', '')
                         is_zip = relative_path.endswith(('.zip', '.fantome'))
                         is_png = relative_path.endswith('.png')
@@ -567,6 +591,10 @@ class RepoDownloader:
                             if relative_path.startswith('skins/'):
                                 relative_path = relative_path.replace('skins/', '', 1)
                             extract_path = self.target_dir / relative_path
+                        elif entry_type == "classic":
+                            if relative_path.startswith('classic/'):
+                                relative_path = relative_path.replace('classic/', '', 1)
+                            extract_path = classic_target_dir / relative_path
                         else:
                             # Extract entire resources folder structure, removing 'resources/' prefix
                             # so it becomes the resources folder
@@ -581,6 +609,8 @@ class RepoDownloader:
                         if extract_path.exists() and not overwrite_existing:
                             if entry_type == "skin":
                                 skipped_skin_count += 1
+                            elif entry_type == "classic":
+                                skipped_classic_count += 1
                             else:
                                 skipped_resources_count += 1
                             processed_bytes += file_bytes
@@ -601,6 +631,8 @@ class RepoDownloader:
                                 extracted_zip_count += 1
                             elif is_png:
                                 extracted_png_count += 1
+                        elif entry_type == "classic":
+                            extracted_classic_count += 1
                         else:
                             extracted_resources_count += 1
 
@@ -635,9 +667,22 @@ class RepoDownloader:
                     if deleted_resources_count > 0:
                         log.info(f"Removed {deleted_resources_count} resource files that no longer exist in repository")
 
-                log.info(f"Extracted {extracted_zip_count} new skin archive files, {extracted_png_count} preview .png files, "
-                        f"and {extracted_resources_count} resource files (skipped {skipped_skin_count} existing skin files, "
-                        f"{skipped_resources_count} existing resource files)")
+                if extract_classic and classic_files:
+                    deleted_classic_count = self._cleanup_removed_skin_files(
+                        classic_files, classic_target_dir
+                    )
+                    if deleted_classic_count > 0:
+                        log.info(
+                            f"Removed {deleted_classic_count} Classic files that no longer exist in repository"
+                        )
+
+                log.info(
+                    f"Extracted {extracted_zip_count} regular skin archives, "
+                    f"{extracted_classic_count} Classic files, {extracted_png_count} previews, "
+                    f"and {extracted_resources_count} resource files "
+                    f"(skipped {skipped_skin_count} regular, {skipped_classic_count} Classic, "
+                    f"and {skipped_resources_count} resource files)"
+                )
 
                 total_mb = _format_size(total_bytes)
                 self._emit_progress(progress_end, f"Extraction complete ({_format_size(processed_bytes)} / {total_mb})")
@@ -723,6 +768,7 @@ class RepoDownloader:
                     progress_start=70.0,
                     progress_end=100.0,
                     extract_skins=True,
+                    extract_classic=True,
                     extract_resources=True,
                 )
 

--- a/utils/download/repo_downloader.py
+++ b/utils/download/repo_downloader.py
@@ -148,18 +148,27 @@ class RepoDownloader:
             return None
 
     def _resolve_local_path(self, repo_path: str) -> Optional[Path]:
-        """Map a repo-relative path (skins/... or resources/...) to a local path."""
+        """Map a repository resource path to its isolated local root."""
         from utils.core.paths import get_user_data_dir
         if repo_path.startswith('skins/'):
             return self.target_dir / repo_path[len('skins/'):]
+        elif repo_path.startswith('classic/'):
+            return self.target_dir.parent / "classic" / repo_path[len('classic/'):]
         elif repo_path.startswith('resources/'):
             return get_user_data_dir() / "resources" / repo_path[len('resources/'):]
         return None
 
+    def _local_resource_roots(self) -> Tuple[Path, Path, Path]:
+        from utils.core.paths import get_user_data_dir
+
+        data_dir = get_user_data_dir()
+        return self.target_dir, self.target_dir.parent / "classic", data_dir / "resources"
+
     def download_changed_files(self, changed_files: List[Dict]) -> bool:
         """Download changed files individually via raw.githubusercontent.com.
 
-        Handles skins/ and resources/ paths. Supports add, modify, remove, rename.
+        Handles skins/, classic/, and resources/ paths. Supports add, modify,
+        remove, and rename.
         Returns True if all files were processed successfully.
         """
         total = len(changed_files)
@@ -222,7 +231,17 @@ class RepoDownloader:
         # Clean up empty directories left by removals/renames
         for dir_path in sorted(dirs_to_check, reverse=True):
             try:
-                while dir_path != self.target_dir and dir_path.exists() and not any(dir_path.iterdir()):
+                root = next(
+                    (
+                        candidate
+                        for candidate in self._local_resource_roots()
+                        if dir_path == candidate or candidate in dir_path.parents
+                    ),
+                    None,
+                )
+                if root is None:
+                    continue
+                while dir_path != root and dir_path.exists() and not any(dir_path.iterdir()):
                     dir_path.rmdir()
                     dir_path = dir_path.parent
             except OSError:
@@ -382,6 +401,8 @@ class RepoDownloader:
             # Remove 'skins/' or 'resources/' prefix to match local structure
             if relative_path.startswith('skins/'):
                 relative_path = relative_path.replace('skins/', '', 1)
+            elif relative_path.startswith('classic/'):
+                relative_path = relative_path.replace('classic/', '', 1)
             elif relative_path.startswith('resources/'):
                 relative_path = relative_path.replace('resources/', '', 1)
 
@@ -400,8 +421,11 @@ class RepoDownloader:
             if not local_file.is_file():
                 continue
             
-            # Skip state files (like .repo_state.json) but keep other files
-            if local_file.name.startswith('.') and local_file.name.endswith('_state.json'):
+            # Downloader state is not repository content and must survive cleanup.
+            if local_file == self.version_file or (
+                local_file.name.startswith('.')
+                and local_file.name.endswith('_state.json')
+            ):
                 continue
             
             # Get relative path from target_dir

--- a/utils/integration/pengu_loader.py
+++ b/utils/integration/pengu_loader.py
@@ -44,6 +44,10 @@ _LEGACY_PENGU_LOGS = (
 _PLUGIN_ENTRYPOINT = "index.js"
 _PLUGIN_ENTRYPOINT_DISABLED = "index.js_"
 _PLUGIN_ENTRYPOINT_BUNDLED_BACKUP = "index.js.bundled"
+_BUNDLED_DISABLED_CLASSIC_MOD_PLUGINS = {
+    "ROSE-ClassicMods",
+    "ROSE-ClassicSkinSelector",
+}
 
 
 def _remove_legacy_pengu_logs(pengu_dir: Path) -> None:
@@ -169,7 +173,9 @@ def _restore_plugin_enable_state(pengu_dir: Path, enabled: set[str], disabled: s
 
         # If the user had a plugin enabled, prefer enabled state: remove any
         # reintroduced `index.js_` from the bundle.
-        for plugin_name in enabled:
+        # These experimental Classic Mod entrypoints ship disabled on main;
+        # do not revive an enabled copy left behind by a development build.
+        for plugin_name in enabled - _BUNDLED_DISABLED_CLASSIC_MOD_PLUGINS:
             plugin_dir = plugins_dir / plugin_name
             if not plugin_dir.is_dir():
                 continue


### PR DESCRIPTION
## About this PR

I've been playing a lot of Classic Mode lately and, honestly, I've gotten a little obsessed with it. As a long-time League player, I really enjoy seeing and playing with the older skins again.

I wanted to use them with Rose, so I spent some time adapting the mode properly. This PR adds Classic Mode support while keeping it separate from regular games. Hopefully, it can help move Rose's Classic Mode support forward. I'd also like to bring back a few more legacy skin models in the future.

## What's changed

- Added automatic Classic Mode detection.
- Added separate Classic carousel, chroma, history, and random-selection plug-ins.
- Added isolated state, history, and per-champion random preferences for Classic Mode.
- Added validated carrier-skin handling, ownership checks, and local visual projection.
- Added isolated Classic resource downloading, package resolution, and injection.
- Added stale-selection protection during final lock and injection preparation.

## Implementation and review notes

- `ROSE-ClassicWheel` ports Catcat's validated JADE adapter for Riot's native skin-card carousel. It is not based on `ROSE-CustomWheel`, which manages third-party mods.
- `ROSE-ClassicChroma`, `ROSE-ClassicHistoric`, and `ROSE-ClassicRandom` port Catcat's isolated JADE controls as Classic counterparts to Rose's regular chroma, history, and random features. They preserve the corresponding behavior and bridge contracts, but they are not source-level forks of the regular plug-ins.
- The existing regular plug-ins remain unchanged. Classic state, controls, resources, and history are kept separate from regular matches.
- I rebuilt the commit history into smaller, feature-focused commits with detailed descriptions so the changes to existing components can be reviewed independently.

## Demo video

https://github.com/user-attachments/assets/65475fce-ed1f-40f5-bc91-f9b4dd48c243

The video shows how the native carousel, chromas, history, random selection, splash-art projection, and final skin injection work in Classic Mode.

## Screenshots

<img width="1003" height="494" alt="Classic Mode skin carousel" src="https://github.com/user-attachments/assets/a9995bdf-347f-4deb-b0ea-fdd46e955e55" />

<img width="808" height="484" alt="Classic skin in game" src="https://github.com/user-attachments/assets/a321c645-5195-460d-b3fa-3215f53c2ce8" />

## A note about the skin resources

Classic Mode uses different carrier skins, so simply replacing a few files was not enough. I rebuilt the packages with the required assets and redirected the model, weapon, animation, and VFX references to the correct carriers.

The corresponding resource changes are available in [Alban1911/LeagueSkins#94](https://github.com/Alban1911/LeagueSkins/pull/94).

There may still be a few rough edges, but the full flow is working on my side.