### PR TITLE
feat: Manage custom mods option

### DIFF
--- a/Pengu Loader/plugins/ROSE-CustomSkinSelector/index.js
+++ b/Pengu Loader/plugins/ROSE-CustomSkinSelector/index.js
@@ -146,6 +146,12 @@
     return String(mod?.relativePath || mod?.modName || "");
   }
 
+  function visibleModName(mod, fallback = "") {
+    const alias = typeof mod?.displayName === "string" ? mod.displayName.trim() : "";
+    if (alias) return alias;
+    return mod?.modName || fallback;
+  }
+
   function isModAvailableForSkin(mod, skinId = getCurrentSkinContext().skinId) {
     if (!mod || mod._none) return false;
     const requestedSkinId = Number(skinId);
@@ -595,7 +601,7 @@
 
       const wheelButton = document.createElement("div");
       wheelButton.className = `chroma-skin-button ${isSelected ? "selected" : ""}`;
-      wheelButton.title = mod.modName || `Custom Skin ${index + 1}`;
+      wheelButton.title = visibleModName(mod, `Custom Skin ${index + 1}`);
 
       const contents = document.createElement("div");
       contents.className = "contents";
@@ -622,13 +628,13 @@
       };
 
       wheelButton.addEventListener("mouseenter", () => {
-        setPreviewImage(thumbnailUrl || "", mod._none ? getCurrentSkinContext().skinName : (mod.modName || getCurrentSkinContext().skinName));
+        setPreviewImage(thumbnailUrl || "", mod._none ? getCurrentSkinContext().skinName : (visibleModName(mod) || getCurrentSkinContext().skinName));
       });
 
       wheelButton.addEventListener("mouseleave", () => {
         const active = visibleMods.find(e => isModSelected(e, getCurrentSkinContext().skinId));
         const au = active && active.thumbnailUrl ? String(active.thumbnailUrl).replace("localhost", "127.0.0.1") : "";
-        const al = active && !active._none ? (active.modName || getCurrentSkinContext().skinName) : getCurrentSkinContext().skinName;
+        const al = active && !active._none ? (visibleModName(active) || getCurrentSkinContext().skinName) : getCurrentSkinContext().skinName;
         setPreviewImage(au, al);
       });
 
@@ -643,7 +649,7 @@
 
     const active = visibleMods.find(e => isModSelected(e, getCurrentSkinContext().skinId));
     const au = active && active.thumbnailUrl ? String(active.thumbnailUrl).replace("localhost", "127.0.0.1") : "";
-    const al = active && !active._none ? (active.modName || getCurrentSkinContext().skinName) : getCurrentSkinContext().skinName;
+    const al = active && !active._none ? (visibleModName(active) || getCurrentSkinContext().skinName) : getCurrentSkinContext().skinName;
     setPreviewImage(au, al);
 
     scrollable.appendChild(list);

--- a/Pengu Loader/plugins/ROSE-CustomWheel/index.js
+++ b/Pengu Loader/plugins/ROSE-CustomWheel/index.js
@@ -131,6 +131,9 @@
   let lastChampionSelectSession = null; // Track current champ select session
   let isFirstOpenInSession = true; // Track if this is first open in current session
   let lastCategoryModsById = {}; // Cache per category id (ui/voiceover/loading_screen/vfx/sfx/others)
+  let lastMapsList = [];
+  let lastFontsList = [];
+  let lastAnnouncersList = [];
   let emittedHistoricSelectionKeys = new Set(); // Avoid re-emitting historic selections across category responses
   let rightPaneMode = "summary"; // "summary" | "picker"
 
@@ -201,15 +204,28 @@
   function getSelectedSummaryForTab(tabId) {
     if (tabId === "skins") {
       if (!championLocked) return "Waiting for champ lock…";
-      return isSelectedModForSkin() ? String(selectedModId) : "None";
+      if (!isSelectedModForSkin()) return "None";
+      return visibleNameForId(currentSkinMods, selectedModId, ["relativePath", "modName"]);
     }
-    if (tabId === "maps") return selectedMapId ? String(selectedMapId) : "None";
-    if (tabId === "fonts") return selectedFontId ? String(selectedFontId) : "None";
-    if (tabId === "announcers") return selectedAnnouncerId ? String(selectedAnnouncerId) : "None";
+    if (tabId === "maps") {
+      return selectedMapId ? visibleNameForId(lastMapsList, selectedMapId, ["id", "name"]) : "None";
+    }
+    if (tabId === "fonts") {
+      return selectedFontId ? visibleNameForId(lastFontsList, selectedFontId, ["id", "name"]) : "None";
+    }
+    if (tabId === "announcers") {
+      return selectedAnnouncerId
+        ? visibleNameForId(lastAnnouncersList, selectedAnnouncerId, ["id", "name"])
+        : "None";
+    }
 
     // UI / Voiceover / Loading Screen / VFX / SFX / Others are their own categories.
     const selected = getSelectedIdsForCategory(tabId);
-    return selected.length ? selected.join(", ") : "None";
+    if (!selected.length) return "None";
+    const items = lastCategoryModsById[tabId] || [];
+    return selected
+      .map((id) => visibleNameForId(items, id, ["id", "name", "modName"]))
+      .join(", ");
   }
 
   function cleanModName(raw) {
@@ -227,6 +243,21 @@
     return name.trim() || raw;
   }
 
+  function visibleModName(mod, fallback = "Unnamed mod") {
+    const alias = typeof mod?.displayName === "string" ? mod.displayName.trim() : "";
+    if (alias) return alias;
+    return cleanModName(mod?.modName || mod?.name) || fallback;
+  }
+
+  function visibleNameForId(items, id, keys) {
+    const wanted = String(id || "").replace(/\\/g, "/");
+    const match = (items || []).find((item) =>
+      keys.some((key) => String(item?.[key] || "").replace(/\\/g, "/") === wanted)
+    );
+    if (match) return visibleModName(match, cleanModName(wanted) || wanted);
+    return cleanModName(wanted) || wanted;
+  }
+
   function getTabLabel(tabId) {
     return SUMMARY_TABS.find((t) => t.id === tabId)?.label || String(tabId || "");
   }
@@ -237,7 +268,7 @@
       const el = panel._summaryValuesByTab[tab.id];
       const raw = getSelectedSummaryForTab(tab.id);
       if (el) {
-        el.textContent = (raw !== "None" && raw !== "Waiting for champ lock…") ? cleanModName(raw) : raw;
+        el.textContent = raw;
       }
       // Toggle active class on the row
       const row = panel._summaryRowsByTab && panel._summaryRowsByTab[tab.id];
@@ -1358,7 +1389,7 @@
 
       const modName = document.createElement("div");
       modName.className = "mod-name";
-      modName.textContent = cleanModName(mod.modName) || "Unnamed mod";
+      modName.textContent = visibleModName(mod);
       modNameRow.appendChild(modName);
 
       const isSelected = (
@@ -1454,7 +1485,7 @@
 
       const mapName = document.createElement("div");
       mapName.className = "mod-name";
-      mapName.textContent = cleanModName(map.name) || "Unnamed map";
+      mapName.textContent = visibleModName(map, "Unnamed map");
       mapNameRow.appendChild(mapName);
 
       listItem.setAttribute("data-map-id", mapId);
@@ -1536,7 +1567,7 @@
 
       const fontName = document.createElement("div");
       fontName.className = "mod-name";
-      fontName.textContent = cleanModName(font.name) || "Unnamed font";
+      fontName.textContent = visibleModName(font, "Unnamed font");
       fontNameRow.appendChild(fontName);
 
       listItem.setAttribute("data-font-id", fontId);
@@ -1618,7 +1649,7 @@
 
       const announcerName = document.createElement("div");
       announcerName.className = "mod-name";
-      announcerName.textContent = cleanModName(announcer.name) || "Unnamed announcer";
+      announcerName.textContent = visibleModName(announcer, "Unnamed announcer");
       announcerNameRow.appendChild(announcerName);
 
       listItem.setAttribute("data-announcer-id", announcerId);
@@ -1705,7 +1736,7 @@
 
       const otherName = document.createElement("div");
       otherName.className = "mod-name";
-      otherName.textContent = cleanModName(other.name || other.modName) || "Unnamed mod";
+      otherName.textContent = visibleModName(other);
       otherNameRow.appendChild(otherName);
 
       listItem.setAttribute("data-other-id", otherId);
@@ -2402,6 +2433,7 @@
     }
 
     const mapsList = Array.isArray(detail.maps) ? detail.maps : [];
+    lastMapsList = mapsList;
 
     // Check for historic mod and auto-select it
     const historicMod = detail.historicMod;
@@ -2454,6 +2486,7 @@
     }
 
     const fontsList = Array.isArray(detail.fonts) ? detail.fonts : [];
+    lastFontsList = fontsList;
 
     // Check for historic mod and auto-select it
     const historicMod = detail.historicMod;
@@ -2503,6 +2536,7 @@
     }
 
     const announcersList = Array.isArray(detail.announcers) ? detail.announcers : [];
+    lastAnnouncersList = announcersList;
 
     // Check for historic mod and auto-select it
     const historicMod = detail.historicMod;

--- a/Pengu Loader/plugins/ROSE-HistoricMode/index.js
+++ b/Pengu Loader/plugins/ROSE-HistoricMode/index.js
@@ -929,6 +929,7 @@
     log("info", "Received custom mod state", {
       active: data?.active === true,
       modName: data?.modName || null,
+      displayName: data?.displayName || null,
       skinId: data?.skinId || null,
       currentSkinId: getCurrentEffectiveSkinId(),
     });
@@ -944,9 +945,13 @@
         customModTargetSkinIds.add(customModTargetSkinId);
       }
       customModPopupActive = true;
-      showSkinName(data.modName);
+      const visibleName = (typeof data.displayName === "string" && data.displayName.trim())
+        ? data.displayName.trim()
+        : data.modName;
+      showSkinName(visibleName);
       log("info", "Displayed custom mod popup", {
         modName: data.modName,
+        displayName: visibleName,
         skinId: customModTargetSkinId,
         targetSkinIds: [...customModTargetSkinIds],
       });

--- a/Pengu Loader/plugins/ROSE-SettingsPanel/index.js
+++ b/Pengu Loader/plugins/ROSE-SettingsPanel/index.js
@@ -612,8 +612,148 @@
     #add-custom-mods-dropdown .ui-dropdown-current-content.shadow {
       color: #CDBE91 !important;
     }
-    
-    
+
+    /* Manage custom mods dropdown - same visual style as add-custom-mods-dropdown */
+    #manage-custom-mods-dropdown {
+      background: #1E2328 !important;
+      background-color: #1E2328 !important;
+      color: #c8aa6e !important;
+      font-family: "Beaufort for LOL", serif !important;
+      pointer-events: all !important;
+      position: relative !important;
+      display: flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+      box-sizing: border-box !important;
+      min-width: 90px !important;
+      height: 100% !important;
+      min-height: 32px !important;
+      cursor: pointer !important;
+      -webkit-user-select: none !important;
+      text-align: center !important;
+      transition: background 0.2s !important;
+      z-index: 10001 !important;
+      outline: none !important;
+    }
+    #manage-custom-mods-dropdown[class*="active"],
+    #manage-custom-mods-dropdown.active {
+      z-index: 10003 !important;
+    }
+    #manage-custom-mods-dropdown ~ *,
+    #manage-custom-mods-dropdown .lol-uikit-dropdown-menu,
+    #manage-custom-mods-dropdown [role="listbox"] {
+      z-index: 10003 !important;
+    }
+    #manage-custom-mods-dropdown,
+    #manage-custom-mods-dropdown::before,
+    #manage-custom-mods-dropdown::after {
+      background: #1E2328 !important;
+      background-color: #1E2328 !important;
+      background-image: none !important;
+      opacity: 1 !important;
+    }
+
+    /* Delete button in the manage-mods list rows */
+    #${FLYOUT_ID} .mod-delete-button,
+    .mod-delete-button {
+      flex: 0 0 auto;
+      background: transparent;
+      border: 1px solid rgba(255, 107, 107, 0.5);
+      border-radius: 3px;
+      color: #ff6b6b;
+      font-family: "Beaufort for LOL", serif;
+      font-size: 12px;
+      padding: 6px 14px;
+      cursor: pointer;
+      transition: background 0.2s, border-color 0.2s, color 0.2s;
+    }
+    .mod-delete-button:hover:not(:disabled) {
+      background: rgba(255, 107, 107, 0.15);
+      border-color: #ff6b6b;
+      color: #ff8f8f;
+    }
+    .mod-delete-button:disabled {
+      opacity: 0.5;
+      cursor: default;
+    }
+
+    /* Rename button in the manage-mods list rows */
+    .mod-rename-button {
+      flex: 0 0 auto;
+      background: transparent;
+      border: 1px solid rgba(200, 170, 110, 0.5);
+      border-radius: 3px;
+      color: #c8aa6e;
+      font-family: "Beaufort for LOL", serif;
+      font-size: 12px;
+      padding: 6px 14px;
+      cursor: pointer;
+      transition: background 0.2s, border-color 0.2s, color 0.2s;
+    }
+    .mod-rename-button:hover:not(:disabled) {
+      background: rgba(200, 170, 110, 0.15);
+      border-color: #c8aa6e;
+      color: #f0e6d2;
+    }
+    .mod-rename-button:disabled {
+      opacity: 0.5;
+      cursor: default;
+    }
+    #manage-custom-mods-dropdown > * {
+      background: transparent !important;
+      background-color: transparent !important;
+    }
+    #manage-custom-mods-dropdown:focus,
+    #manage-custom-mods-dropdown:active,
+    #manage-custom-mods-dropdown:focus-visible,
+    #manage-custom-mods-dropdown:focus-within,
+    #manage-custom-mods-dropdown:focus *,
+    #manage-custom-mods-dropdown:active * {
+      filter: none !important;
+      -webkit-filter: none !important;
+      transform: none !important;
+      -webkit-transform: none !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+      border-color: transparent !important;
+    }
+    #manage-custom-mods-dropdown .framed-dropdown-type {
+      text-align: left !important;
+    }
+    #manage-custom-mods-dropdown[class*="active"] .placeholder-option,
+    #manage-custom-mods-dropdown.active .placeholder-option {
+      display: none !important;
+    }
+    #manage-custom-mods-dropdown .placeholder-option {
+      display: block !important;
+    }
+    #manage-custom-mods-dropdown lol-uikit-dropdown-option::after,
+    #manage-custom-mods-dropdown lol-uikit-dropdown-option::before,
+    #manage-custom-mods-dropdown .framed-dropdown-type::after,
+    #manage-custom-mods-dropdown .framed-dropdown-type::before,
+    #manage-custom-mods-dropdown lol-uikit-dropdown-option [class*="check"],
+    #manage-custom-mods-dropdown lol-uikit-dropdown-option [class*="icon"],
+    #manage-custom-mods-dropdown lol-uikit-dropdown-option [class*="selected"] {
+      display: none !important;
+      visibility: hidden !important;
+      opacity: 0 !important;
+    }
+    #manage-custom-mods-dropdown .ui-dropdown {
+      color: #CDBE91 !important;
+      font-size: 12px !important;
+      font-weight: normal !important;
+      line-height: 16px !important;
+      letter-spacing: 0.025em !important;
+      -webkit-font-smoothing: subpixel-antialiased !important;
+    }
+    #manage-custom-mods-dropdown::part(content),
+    #manage-custom-mods-dropdown .ui-dropdown-current-content,
+    #manage-custom-mods-dropdown .ui-dropdown-current-content.shadow {
+      color: #CDBE91 !important;
+    }
+
+
     /* Add Custom Mods Dialog Styles */
     #add-custom-mods-dialog,
     #champion-selection-dialog,
@@ -2196,20 +2336,6 @@
     modsDropdownContainer.appendChild(modsDropdown);
     form.appendChild(modsDropdownContainer);
 
-    // Manage custom mods button - lets the user delete previously imported mods
-    const manageModsContainer = document.createElement("div");
-    manageModsContainer.style.marginTop = "8px";
-    manageModsContainer.style.width = "100%";
-
-    const manageModsButton = document.createElement("lol-uikit-flat-button-secondary");
-    manageModsButton.id = "manage-custom-mods-button";
-    manageModsButton.textContent = "Manage custom mods";
-    manageModsButton.style.width = "100%";
-    manageModsButton.addEventListener("click", () => {
-      openManageCustomModsDialog();
-    });
-    manageModsContainer.appendChild(manageModsButton);
-    form.appendChild(manageModsContainer);
 
     // Inject shadow DOM styles to override :host .ui-dropdown color
     let retryCount = 0;
@@ -2295,6 +2421,177 @@
       });
     });
     activeObserver.observe(modsDropdown, { attributes: true, attributeFilter: ['class'] });
+
+    // Manage custom mods dropdown
+    const manageDropdownContainer = document.createElement("div");
+    manageDropdownContainer.style.marginTop = "8px";
+    manageDropdownContainer.style.width = "100%";
+
+    const manageDropdown = document.createElement("lol-uikit-framed-dropdown");
+    manageDropdown.id = "manage-custom-mods-dropdown";
+    manageDropdown.className = "lol-publishing-locale-preference-dropdown";
+    manageDropdown.setAttribute("tabindex", "0");
+    manageDropdown.style.width = "100%";
+
+    const managePlaceholderOption = document.createElement("lol-uikit-dropdown-option");
+    managePlaceholderOption.setAttribute("slot", "lol-uikit-dropdown-option");
+    managePlaceholderOption.setAttribute("value", "");
+    managePlaceholderOption.setAttribute("selected", "");
+    managePlaceholderOption.className = "placeholder-option framed-dropdown-type";
+    managePlaceholderOption.textContent = "Manage custom mods";
+    managePlaceholderOption.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+      return false;
+    }, true);
+    manageDropdown.appendChild(managePlaceholderOption);
+
+    const manageCategories = [
+      { id: "skins", name: "Skins" },
+      { id: "maps", name: "Maps" },
+      { id: "fonts", name: "Fonts" },
+      { id: "announcers", name: "Announcers" },
+      { id: "ui", name: "UI" },
+      { id: "voiceover", name: "Voiceover" },
+      { id: "loading_screen", name: "Loading Screen" },
+      { id: "vfx", name: "VFX" },
+      { id: "sfx", name: "SFX" },
+      { id: "others", name: "Others" },
+    ];
+    manageCategories.forEach((category) => {
+      const option = document.createElement("lol-uikit-dropdown-option");
+      option.setAttribute("slot", "lol-uikit-dropdown-option");
+      option.setAttribute("value", category.id);
+      option.className = "framed-dropdown-type";
+      option.textContent = category.name;
+      manageDropdown.appendChild(option);
+    });
+
+    const removeManageFocusAndGlow = () => {
+      if (document.activeElement === manageDropdown || manageDropdown.contains(document.activeElement)) {
+        manageDropdown.blur();
+      }
+      const focusedEl = manageDropdown.querySelector(':focus');
+      if (focusedEl) focusedEl.blur();
+      manageDropdown.removeAttribute('tabindex');
+      manageDropdown.setAttribute('tabindex', '0');
+      const manageShadowRoot = manageDropdown.shadowRoot;
+      if (manageShadowRoot && manageShadowRoot.activeElement) manageShadowRoot.activeElement.blur();
+    };
+
+    const resetManageDropdown = () => {
+      manageDropdown.classList.remove("active");
+      manageDropdown.querySelectorAll('lol-uikit-dropdown-option[value!=""]').forEach(opt => opt.removeAttribute("selected"));
+      const managePh = manageDropdown.querySelector('.placeholder-option');
+      if (managePh) {
+        managePh.setAttribute("selected", "");
+        manageDropdown.setAttribute("value", "");
+      }
+      removeManageFocusAndGlow();
+      setTimeout(() => {
+        const ph = manageDropdown.querySelector('.placeholder-option');
+        if (ph && !ph.hasAttribute('selected')) ph.setAttribute("selected", "");
+        manageDropdown.querySelectorAll('lol-uikit-dropdown-option[value!=""]').forEach(opt => opt.removeAttribute("selected"));
+        removeManageFocusAndGlow();
+      }, 10);
+    };
+
+    manageDropdown.addEventListener("change", (e) => {
+      const selectedValue = e.target.value || e.detail?.value;
+      if (selectedValue) {
+        handleManageCategorySelection(selectedValue);
+        resetManageDropdown();
+      }
+    });
+
+    manageDropdown.querySelectorAll('lol-uikit-dropdown-option').forEach((option) => {
+      option.addEventListener("click", (e) => {
+        e.stopPropagation();
+        const categoryId = option.getAttribute("value");
+        if (categoryId) {
+          option.removeAttribute("selected");
+          handleManageCategorySelection(categoryId);
+          resetManageDropdown();
+          [0, 50, 100, 200].forEach(d => setTimeout(removeManageFocusAndGlow, d));
+        }
+      }, true);
+    });
+
+    const manageSelectedObserver = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'selected') {
+          const target = mutation.target;
+          if (target.getAttribute('value')) {
+            const ph = manageDropdown.querySelector('.placeholder-option');
+            if (ph && !ph.hasAttribute('selected')) {
+              target.removeAttribute('selected');
+              ph.setAttribute('selected', '');
+            }
+          }
+        }
+      });
+    });
+    manageDropdown.querySelectorAll('lol-uikit-dropdown-option').forEach(opt =>
+      manageSelectedObserver.observe(opt, { attributes: true, attributeFilter: ['selected'] })
+    );
+
+    manageDropdownContainer.appendChild(manageDropdown);
+    form.appendChild(manageDropdownContainer);
+
+    let manageRetryCount = 0;
+    const injectManageShadowStyles = () => {
+      const root = manageDropdown.shadowRoot;
+      if (!root) {
+        if (manageRetryCount < MAX_RETRIES) { manageRetryCount++; setTimeout(injectManageShadowStyles, 50); }
+        return;
+      }
+      if (root.querySelector('style[data-rose-dropdown-color]')) return;
+      const s = document.createElement("style");
+      s.setAttribute("data-rose-dropdown-color", "true");
+      s.textContent = `
+        :host .ui-dropdown {
+          color: #CDBE91 !important;
+          font-size: 12px !important;
+          font-weight: normal !important;
+          line-height: 16px !important;
+          letter-spacing: 0.025em !important;
+          -webkit-font-smoothing: subpixel-antialiased !important;
+        }
+        :host:not(:focus):not(:focus-within) .ui-dropdown,
+        :host:not(:focus):not(:focus-within) * {
+          filter: none !important;
+          -webkit-filter: none !important;
+          box-shadow: none !important;
+          text-shadow: none !important;
+          outline: none !important;
+        }
+      `;
+      root.appendChild(s);
+    };
+    injectManageShadowStyles();
+
+    manageDropdown.addEventListener("click", (e) => {
+      if (!e.target.closest('lol-uikit-dropdown-option')) setTimeout(removeManageFocusAndGlow, 100);
+    });
+    manageDropdown.addEventListener("mouseleave", () => {
+      if (!manageDropdown.classList.contains('active')) removeManageFocusAndGlow();
+    });
+    manageDropdown.addEventListener("change", () => {
+      [50, 150].forEach(d => setTimeout(removeManageFocusAndGlow, d));
+    });
+
+    const manageActiveObserver = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+          if (!manageDropdown.classList.contains('active')) {
+            removeManageFocusAndGlow();
+            [50, 150].forEach(d => setTimeout(removeManageFocusAndGlow, d));
+          }
+        }
+      });
+    });
+    manageActiveObserver.observe(manageDropdown, { attributes: true, attributeFilter: ['class'] });
 
     // Open logs folder button
     const logsButton = document.createElement("lol-uikit-flat-button-secondary");
@@ -3249,99 +3546,7 @@
     { id: "others", name: "Others" },
   ];
 
-  function openManageCustomModsDialog() {
-    const existingDialog = document.getElementById("manage-custom-mods-dialog");
-    if (existingDialog) {
-      existingDialog.remove();
-    }
-
-    const dialog = document.createElement("div");
-    dialog.id = "manage-custom-mods-dialog";
-    dialog.style.position = "fixed";
-    dialog.style.top = "0";
-    dialog.style.left = "0";
-    dialog.style.width = "100%";
-    dialog.style.height = "100%";
-    dialog.style.zIndex = "10001";
-    dialog.style.pointerEvents = "none";
-    document.body.appendChild(dialog);
-
-    const backdrop = document.createElement("div");
-    backdrop.className = "backdrop";
-    backdrop.addEventListener("click", (e) => {
-      if (e.target === backdrop) {
-        closeManageCustomModsDialog();
-      }
-    });
-    dialog.appendChild(backdrop);
-
-    let flyoutFrame;
-    try {
-      flyoutFrame = document.createElement("lol-uikit-flyout-frame");
-      flyoutFrame.id = "add-custom-mods-flyout";
-      flyoutFrame.className = "flyout";
-      flyoutFrame.setAttribute("orientation", "center");
-      flyoutFrame.setAttribute("animated", "true");
-      flyoutFrame.setAttribute("show", "true");
-    } catch (e) {
-      flyoutFrame = document.createElement("div");
-      flyoutFrame.id = "add-custom-mods-flyout";
-      flyoutFrame.className = "flyout";
-    }
-    flyoutFrame.style.position = "absolute";
-    flyoutFrame.style.top = "50%";
-    flyoutFrame.style.left = "50%";
-    flyoutFrame.style.transform = "translate(-50%, -50%)";
-    flyoutFrame.style.zIndex = "10002";
-    flyoutFrame.style.pointerEvents = "all";
-
-    let flyoutContent;
-    try {
-      flyoutContent = document.createElement("lc-flyout-content");
-    } catch (e) {
-      flyoutContent = document.createElement("div");
-      flyoutContent.className = "lc-flyout-content";
-    }
-
-    const title = document.createElement("div");
-    title.className = "settings-title";
-    title.textContent = "Manage Custom Mods";
-    flyoutContent.appendChild(title);
-
-    const categoriesContainer = document.createElement("div");
-    categoriesContainer.style.display = "flex";
-    categoriesContainer.style.flexDirection = "column";
-    categoriesContainer.style.gap = "10px";
-
-    MANAGE_MOD_CATEGORIES.forEach((category) => {
-      const categoryButton = document.createElement("lol-uikit-flat-button-secondary");
-      categoryButton.textContent = category.name;
-      categoryButton.style.width = "100%";
-      categoryButton.style.padding = "12px";
-      categoryButton.addEventListener("click", () => {
-        handleManageCategorySelection(category.id);
-      });
-      categoriesContainer.appendChild(categoryButton);
-    });
-
-    flyoutContent.appendChild(categoriesContainer);
-    flyoutFrame.appendChild(flyoutContent);
-    dialog.appendChild(flyoutFrame);
-
-    flyoutFrame.addEventListener("click", (e) => {
-      e.stopPropagation();
-    });
-  }
-
-  function closeManageCustomModsDialog() {
-    const dialog = document.getElementById("manage-custom-mods-dialog");
-    if (dialog) {
-      dialog.remove();
-    }
-  }
-
   function handleManageCategorySelection(category) {
-    closeManageCustomModsDialog();
     if (category === "skins") {
       openChampionSelection("manage");
     } else {
@@ -3349,17 +3554,23 @@
     }
   }
 
-  function createModsListDialog(id, titleText, onBack) {
+  function createModsListDialog(id, titleText, onBack, onDismiss) {
     const existingDialog = document.getElementById(id);
     if (existingDialog) {
       existingDialog.remove();
     }
 
+    const dismiss = () => {
+      dialog.remove();
+      if (onDismiss) onDismiss();
+    };
+
     const dialog = document.createElement("div");
     dialog.id = id;
+    dialog.style.cssText = "position:fixed;top:0;left:0;width:100%;height:100%;z-index:10001;background:rgba(0,0,0,0.5);display:flex;align-items:center;justify-content:center;";
     dialog.addEventListener("click", (e) => {
       if (e.target === dialog) {
-        dialog.remove();
+        dismiss();
       }
     });
     document.body.appendChild(dialog);
@@ -3371,13 +3582,13 @@
     flyoutFrame.style.boxSizing = "border-box";
     flyoutFrame.style.overflowY = "hidden";
     flyoutFrame.style.overflowX = "hidden";
+    flyoutFrame.style.position = "relative";
+    flyoutFrame.style.zIndex = "10002";
     flyoutFrame.addEventListener("click", (e) => e.stopPropagation());
 
     const flyoutContent = document.createElement("div");
     flyoutContent.className = "lc-flyout-content";
-    flyoutContent.style.display = "flex";
-    flyoutContent.style.flexDirection = "column";
-    flyoutContent.style.boxSizing = "border-box";
+    flyoutContent.style.cssText = "display:flex;flex-direction:column;box-sizing:border-box;background:#010a13;border:1px solid #c8aa6e;padding:20px;width:100%;box-shadow:0 4px 12px rgba(0,0,0,0.5);color:#cdbe91;font-family:'Beaufort for LOL',serif;";
 
     const header = document.createElement("div");
     header.className = "dialog-header";
@@ -3388,7 +3599,7 @@
     backButton.setAttribute("aria-label", "Go back");
     backButton.addEventListener("click", (e) => {
       e.stopPropagation();
-      dialog.remove();
+      dismiss();
       if (onBack) onBack();
     });
     header.appendChild(backButton);
@@ -3413,7 +3624,7 @@
     return { dialog, listContainer };
   }
 
-  function renderModRow(listContainer, mod, onDelete) {
+  function renderModRow(listContainer, mod, onDelete, onRename) {
     const row = document.createElement("div");
     row.className = "mod-manage-row";
     row.style.display = "flex";
@@ -3433,16 +3644,19 @@
       const thumb = document.createElement("img");
       thumb.src = mod.thumbnailUrl;
       thumb.alt = mod.name;
-      thumb.style.width = "40px";
-      thumb.style.height = "40px";
+      thumb.style.width = "44px";
+      thumb.style.height = "44px";
+      thumb.style.flex = "0 0 44px";
       thumb.style.objectFit = "cover";
-      thumb.style.borderRadius = "4px";
+      thumb.style.borderRadius = "50%";
+      thumb.style.border = "2px solid #5b5a56";
       thumb.onerror = function () { this.style.display = "none"; };
       infoWrapper.appendChild(thumb);
     }
 
+    const displayLabel = mod.displayName || mod.name;
     const nameEl = document.createElement("div");
-    nameEl.textContent = mod.name;
+    nameEl.textContent = displayLabel;
     nameEl.style.color = "#cdbe91";
     nameEl.style.fontFamily = '"Beaufort for LOL", serif';
     nameEl.style.overflow = "hidden";
@@ -3452,19 +3666,97 @@
 
     row.appendChild(infoWrapper);
 
+    const actions = document.createElement("div");
+    actions.style.display = "flex";
+    actions.style.alignItems = "center";
+    actions.style.gap = "8px";
+    actions.style.flex = "0 0 auto";
+
+    if (onRename) {
+      const renameButton = document.createElement("button");
+      renameButton.type = "button";
+      renameButton.className = "mod-rename-button";
+      renameButton.textContent = "Rename";
+      renameButton.addEventListener("click", (e) => {
+        e.stopPropagation();
+        promptRenameMod(displayLabel, (newName) => onRename(renameButton, row, newName));
+      });
+      actions.appendChild(renameButton);
+    }
+
     const deleteButton = document.createElement("button");
     deleteButton.type = "button";
-    deleteButton.className = "back-button";
+    deleteButton.className = "mod-delete-button";
     deleteButton.textContent = "Delete";
-    deleteButton.style.flex = "0 0 auto";
-    deleteButton.style.color = "#ff6b6b";
     deleteButton.addEventListener("click", (e) => {
       e.stopPropagation();
-      confirmDeleteMod(mod.name, () => onDelete(deleteButton, row));
+      confirmDeleteMod(displayLabel, () => onDelete(deleteButton, row));
     });
-    row.appendChild(deleteButton);
+    actions.appendChild(deleteButton);
 
+    row.appendChild(actions);
     listContainer.appendChild(row);
+  }
+
+  function promptRenameMod(currentName, onConfirm) {
+    const existing = document.getElementById("rename-mod-dialog");
+    if (existing) existing.remove();
+
+    const dlg = document.createElement("div");
+    dlg.id = "rename-mod-dialog";
+    dlg.style.cssText = "position:fixed;top:0;left:0;width:100%;height:100%;z-index:10004;";
+
+    const backdrop = document.createElement("div");
+    backdrop.className = "backdrop";
+    backdrop.addEventListener("click", () => dlg.remove());
+    dlg.appendChild(backdrop);
+
+    const box = document.createElement("div");
+    box.className = "flyout";
+    box.style.cssText = "position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:380px;padding:20px;background:#010a13;border:1px solid #c8aa6e;box-sizing:border-box;";
+    box.addEventListener("click", (e) => e.stopPropagation());
+
+    const label = document.createElement("div");
+    label.textContent = "Rename mod";
+    label.style.cssText = "color:#c8aa6e;font-family:'Beaufort for LOL',serif;font-size:16px;font-weight:bold;margin-bottom:12px;text-align:center;";
+    box.appendChild(label);
+
+    const input = document.createElement("input");
+    input.type = "text";
+    input.value = currentName || "";
+    input.maxLength = 100;
+    input.style.cssText = "width:100%;padding:8px;background:#1e2328;border:1px solid #5c5b56;color:#cdbe91;font-size:14px;font-family:'Beaufort for LOL',serif;box-sizing:border-box;outline:none;";
+    box.appendChild(input);
+
+    const actionsRow = document.createElement("div");
+    actionsRow.style.cssText = "display:flex;justify-content:flex-end;gap:10px;margin-top:16px;";
+
+    const cancelButton = document.createElement("lol-uikit-flat-button-secondary");
+    cancelButton.textContent = "Cancel";
+    cancelButton.addEventListener("click", () => dlg.remove());
+    actionsRow.appendChild(cancelButton);
+
+    const saveButton = document.createElement("lol-uikit-flat-button-secondary");
+    saveButton.textContent = "Save";
+    const submit = () => {
+      const value = input.value.trim();
+      if (!value) return;
+      dlg.remove();
+      onConfirm(value);
+    };
+    saveButton.addEventListener("click", submit);
+    actionsRow.appendChild(saveButton);
+
+    box.appendChild(actionsRow);
+    dlg.appendChild(box);
+    document.body.appendChild(dlg);
+
+    input.focus();
+    input.select();
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") { e.preventDefault(); submit(); }
+      else if (e.key === "Escape") { e.preventDefault(); dlg.remove(); }
+    });
   }
 
   function confirmDeleteMod(modName, onConfirm) {
@@ -3473,26 +3765,17 @@
 
     const confirmDialog = document.createElement("div");
     confirmDialog.id = "delete-mod-confirm-dialog";
-    confirmDialog.style.position = "fixed";
-    confirmDialog.style.top = "0";
-    confirmDialog.style.left = "0";
-    confirmDialog.style.width = "100%";
-    confirmDialog.style.height = "100%";
-    confirmDialog.style.zIndex = "10003";
+    confirmDialog.style.cssText = "position:fixed;top:0;left:0;width:100%;height:100%;z-index:10004;";
 
     const backdrop = document.createElement("div");
     backdrop.className = "backdrop";
+    backdrop.style.cssText = "position:absolute;inset:0;background:rgba(0,0,0,0.55);";
     backdrop.addEventListener("click", () => confirmDialog.remove());
     confirmDialog.appendChild(backdrop);
 
     const box = document.createElement("div");
     box.className = "flyout";
-    box.style.position = "absolute";
-    box.style.top = "50%";
-    box.style.left = "50%";
-    box.style.transform = "translate(-50%, -50%)";
-    box.style.width = "360px";
-    box.style.padding = "20px";
+    box.style.cssText = "position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:360px;padding:20px;background:#010a13;border:1px solid #c8aa6e;box-sizing:border-box;box-shadow:0 4px 12px rgba(0,0,0,0.5);";
     box.addEventListener("click", (e) => e.stopPropagation());
 
     const message = document.createElement("div");
@@ -3530,14 +3813,14 @@
     createModsListDialog(
       "champion-mods-manage-dialog",
       "Manage Mods - Loading...",
-      () => openChampionSelection("manage")
+      () => openChampionSelection("manage"),
+      () => { delete window.__roseManageChampionId; }
     );
     window.__roseManageChampionId = championId;
 
     if (bridge) bridge.send({
-      type: "request-skin-mods",
+      type: "request-manage-champion-mods",
       championId: championId,
-      skinId: Number(championId) * 1000,
     });
   }
 
@@ -3568,14 +3851,15 @@
       return;
     }
 
-    // De-duplicate by mod name: the same mod can target multiple skins/chromas.
+    // De-duplicate by path: the same folder can appear once per target skin.
     const seen = new Set();
     mods.forEach((mod) => {
-      if (seen.has(mod.modName)) return;
-      seen.add(mod.modName);
+      const dedupeKey = mod.relativePath || mod.modName;
+      if (seen.has(dedupeKey)) return;
+      seen.add(dedupeKey);
       renderModRow(
         listContainer,
-        { name: mod.modName, thumbnailUrl: mod.thumbnailUrl },
+        { name: mod.modName, displayName: mod.displayName, thumbnailUrl: mod.thumbnailUrl },
         (deleteButton, row) => {
           deleteButton.disabled = true;
           deleteButton.textContent = "Deleting...";
@@ -3585,6 +3869,17 @@
             modName: mod.modName,
             relativePath: mod.relativePath,
           });
+        },
+        (renameButton, row, newName) => {
+          renameButton.disabled = true;
+          renameButton.textContent = "Saving...";
+          if (bridge) bridge.send({
+            type: "rename-champion-mod",
+            championId: window.__roseManageChampionId,
+            modName: mod.modName,
+            relativePath: mod.relativePath,
+            newName: newName,
+          });
         }
       );
     });
@@ -3593,10 +3888,27 @@
   function handleChampionModDeleted(payload) {
     if (!payload.success) {
       log("error", "Failed to delete champion mod: " + (payload.error || "unknown error"));
-      return;
+    } else {
+      log("info", `Champion mod deleted: champion=${payload.championId}, mod=${payload.modName}`);
     }
-    log("info", `Champion mod deleted: champion=${payload.championId}, mod=${payload.modName}`);
-    if (Number(payload.championId) === Number(window.__roseManageChampionId)) {
+    if (
+      document.getElementById("champion-mods-manage-dialog") &&
+      Number(payload.championId) === Number(window.__roseManageChampionId)
+    ) {
+      openChampionModsList(payload.championId);
+    }
+  }
+
+  function handleChampionModRenamed(payload) {
+    if (!payload.success) {
+      log("error", "Failed to rename champion mod: " + (payload.error || "unknown error"));
+    } else {
+      log("info", `Champion mod renamed: champion=${payload.championId}, mod=${payload.modName} -> ${payload.displayName}`);
+    }
+    if (
+      document.getElementById("champion-mods-manage-dialog") &&
+      Number(payload.championId) === Number(window.__roseManageChampionId)
+    ) {
       openChampionModsList(payload.championId);
     }
   }
@@ -3606,12 +3918,13 @@
     createModsListDialog(
       "category-mods-manage-dialog",
       `Manage Mods - ${categoryMeta ? categoryMeta.name : category}`,
-      () => openManageCustomModsDialog()
+      null,
+      () => { delete window.__roseManageCategory; }
     );
     window.__roseManageCategory = category;
 
     if (bridge) bridge.send({
-      type: "request-category-mods",
+      type: "request-manage-category-mods",
       category: category,
     });
   }
@@ -3630,25 +3943,56 @@
     }
 
     mods.forEach((mod) => {
-      renderModRow(listContainer, { name: mod.name }, (deleteButton) => {
-        deleteButton.disabled = true;
-        deleteButton.textContent = "Deleting...";
-        if (bridge) bridge.send({
-          type: "delete-category-mod",
-          category: window.__roseManageCategory,
-          modName: mod.name,
-        });
-      });
+      renderModRow(
+        listContainer,
+        { name: mod.name, displayName: mod.displayName },
+        (deleteButton) => {
+          deleteButton.disabled = true;
+          deleteButton.textContent = "Deleting...";
+          if (bridge) bridge.send({
+            type: "delete-category-mod",
+            category: window.__roseManageCategory,
+            modName: mod.name,
+          });
+        },
+        (renameButton, row, newName) => {
+          renameButton.disabled = true;
+          renameButton.textContent = "Saving...";
+          if (bridge) bridge.send({
+            type: "rename-category-mod",
+            category: window.__roseManageCategory,
+            modName: mod.name,
+            newName: newName,
+          });
+        }
+      );
     });
   }
 
   function handleCategoryModDeleted(payload) {
     if (!payload.success) {
       log("error", "Failed to delete category mod: " + (payload.error || "unknown error"));
-      return;
+    } else {
+      log("info", `Category mod deleted: category=${payload.category}, mod=${payload.modName}`);
     }
-    log("info", `Category mod deleted: category=${payload.category}, mod=${payload.modName}`);
-    if (payload.category === window.__roseManageCategory) {
+    if (
+      document.getElementById("category-mods-manage-dialog") &&
+      payload.category === window.__roseManageCategory
+    ) {
+      openCategoryModsList(payload.category);
+    }
+  }
+
+  function handleCategoryModRenamed(payload) {
+    if (!payload.success) {
+      log("error", "Failed to rename category mod: " + (payload.error || "unknown error"));
+    } else {
+      log("info", `Category mod renamed: category=${payload.category}, mod=${payload.modName} -> ${payload.displayName}`);
+    }
+    if (
+      document.getElementById("category-mods-manage-dialog") &&
+      payload.category === window.__roseManageCategory
+    ) {
       openCategoryModsList(payload.category);
     }
   }
@@ -4432,10 +4776,12 @@
       bridge.subscribe("champions-list-response", handleChampionsListResponse);
       bridge.subscribe("champion-skins-response", handleChampionSkinsResponse);
       bridge.subscribe("folder-opened-response", handleFolderOpenedResponse);
-      bridge.subscribe("skin-mods-response", handleManageSkinModsResponse);
-      bridge.subscribe("category-mods-response", handleManageCategoryModsResponse);
+      bridge.subscribe("manage-champion-mods-response", handleManageSkinModsResponse);
+      bridge.subscribe("manage-category-mods-response", handleManageCategoryModsResponse);
       bridge.subscribe("champion-mod-deleted", handleChampionModDeleted);
       bridge.subscribe("category-mod-deleted", handleCategoryModDeleted);
+      bridge.subscribe("champion-mod-renamed", handleChampionModRenamed);
+      bridge.subscribe("category-mod-renamed", handleCategoryModRenamed);
 
       // On every (re)connect, sync state
       bridge.onReady(() => {

--- a/Pengu Loader/plugins/ROSE-SettingsPanel/index.js
+++ b/Pengu Loader/plugins/ROSE-SettingsPanel/index.js
@@ -2196,6 +2196,21 @@
     modsDropdownContainer.appendChild(modsDropdown);
     form.appendChild(modsDropdownContainer);
 
+    // Manage custom mods button - lets the user delete previously imported mods
+    const manageModsContainer = document.createElement("div");
+    manageModsContainer.style.marginTop = "8px";
+    manageModsContainer.style.width = "100%";
+
+    const manageModsButton = document.createElement("lol-uikit-flat-button-secondary");
+    manageModsButton.id = "manage-custom-mods-button";
+    manageModsButton.textContent = "Manage custom mods";
+    manageModsButton.style.width = "100%";
+    manageModsButton.addEventListener("click", () => {
+      openManageCustomModsDialog();
+    });
+    manageModsContainer.appendChild(manageModsButton);
+    form.appendChild(manageModsContainer);
+
     // Inject shadow DOM styles to override :host .ui-dropdown color
     let retryCount = 0;
     const MAX_RETRIES = 20;
@@ -2840,7 +2855,9 @@
     }
   }
 
-  function openChampionSelection() {
+  function openChampionSelection(mode) {
+    window.__roseChampionSelectionMode = mode === "manage" ? "manage" : "add";
+
     // Remove existing dialog if any
     const existingDialog = document.getElementById("champion-selection-dialog");
     if (existingDialog) {
@@ -2888,7 +2905,9 @@
     // Title text
     const titleWrapper = document.createElement("div");
     titleWrapper.className = "dialog-title-wrapper";
-    titleWrapper.textContent = "Select Champion";
+    titleWrapper.textContent = window.__roseChampionSelectionMode === "manage"
+      ? "Manage Mods - Select Champion"
+      : "Select Champion";
     header.appendChild(titleWrapper);
 
     flyoutContent.appendChild(header);
@@ -3010,9 +3029,15 @@
   }
 
   function handleChampionSelection(championId) {
+    const mode = window.__roseChampionSelectionMode === "manage" ? "manage" : "add";
     closeChampionSelection();
-    openSkinSelection(championId);
-    log("info", "Champion selected for custom mods: champion=" + championId);
+    if (mode === "manage") {
+      openChampionModsList(championId);
+      log("info", "Champion selected for mod management: champion=" + championId);
+    } else {
+      openSkinSelection(championId);
+      log("info", "Champion selected for custom mods: champion=" + championId);
+    }
   }
 
   function openSkinSelection(championId) {
@@ -3207,6 +3232,425 @@
       skinIds: selectedSkinIds,
     });
     log("info", `Skin selection confirmed: champion=${championId}, skins=${selectedSkinIds.join(",")}`);
+  }
+
+  // ==================== Manage Custom Mods (delete) ====================
+
+  const MANAGE_MOD_CATEGORIES = [
+    { id: "skins", name: "Skins" },
+    { id: "maps", name: "Maps" },
+    { id: "fonts", name: "Fonts" },
+    { id: "announcers", name: "Announcers" },
+    { id: "ui", name: "UI" },
+    { id: "voiceover", name: "Voiceover" },
+    { id: "loading_screen", name: "Loading Screen" },
+    { id: "vfx", name: "VFX" },
+    { id: "sfx", name: "SFX" },
+    { id: "others", name: "Others" },
+  ];
+
+  function openManageCustomModsDialog() {
+    const existingDialog = document.getElementById("manage-custom-mods-dialog");
+    if (existingDialog) {
+      existingDialog.remove();
+    }
+
+    const dialog = document.createElement("div");
+    dialog.id = "manage-custom-mods-dialog";
+    dialog.style.position = "fixed";
+    dialog.style.top = "0";
+    dialog.style.left = "0";
+    dialog.style.width = "100%";
+    dialog.style.height = "100%";
+    dialog.style.zIndex = "10001";
+    dialog.style.pointerEvents = "none";
+    document.body.appendChild(dialog);
+
+    const backdrop = document.createElement("div");
+    backdrop.className = "backdrop";
+    backdrop.addEventListener("click", (e) => {
+      if (e.target === backdrop) {
+        closeManageCustomModsDialog();
+      }
+    });
+    dialog.appendChild(backdrop);
+
+    let flyoutFrame;
+    try {
+      flyoutFrame = document.createElement("lol-uikit-flyout-frame");
+      flyoutFrame.id = "add-custom-mods-flyout";
+      flyoutFrame.className = "flyout";
+      flyoutFrame.setAttribute("orientation", "center");
+      flyoutFrame.setAttribute("animated", "true");
+      flyoutFrame.setAttribute("show", "true");
+    } catch (e) {
+      flyoutFrame = document.createElement("div");
+      flyoutFrame.id = "add-custom-mods-flyout";
+      flyoutFrame.className = "flyout";
+    }
+    flyoutFrame.style.position = "absolute";
+    flyoutFrame.style.top = "50%";
+    flyoutFrame.style.left = "50%";
+    flyoutFrame.style.transform = "translate(-50%, -50%)";
+    flyoutFrame.style.zIndex = "10002";
+    flyoutFrame.style.pointerEvents = "all";
+
+    let flyoutContent;
+    try {
+      flyoutContent = document.createElement("lc-flyout-content");
+    } catch (e) {
+      flyoutContent = document.createElement("div");
+      flyoutContent.className = "lc-flyout-content";
+    }
+
+    const title = document.createElement("div");
+    title.className = "settings-title";
+    title.textContent = "Manage Custom Mods";
+    flyoutContent.appendChild(title);
+
+    const categoriesContainer = document.createElement("div");
+    categoriesContainer.style.display = "flex";
+    categoriesContainer.style.flexDirection = "column";
+    categoriesContainer.style.gap = "10px";
+
+    MANAGE_MOD_CATEGORIES.forEach((category) => {
+      const categoryButton = document.createElement("lol-uikit-flat-button-secondary");
+      categoryButton.textContent = category.name;
+      categoryButton.style.width = "100%";
+      categoryButton.style.padding = "12px";
+      categoryButton.addEventListener("click", () => {
+        handleManageCategorySelection(category.id);
+      });
+      categoriesContainer.appendChild(categoryButton);
+    });
+
+    flyoutContent.appendChild(categoriesContainer);
+    flyoutFrame.appendChild(flyoutContent);
+    dialog.appendChild(flyoutFrame);
+
+    flyoutFrame.addEventListener("click", (e) => {
+      e.stopPropagation();
+    });
+  }
+
+  function closeManageCustomModsDialog() {
+    const dialog = document.getElementById("manage-custom-mods-dialog");
+    if (dialog) {
+      dialog.remove();
+    }
+  }
+
+  function handleManageCategorySelection(category) {
+    closeManageCustomModsDialog();
+    if (category === "skins") {
+      openChampionSelection("manage");
+    } else {
+      openCategoryModsList(category);
+    }
+  }
+
+  function createModsListDialog(id, titleText, onBack) {
+    const existingDialog = document.getElementById(id);
+    if (existingDialog) {
+      existingDialog.remove();
+    }
+
+    const dialog = document.createElement("div");
+    dialog.id = id;
+    dialog.addEventListener("click", (e) => {
+      if (e.target === dialog) {
+        dialog.remove();
+      }
+    });
+    document.body.appendChild(dialog);
+
+    const flyoutFrame = document.createElement("div");
+    flyoutFrame.className = "flyout";
+    flyoutFrame.style.maxHeight = "75vh";
+    flyoutFrame.style.width = "700px";
+    flyoutFrame.style.boxSizing = "border-box";
+    flyoutFrame.style.overflowY = "hidden";
+    flyoutFrame.style.overflowX = "hidden";
+    flyoutFrame.addEventListener("click", (e) => e.stopPropagation());
+
+    const flyoutContent = document.createElement("div");
+    flyoutContent.className = "lc-flyout-content";
+    flyoutContent.style.display = "flex";
+    flyoutContent.style.flexDirection = "column";
+    flyoutContent.style.boxSizing = "border-box";
+
+    const header = document.createElement("div");
+    header.className = "dialog-header";
+
+    const backButton = document.createElement("button");
+    backButton.className = "back-button";
+    backButton.innerHTML = '<svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>';
+    backButton.setAttribute("aria-label", "Go back");
+    backButton.addEventListener("click", (e) => {
+      e.stopPropagation();
+      dialog.remove();
+      if (onBack) onBack();
+    });
+    header.appendChild(backButton);
+
+    const titleWrapper = document.createElement("div");
+    titleWrapper.className = "dialog-title-wrapper";
+    titleWrapper.textContent = titleText;
+    header.appendChild(titleWrapper);
+    flyoutContent.appendChild(header);
+
+    const listContainer = document.createElement("div");
+    listContainer.id = `${id}-list`;
+    listContainer.style.overflowY = "auto";
+    listContainer.style.overflowX = "hidden";
+    listContainer.style.maxHeight = "60vh";
+    listContainer.style.marginTop = "12px";
+    listContainer.innerHTML = `<div style="color: #cdbe91; text-align: center; padding: 20px; font-family: 'Beaufort for LOL', serif;">Loading mods...</div>`;
+    flyoutContent.appendChild(listContainer);
+
+    flyoutFrame.appendChild(flyoutContent);
+    dialog.appendChild(flyoutFrame);
+    return { dialog, listContainer };
+  }
+
+  function renderModRow(listContainer, mod, onDelete) {
+    const row = document.createElement("div");
+    row.className = "mod-manage-row";
+    row.style.display = "flex";
+    row.style.alignItems = "center";
+    row.style.justifyContent = "space-between";
+    row.style.gap = "10px";
+    row.style.padding = "10px";
+    row.style.borderBottom = "1px solid rgba(205, 190, 145, 0.2)";
+
+    const infoWrapper = document.createElement("div");
+    infoWrapper.style.display = "flex";
+    infoWrapper.style.alignItems = "center";
+    infoWrapper.style.gap = "10px";
+    infoWrapper.style.minWidth = "0";
+
+    if (mod.thumbnailUrl) {
+      const thumb = document.createElement("img");
+      thumb.src = mod.thumbnailUrl;
+      thumb.alt = mod.name;
+      thumb.style.width = "40px";
+      thumb.style.height = "40px";
+      thumb.style.objectFit = "cover";
+      thumb.style.borderRadius = "4px";
+      thumb.onerror = function () { this.style.display = "none"; };
+      infoWrapper.appendChild(thumb);
+    }
+
+    const nameEl = document.createElement("div");
+    nameEl.textContent = mod.name;
+    nameEl.style.color = "#cdbe91";
+    nameEl.style.fontFamily = '"Beaufort for LOL", serif';
+    nameEl.style.overflow = "hidden";
+    nameEl.style.textOverflow = "ellipsis";
+    nameEl.style.whiteSpace = "nowrap";
+    infoWrapper.appendChild(nameEl);
+
+    row.appendChild(infoWrapper);
+
+    const deleteButton = document.createElement("button");
+    deleteButton.type = "button";
+    deleteButton.className = "back-button";
+    deleteButton.textContent = "Delete";
+    deleteButton.style.flex = "0 0 auto";
+    deleteButton.style.color = "#ff6b6b";
+    deleteButton.addEventListener("click", (e) => {
+      e.stopPropagation();
+      confirmDeleteMod(mod.name, () => onDelete(deleteButton, row));
+    });
+    row.appendChild(deleteButton);
+
+    listContainer.appendChild(row);
+  }
+
+  function confirmDeleteMod(modName, onConfirm) {
+    const existing = document.getElementById("delete-mod-confirm-dialog");
+    if (existing) existing.remove();
+
+    const confirmDialog = document.createElement("div");
+    confirmDialog.id = "delete-mod-confirm-dialog";
+    confirmDialog.style.position = "fixed";
+    confirmDialog.style.top = "0";
+    confirmDialog.style.left = "0";
+    confirmDialog.style.width = "100%";
+    confirmDialog.style.height = "100%";
+    confirmDialog.style.zIndex = "10003";
+
+    const backdrop = document.createElement("div");
+    backdrop.className = "backdrop";
+    backdrop.addEventListener("click", () => confirmDialog.remove());
+    confirmDialog.appendChild(backdrop);
+
+    const box = document.createElement("div");
+    box.className = "flyout";
+    box.style.position = "absolute";
+    box.style.top = "50%";
+    box.style.left = "50%";
+    box.style.transform = "translate(-50%, -50%)";
+    box.style.width = "360px";
+    box.style.padding = "20px";
+    box.addEventListener("click", (e) => e.stopPropagation());
+
+    const message = document.createElement("div");
+    message.style.color = "#cdbe91";
+    message.style.fontFamily = '"Beaufort for LOL", serif';
+    message.style.marginBottom = "16px";
+    message.textContent = `Delete mod "${modName}"? This cannot be undone.`;
+    box.appendChild(message);
+
+    const actions = document.createElement("div");
+    actions.style.display = "flex";
+    actions.style.justifyContent = "flex-end";
+    actions.style.gap = "10px";
+
+    const cancelButton = document.createElement("lol-uikit-flat-button-secondary");
+    cancelButton.textContent = "Cancel";
+    cancelButton.addEventListener("click", () => confirmDialog.remove());
+    actions.appendChild(cancelButton);
+
+    const deleteButton = document.createElement("lol-uikit-flat-button-secondary");
+    deleteButton.textContent = "Delete";
+    deleteButton.style.color = "#ff6b6b";
+    deleteButton.addEventListener("click", () => {
+      confirmDialog.remove();
+      onConfirm();
+    });
+    actions.appendChild(deleteButton);
+
+    box.appendChild(actions);
+    confirmDialog.appendChild(box);
+    document.body.appendChild(confirmDialog);
+  }
+
+  function openChampionModsList(championId) {
+    createModsListDialog(
+      "champion-mods-manage-dialog",
+      "Manage Mods - Loading...",
+      () => openChampionSelection("manage")
+    );
+    window.__roseManageChampionId = championId;
+
+    if (bridge) bridge.send({
+      type: "request-skin-mods",
+      championId: championId,
+      skinId: Number(championId) * 1000,
+    });
+  }
+
+  function closeChampionModsList() {
+    const dialog = document.getElementById("champion-mods-manage-dialog");
+    if (dialog) dialog.remove();
+    delete window.__roseManageChampionId;
+  }
+
+  function handleManageSkinModsResponse(payload) {
+    if (Number(payload.championId) !== Number(window.__roseManageChampionId)) return;
+
+    const dialog = document.getElementById("champion-mods-manage-dialog");
+    const listContainer = document.getElementById("champion-mods-manage-dialog-list");
+    if (!dialog || !listContainer) return;
+
+    const titleWrapper = dialog.querySelector(".dialog-title-wrapper");
+    if (titleWrapper) {
+      titleWrapper.textContent = payload.championName
+        ? `Manage Mods - ${payload.championName}`
+        : "Manage Mods";
+    }
+
+    listContainer.innerHTML = "";
+    const mods = payload.mods || [];
+    if (mods.length === 0) {
+      listContainer.innerHTML = `<div style="color: #cdbe91; text-align: center; padding: 20px; font-family: 'Beaufort for LOL', serif;">No custom mods installed for this champion.</div>`;
+      return;
+    }
+
+    // De-duplicate by mod name: the same mod can target multiple skins/chromas.
+    const seen = new Set();
+    mods.forEach((mod) => {
+      if (seen.has(mod.modName)) return;
+      seen.add(mod.modName);
+      renderModRow(
+        listContainer,
+        { name: mod.modName, thumbnailUrl: mod.thumbnailUrl },
+        (deleteButton, row) => {
+          deleteButton.disabled = true;
+          deleteButton.textContent = "Deleting...";
+          if (bridge) bridge.send({
+            type: "delete-champion-mod",
+            championId: window.__roseManageChampionId,
+            modName: mod.modName,
+            relativePath: mod.relativePath,
+          });
+        }
+      );
+    });
+  }
+
+  function handleChampionModDeleted(payload) {
+    if (!payload.success) {
+      log("error", "Failed to delete champion mod: " + (payload.error || "unknown error"));
+      return;
+    }
+    log("info", `Champion mod deleted: champion=${payload.championId}, mod=${payload.modName}`);
+    if (Number(payload.championId) === Number(window.__roseManageChampionId)) {
+      openChampionModsList(payload.championId);
+    }
+  }
+
+  function openCategoryModsList(category) {
+    const categoryMeta = MANAGE_MOD_CATEGORIES.find((c) => c.id === category);
+    createModsListDialog(
+      "category-mods-manage-dialog",
+      `Manage Mods - ${categoryMeta ? categoryMeta.name : category}`,
+      () => openManageCustomModsDialog()
+    );
+    window.__roseManageCategory = category;
+
+    if (bridge) bridge.send({
+      type: "request-category-mods",
+      category: category,
+    });
+  }
+
+  function handleManageCategoryModsResponse(payload) {
+    if (payload.category !== window.__roseManageCategory) return;
+
+    const listContainer = document.getElementById("category-mods-manage-dialog-list");
+    if (!listContainer) return;
+
+    listContainer.innerHTML = "";
+    const mods = payload.mods || [];
+    if (mods.length === 0) {
+      listContainer.innerHTML = `<div style="color: #cdbe91; text-align: center; padding: 20px; font-family: 'Beaufort for LOL', serif;">No custom mods installed in this category.</div>`;
+      return;
+    }
+
+    mods.forEach((mod) => {
+      renderModRow(listContainer, { name: mod.name }, (deleteButton) => {
+        deleteButton.disabled = true;
+        deleteButton.textContent = "Deleting...";
+        if (bridge) bridge.send({
+          type: "delete-category-mod",
+          category: window.__roseManageCategory,
+          modName: mod.name,
+        });
+      });
+    });
+  }
+
+  function handleCategoryModDeleted(payload) {
+    if (!payload.success) {
+      log("error", "Failed to delete category mod: " + (payload.error || "unknown error"));
+      return;
+    }
+    log("info", `Category mod deleted: category=${payload.category}, mod=${payload.modName}`);
+    if (payload.category === window.__roseManageCategory) {
+      openCategoryModsList(payload.category);
+    }
   }
 
   function handleChampionsListResponse(payload) {
@@ -3988,6 +4432,10 @@
       bridge.subscribe("champions-list-response", handleChampionsListResponse);
       bridge.subscribe("champion-skins-response", handleChampionSkinsResponse);
       bridge.subscribe("folder-opened-response", handleFolderOpenedResponse);
+      bridge.subscribe("skin-mods-response", handleManageSkinModsResponse);
+      bridge.subscribe("category-mods-response", handleManageCategoryModsResponse);
+      bridge.subscribe("champion-mod-deleted", handleChampionModDeleted);
+      bridge.subscribe("category-mod-deleted", handleCategoryModDeleted);
 
       // On every (re)connect, sync state
       bridge.onReady(() => {

--- a/injection/mods/storage.py
+++ b/injection/mods/storage.py
@@ -450,6 +450,117 @@ class ModStorageService:
             safe_remove_entry(temporary_dir)
             raise
 
+    def _resolve_mod_path(self, base_dir: Path, relative_path: object) -> Optional[Path]:
+        """Resolve a user-supplied relative path, guarding against traversal."""
+        if not relative_path:
+            return None
+        try:
+            candidate = (self.mods_root / str(relative_path)).resolve()
+            base_resolved = base_dir.resolve()
+        except OSError:
+            return None
+        if base_resolved != candidate and base_resolved not in candidate.parents:
+            return None
+        return candidate
+
+    def delete_champion_mod(
+        self,
+        champion_id: int | str,
+        mod_name: Optional[str] = None,
+        relative_path: Optional[str] = None,
+    ) -> bool:
+        """Delete one previously imported mod from a champion's mod folder."""
+        champion_id_int = self._to_int(champion_id)
+        if champion_id_int is None or champion_id_int <= 0:
+            raise ValueError(f"Invalid champion ID: {champion_id}")
+
+        with self._storage_lock:
+            champion_dir = self.get_champion_dir(champion_id_int)
+            target = self._resolve_mod_path(champion_dir, relative_path)
+            if target is None and mod_name:
+                try:
+                    champion_relative = champion_dir.relative_to(self.mods_root).as_posix()
+                except ValueError:
+                    champion_relative = None
+                if champion_relative:
+                    target = self._resolve_mod_path(champion_dir, f"{champion_relative}/{mod_name}")
+            if target is None or not target.exists():
+                return False
+            if target.name in {self.TARGET_METADATA, self.LEGACY_TARGET_METADATA}:
+                raise ValueError("Refusing to delete mod metadata file")
+
+            resolved_mod_name = mod_name or target.stem
+            safe_remove_entry(target)
+
+            default_targets, mod_targets = self._load_target_manifest(champion_id_int)
+            removed = False
+            for key in list(mod_targets.keys()):
+                metadata = mod_targets[key]
+                stored_name = str(metadata.get("name") or key)
+                if key == resolved_mod_name or stored_name == resolved_mod_name or key == target.name or stored_name == target.name:
+                    mod_targets.pop(key, None)
+                    removed = True
+
+            if removed:
+                manifest_path = champion_dir / self.TARGET_METADATA
+                payload = {
+                    "version": 1,
+                    "championId": champion_id_int,
+                    "targets": list(default_targets),
+                    "mods": dict(sorted(mod_targets.items())),
+                }
+                temporary_path = manifest_path.with_name(f".{manifest_path.name}.tmp")
+                temporary_path.write_text(
+                    json.dumps(payload, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
+                temporary_path.replace(manifest_path)
+
+            self._champion_listing_cache.pop(champion_id_int, None)
+            return True
+
+    def delete_category_mod(self, category: str, mod_name: str) -> bool:
+        """Delete one previously imported mod from a category folder."""
+        if category not in self.MOD_CATEGORIES:
+            raise ValueError(f"Unsupported mod category: {category}")
+        if not mod_name:
+            raise ValueError("Mod name is required")
+
+        with self._storage_lock:
+            category_dir = self.mods_root / category
+            resolved = self._resolve_mod_path(category_dir, f"{category}/{mod_name}")
+            if resolved is None or not resolved.exists():
+                return False
+            if resolved.name == self.CATEGORY_METADATA:
+                raise ValueError("Refusing to delete mod metadata file")
+
+            safe_remove_entry(resolved)
+
+            manifest_path = category_dir / self.CATEGORY_METADATA
+            try:
+                payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except (OSError, TypeError, ValueError, json.JSONDecodeError):
+                payload = {}
+            if not isinstance(payload, dict):
+                payload = {}
+            raw_mods = payload.get("mods")
+            mods = dict(raw_mods) if isinstance(raw_mods, dict) else {}
+            if mod_name in mods:
+                mods.pop(mod_name, None)
+                payload.update({
+                    "version": 1,
+                    "category": category,
+                    "mods": dict(sorted(mods.items())),
+                })
+                temporary_manifest = manifest_path.with_name(f".{manifest_path.name}.tmp")
+                temporary_manifest.write_text(
+                    json.dumps(payload, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
+                temporary_manifest.replace(manifest_path)
+
+            return True
+
     def _load_category_manifest(self, category: str) -> set[str]:
         manifest_path = self.mods_root / category / self.CATEGORY_METADATA
         try:

--- a/injection/mods/storage.py
+++ b/injection/mods/storage.py
@@ -39,6 +39,7 @@ class SkinModEntry:
     updated_at: float
     description: Optional[str] = None
     target_skin_ids: tuple[int, ...] = ()
+    display_name: Optional[str] = None
 
 
 class ModStorageService:
@@ -294,31 +295,32 @@ class ModStorageService:
                 continue
         return folder_hash.hexdigest(), wad_hashes
 
-    def _get_manifest_targets_for_mod(
+    def _resolve_mod_metadata(
         self,
         candidate: Path,
         mod_name: str,
         mod_targets: dict[str, dict],
-    ) -> tuple[int, ...]:
+    ) -> Optional[dict]:
+        """Return the manifest metadata dict for a mod, or None if unmatched."""
         named_metadata = mod_targets.get(mod_name)
 
         # Imported mods store their stable metadata under a content hash, but
         # also retain the original folder name.  Use that cheap lookup first;
         # hashing every WAD on every hover made the champ-select button wait
         # for the entire mod tree to be read.
-        if named_metadata is not None:
-            return self._normalize_target_ids(named_metadata)
+        if isinstance(named_metadata, dict):
+            return named_metadata
         for metadata in mod_targets.values():
             if (
                 isinstance(metadata, dict)
                 and str(metadata.get("name") or "") == str(mod_name)
             ):
-                return self._normalize_target_ids(metadata)
+                return metadata
 
         # Legacy manifests may not have a per-mod mapping at all.  There is
         # nothing to match in that case, so avoid an unnecessary full hash.
         if not mod_targets:
-            return ()
+            return None
 
         # Only renamed/unmatched folders need the content-based fallback.
         folder_hash, wad_hashes = self._hash_mod_folder(candidate)
@@ -336,10 +338,28 @@ class ModStorageService:
                     and stored_wad_hashes == wad_hashes
                 )
             ):
-                return self._normalize_target_ids(metadata)
-        if named_metadata is not None:
-            return self._normalize_target_ids(named_metadata)
-        return ()
+                return metadata
+        return None
+
+    def _get_manifest_targets_for_mod(
+        self,
+        candidate: Path,
+        mod_name: str,
+        mod_targets: dict[str, dict],
+    ) -> tuple[int, ...]:
+        metadata = self._resolve_mod_metadata(candidate, mod_name, mod_targets)
+        if metadata is None:
+            return ()
+        return self._normalize_target_ids(metadata)
+
+    @staticmethod
+    def _extract_display_name(metadata: Optional[dict]) -> Optional[str]:
+        if not isinstance(metadata, dict):
+            return None
+        raw = metadata.get("displayName")
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()
+        return None
 
     def set_champion_target_ids(
         self,
@@ -363,18 +383,24 @@ class ModStorageService:
         if mod_name:
             if mod_path is not None:
                 folder_hash, wad_hashes = self._hash_mod_folder(Path(mod_path))
+                existing_display_name = None
                 for key, metadata in list(mod_targets.items()):
                     if key == folder_hash or (
                         isinstance(metadata, dict)
                         and metadata.get("folderHash") == folder_hash
                     ):
+                        if isinstance(metadata, dict):
+                            existing_display_name = self._extract_display_name(metadata)
                         mod_targets.pop(key, None)
-                mod_targets[folder_hash] = {
+                entry = {
                     "name": str(mod_name),
                     "folderHash": folder_hash,
                     "wadHashes": wad_hashes,
                     "targets": list(targets),
                 }
+                if existing_display_name:
+                    entry["displayName"] = existing_display_name
+                mod_targets[folder_hash] = entry
             else:
                 mod_targets[str(mod_name)] = {
                     "name": str(mod_name),
@@ -398,6 +424,146 @@ class ModStorageService:
         temporary_path.replace(manifest_path)
         self._champion_listing_cache.pop(champion_id_int, None)
         return manifest_path
+
+    MAX_DISPLAY_NAME_LENGTH = 100
+
+    def set_champion_mod_display_name(
+        self,
+        champion_id: int | str,
+        display_name: str,
+        mod_name: Optional[str] = None,
+        relative_path: Optional[str] = None,
+    ) -> str:
+        """Persist a user-facing display alias for an imported skin mod.
+
+        The mod's on-disk folder is left untouched; only the manifest entry
+        gains a ``displayName`` field, so target associations and any saved
+        selections that reference the folder path stay intact.
+        """
+        champion_id_int = self._to_int(champion_id)
+        if champion_id_int is None or champion_id_int <= 0:
+            raise ValueError(f"Invalid champion ID: {champion_id}")
+
+        clean_name = str(display_name or "").strip()[: self.MAX_DISPLAY_NAME_LENGTH]
+        if not clean_name:
+            raise ValueError("Display name cannot be empty")
+
+        with self._storage_lock:
+            champion_dir = self.get_champion_dir(champion_id_int)
+            manifest_path = champion_dir / self.TARGET_METADATA
+            try:
+                payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except (OSError, TypeError, ValueError, json.JSONDecodeError):
+                payload = None
+            if not isinstance(payload, dict):
+                raise ValueError("No mod manifest found for this champion")
+
+            raw_mods = payload.get("mods")
+            mods = dict(raw_mods) if isinstance(raw_mods, dict) else {}
+            if not mods:
+                raise ValueError("No mods registered for this champion")
+
+            # Match by folder/manifest name only. Hashing WADs here ran on the
+            # WebSocket event loop and could stall past ping_timeout, so the
+            # UI never received champion-mod-renamed and stayed on "Saving...".
+            name_candidates = []
+            if mod_name:
+                name_candidates.append(str(mod_name))
+            target_path = self._resolve_mod_path(champion_dir, relative_path)
+            if target_path is not None:
+                name_candidates.append(target_path.name)
+            name_candidates = list(dict.fromkeys(name_candidates))
+
+            matched_key = None
+            for candidate_name in name_candidates:
+                for key, metadata in mods.items():
+                    stored_name = metadata.get("name") if isinstance(metadata, dict) else None
+                    if key == candidate_name or str(stored_name or "") == candidate_name:
+                        matched_key = key
+                        break
+                if matched_key is not None:
+                    break
+            if matched_key is None:
+                raise ValueError("Mod not found in manifest")
+
+            entry = mods[matched_key]
+            if not isinstance(entry, dict):
+                entry = {"name": str(mod_name or matched_key)}
+            entry["displayName"] = clean_name
+            mods[matched_key] = entry
+
+            payload["mods"] = dict(sorted(mods.items()))
+            payload.setdefault("version", 1)
+            payload.setdefault("championId", champion_id_int)
+
+            temporary_path = manifest_path.with_name(f".{manifest_path.name}.tmp")
+            temporary_path.write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            temporary_path.replace(manifest_path)
+            self._champion_listing_cache.pop(champion_id_int, None)
+            return clean_name
+
+    def set_category_mod_display_name(
+        self,
+        category: str,
+        mod_name: str,
+        display_name: str,
+    ) -> str:
+        """Persist a user-facing display alias for a category mod."""
+        if category not in self.MOD_CATEGORIES:
+            raise ValueError(f"Unsupported mod category: {category}")
+        if not mod_name:
+            raise ValueError("Mod name is required")
+
+        clean_name = str(display_name or "").strip()[: self.MAX_DISPLAY_NAME_LENGTH]
+        if not clean_name:
+            raise ValueError("Display name cannot be empty")
+
+        with self._storage_lock:
+            category_dir = self.mods_root / category
+            manifest_path = category_dir / self.CATEGORY_METADATA
+            try:
+                payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except (OSError, TypeError, ValueError, json.JSONDecodeError):
+                payload = {}
+            if not isinstance(payload, dict):
+                payload = {}
+
+            raw_mods = payload.get("mods")
+            mods = dict(raw_mods) if isinstance(raw_mods, dict) else {}
+
+            matched_key = None
+            if mod_name in mods:
+                matched_key = mod_name
+            else:
+                for key, metadata in mods.items():
+                    stored = metadata.get("path") if isinstance(metadata, dict) else None
+                    if str(stored or key) == str(mod_name):
+                        matched_key = key
+                        break
+            if matched_key is None:
+                raise ValueError("Mod not found in manifest")
+
+            entry = mods[matched_key]
+            if not isinstance(entry, dict):
+                entry = {"name": matched_key, "path": matched_key}
+            entry["displayName"] = clean_name
+            mods[matched_key] = entry
+
+            payload.update({
+                "version": 1,
+                "category": category,
+                "mods": dict(sorted(mods.items())),
+            })
+            temporary_manifest = manifest_path.with_name(f".{manifest_path.name}.tmp")
+            temporary_manifest.write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            temporary_manifest.replace(manifest_path)
+            return clean_name
 
     def import_mod_file(
         self,
@@ -463,6 +629,32 @@ class ModStorageService:
             return None
         return candidate
 
+    @staticmethod
+    def _is_unsafe_mod_identity(value: object) -> bool:
+        name = str(value or "").strip().replace("\\", "/")
+        if not name or name in {".", ".."}:
+            return True
+        return any(part in {".", ".."} for part in name.split("/"))
+
+    def _is_direct_mod_entry(self, base_dir: Path, target: Optional[Path]) -> bool:
+        """True when target is a single child of base_dir, not the container itself."""
+        if target is None:
+            return False
+        try:
+            base_resolved = base_dir.resolve()
+            target_resolved = target.resolve()
+        except OSError:
+            return False
+        if target_resolved.name in {
+            self.TARGET_METADATA,
+            self.LEGACY_TARGET_METADATA,
+            self.CATEGORY_METADATA,
+            ".",
+            "..",
+        }:
+            return False
+        return target_resolved != base_resolved and target_resolved.parent == base_resolved
+
     def delete_champion_mod(
         self,
         champion_id: int | str,
@@ -474,17 +666,24 @@ class ModStorageService:
         if champion_id_int is None or champion_id_int <= 0:
             raise ValueError(f"Invalid champion ID: {champion_id}")
 
+        if self._is_unsafe_mod_identity(mod_name) and self._is_unsafe_mod_identity(relative_path):
+            return False
+        if self._is_unsafe_mod_identity(mod_name) and not relative_path:
+            return False
+
         with self._storage_lock:
             champion_dir = self.get_champion_dir(champion_id_int)
-            target = self._resolve_mod_path(champion_dir, relative_path)
-            if target is None and mod_name:
+            target = None
+            if relative_path and not self._is_unsafe_mod_identity(relative_path):
+                target = self._resolve_mod_path(champion_dir, relative_path)
+            if target is None and mod_name and not self._is_unsafe_mod_identity(mod_name):
                 try:
                     champion_relative = champion_dir.relative_to(self.mods_root).as_posix()
                 except ValueError:
                     champion_relative = None
                 if champion_relative:
                     target = self._resolve_mod_path(champion_dir, f"{champion_relative}/{mod_name}")
-            if target is None or not target.exists():
+            if not self._is_direct_mod_entry(champion_dir, target) or not target.exists():
                 return False
             if target.name in {self.TARGET_METADATA, self.LEGACY_TARGET_METADATA}:
                 raise ValueError("Refusing to delete mod metadata file")
@@ -523,13 +722,13 @@ class ModStorageService:
         """Delete one previously imported mod from a category folder."""
         if category not in self.MOD_CATEGORIES:
             raise ValueError(f"Unsupported mod category: {category}")
-        if not mod_name:
-            raise ValueError("Mod name is required")
+        if not mod_name or self._is_unsafe_mod_identity(mod_name):
+            return False
 
         with self._storage_lock:
             category_dir = self.mods_root / category
             resolved = self._resolve_mod_path(category_dir, f"{category}/{mod_name}")
-            if resolved is None or not resolved.exists():
+            if not self._is_direct_mod_entry(category_dir, resolved) or not resolved.exists():
                 return False
             if resolved.name == self.CATEGORY_METADATA:
                 raise ValueError("Refusing to delete mod metadata file")
@@ -680,11 +879,8 @@ class ModStorageService:
             except OSError:
                 updated_at = 0.0
 
-            target_skin_ids = self._get_manifest_targets_for_mod(
-                candidate,
-                mod_name,
-                mod_targets,
-            )
+            metadata = self._resolve_mod_metadata(candidate, mod_name, mod_targets)
+            target_skin_ids = self._normalize_target_ids(metadata) if metadata else ()
             if not target_skin_ids:
                 target_skin_ids = default_targets
             if not target_skin_ids:
@@ -700,6 +896,7 @@ class ModStorageService:
                     updated_at=updated_at,
                     description=self._read_mod_description(candidate),
                     target_skin_ids=tuple(target_skin_ids),
+                    display_name=self._extract_display_name(metadata),
                 )
             )
         return entries
@@ -793,6 +990,7 @@ class ModStorageService:
             return []
 
         registered_mods = self._load_category_manifest(category)
+        display_names = self._load_category_display_names(category)
         entries = []
         for candidate in sorted(category_dir.iterdir(), key=lambda p: p.name.lower()):
             if not candidate.is_dir() or candidate.name == self.CATEGORY_METADATA:
@@ -800,26 +998,51 @@ class ModStorageService:
             mod_name = candidate.name
             if mod_name.casefold() not in registered_mods:
                 continue
-            
+
             try:
                 updated_at = candidate.stat().st_mtime
             except OSError:
                 updated_at = 0.0
-            
+
             try:
                 relative_path = candidate.relative_to(self.mods_root)
             except Exception:
                 relative_path = candidate
-            
+
             entries.append({
                 "id": str(relative_path).replace("\\", "/"),
                 "name": mod_name,
+                "displayName": display_names.get(mod_name.casefold()),
                 "path": str(relative_path).replace("\\", "/"),
                 "updatedAt": updated_at,
                 "description": self._read_mod_description(candidate),
             })
-        
+
         return entries
+
+    def _load_category_display_names(self, category: str) -> dict[str, str]:
+        """Map registered mod paths (casefolded) to their display aliases."""
+        manifest_path = self.mods_root / category / self.CATEGORY_METADATA
+        try:
+            payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return {}
+        if not isinstance(payload, dict):
+            return {}
+        raw_mods = payload.get("mods") or {}
+        if not isinstance(raw_mods, dict):
+            return {}
+
+        display_names: dict[str, str] = {}
+        for mod_key, raw_metadata in raw_mods.items():
+            metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
+            display = metadata.get("displayName")
+            if not isinstance(display, str) or not display.strip():
+                continue
+            mod_path = str(metadata.get("path") or mod_key).replace("\\", "/").strip("/")
+            if mod_path and "/" not in mod_path:
+                display_names[mod_path.casefold()] = display.strip()
+        return display_names
 
     @staticmethod
     def _to_int(value: int | str) -> Optional[int]:

--- a/pengu/communication/broadcaster.py
+++ b/pengu/communication/broadcaster.py
@@ -198,6 +198,12 @@ class Broadcaster:
         selected_custom_mod = getattr(self.shared_state, 'selected_custom_mod', None)
         active = selected_custom_mod is not None
         mod_name = selected_custom_mod.get("mod_name") if selected_custom_mod else None
+        raw_display_name = selected_custom_mod.get("display_name") if selected_custom_mod else None
+        display_name = (
+            raw_display_name.strip()
+            if isinstance(raw_display_name, str) and raw_display_name.strip()
+            else None
+        )
         skin_id = selected_custom_mod.get("skin_id") if selected_custom_mod else None
         champion_id = selected_custom_mod.get("champion_id") if selected_custom_mod else None
         relative_path = selected_custom_mod.get("relative_path") if selected_custom_mod else None
@@ -210,6 +216,7 @@ class Broadcaster:
             "type": "custom-mod-state",
             "active": active,
             "modName": mod_name,
+            "displayName": display_name,
             "skinId": skin_id,
             "championId": champion_id,
             "relativePath": relative_path,

--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -183,6 +183,10 @@ class MessageHandler:
             self._handle_open_mods_folder(payload)
         elif payload_type == "request-skin-mods":
             self._handle_request_skin_mods(payload)
+        elif payload_type == "request-manage-champion-mods":
+            self._handle_request_manage_champion_mods(payload)
+        elif payload_type == "request-manage-category-mods":
+            self._handle_request_manage_category_mods(payload)
         elif payload_type == "request-maps":
             self._handle_request_maps(payload)
         elif payload_type == "request-fonts":
@@ -234,6 +238,10 @@ class MessageHandler:
             self._handle_delete_champion_mod(payload)
         elif payload_type == "delete-category-mod":
             self._handle_delete_category_mod(payload)
+        elif payload_type == "rename-champion-mod":
+            self._handle_rename_champion_mod(payload)
+        elif payload_type == "rename-category-mod":
+            self._handle_rename_category_mod(payload)
         elif payload_type == "dismiss-historic":
             self._handle_dismiss_historic(payload)
         # Party mode messages
@@ -868,6 +876,7 @@ class MessageHandler:
             mods_payload.append(
                 {
                     "modName": entry.mod_name,
+                    "displayName": entry.display_name,
                     "skinId": entry.skin_id,
                     "targetSkinIds": sorted(target_skin_ids),
                     "availableForRequestedSkin": bool(target_skin_ids & compatible_skin_ids),
@@ -916,6 +925,103 @@ class MessageHandler:
             "timestamp": int(time.time() * 1000),
         }
         self._send_response(json.dumps(response_payload))
+
+    def _lookup_champion_name(self, champion_id: object) -> Optional[str]:
+        try:
+            champ_id = int(champion_id)
+        except (TypeError, ValueError):
+            return None
+        scraper = getattr(self, "skin_scraper", None)
+        lcu = getattr(scraper, "lcu", None) if scraper else None
+        if not lcu or not getattr(lcu, "ok", False):
+            return None
+        try:
+            champion_data = lcu.get(
+                f"/lol-game-data/assets/v1/champions/{champ_id}.json",
+                timeout=5.0,
+            )
+        except Exception:
+            return None
+        if not isinstance(champion_data, dict):
+            return None
+        name = champion_data.get("name")
+        return str(name) if name else None
+
+    def _serialize_manage_champion_mods(self, entries) -> list[dict]:
+        mods_payload = []
+        for entry in entries:
+            target_skin_ids = self._get_entry_target_skin_ids(entry)
+            try:
+                relative_path = entry.path.relative_to(self.mod_storage.mods_root)
+            except Exception:
+                relative_path = entry.path
+            thumbnail_relative_path = None
+            thumbnail_url = None
+            try:
+                if entry.path.is_dir():
+                    thumbnail_path = entry.path / "META" / "image.png"
+                    if thumbnail_path.exists() and thumbnail_path.is_file():
+                        thumbnail_relative_path = str(
+                            thumbnail_path.relative_to(self.mod_storage.mods_root)
+                        ).replace("\\", "/")
+                        quoted_path = quote(thumbnail_relative_path, safe="/")
+                        thumbnail_url = f"http://127.0.0.1:{self.port}/mod-asset/{quoted_path}"
+            except Exception:
+                pass
+            mods_payload.append(
+                {
+                    "modName": entry.mod_name,
+                    "displayName": entry.display_name,
+                    "skinId": entry.skin_id,
+                    "targetSkinIds": sorted(target_skin_ids),
+                    "description": entry.description,
+                    "updatedAt": int(entry.updated_at * 1000),
+                    "relativePath": str(relative_path).replace("\\", "/"),
+                    "thumbnailRelativePath": thumbnail_relative_path,
+                    "thumbnailUrl": thumbnail_url,
+                }
+            )
+        return mods_payload
+
+    def _handle_request_manage_champion_mods(self, payload: dict) -> None:
+        """List champion mods for the Settings manage UI without touching champ-select state."""
+        if not self.mod_storage:
+            return
+        champion_id = payload.get("championId")
+        if not champion_id:
+            return
+        try:
+            entries = self.mod_storage.list_mods_for_champion(champion_id)
+        except Exception as exc:
+            log.error("[ManageMods] Failed to list champion mods: %s", exc)
+            entries = []
+        self._send_response(json.dumps({
+            "type": "manage-champion-mods-response",
+            "championId": champion_id,
+            "championName": self._lookup_champion_name(champion_id),
+            "mods": self._serialize_manage_champion_mods(entries),
+            "timestamp": int(time.time() * 1000),
+        }))
+
+    def _handle_request_manage_category_mods(self, payload: dict) -> None:
+        """List category mods for the Settings manage UI without historic auto-select."""
+        if not self.mod_storage:
+            return
+        category = payload.get("category")
+        if category not in self.mod_storage.MOD_CATEGORIES:
+            log.warning("[ManageMods] Invalid category: %s", category)
+            return
+        try:
+            mods = self.mod_storage.list_mods_for_category(category)
+        except Exception as exc:
+            log.error("[ManageMods] Failed to list category %s: %s", category, exc)
+            mods = []
+        self._send_response(json.dumps({
+            "type": "manage-category-mods-response",
+            "category": category,
+            "mods": mods,
+            "timestamp": int(time.time() * 1000),
+        }))
 
     def _get_compatible_skin_ids(self, skin_id: int | str) -> set[int]:
         """Return storage skin IDs that can be used for a requested skin.
@@ -1008,6 +1114,7 @@ class MessageHandler:
             result.update(
                 {
                     "modName": selected_mod.mod_name,
+                    "displayName": selected_mod.display_name,
                     "relativePath": str(relative_path).replace(chr(92), "/"),
                     "targetSkinId": payload.get("skinId"),
                     "storageSkinId": selected_mod.skin_id,
@@ -1430,6 +1537,7 @@ class MessageHandler:
                 "target_skin_ids": sorted(self._get_entry_target_skin_ids(selected_mod)),
                 "champion_id": champion_id,
                 "mod_name": selected_mod.mod_name,
+                "display_name": selected_mod.display_name,
                 "mod_path": str(selected_mod.path),
                 "mod_folder_name": mod_folder_name,  # Add this for injection
                 "relative_path": str(selected_mod.path.relative_to(self.mod_storage.mods_root)).replace("\\", "/"),
@@ -1610,6 +1718,60 @@ class MessageHandler:
                 "error": str(exc),
             }))
 
+    def _clear_category_selection_if_matches(self, category: object, mod_name: object) -> None:
+        """Clear live selection and mod historic if they point at the deleted category mod."""
+        if not category or not mod_name:
+            return
+        target = f"{category}/{mod_name}".replace("\\", "/")
+
+        def _same_path(value: object) -> bool:
+            return bool(value) and str(value).replace("\\", "/") == target
+
+        single_attr = {
+            "maps": ("selected_map_mod", "map"),
+            "fonts": ("selected_font_mod", "font"),
+            "announcers": ("selected_announcer_mod", "announcer"),
+        }.get(str(category))
+        if single_attr:
+            attr, historic_key = single_attr
+            selected = getattr(self.shared_state, attr, None)
+            if isinstance(selected, dict) and _same_path(selected.get("relative_path")):
+                setattr(self.shared_state, attr, None)
+            try:
+                from utils.core.mod_historic import clear_historic_mod, get_historic_mod
+                historic_value = get_historic_mod(historic_key)
+                if _same_path(historic_value):
+                    clear_historic_mod(historic_key)
+            except Exception as exc:
+                log.debug("[DeleteMod] Failed to clear category historic: %s", exc)
+            return
+
+        selected_others = list(getattr(self.shared_state, "selected_other_mods", None) or [])
+        remaining = [
+            item for item in selected_others
+            if not (isinstance(item, dict) and _same_path(item.get("relative_path")))
+        ]
+        if len(remaining) != len(selected_others):
+            self.shared_state.selected_other_mods = remaining
+        try:
+            from utils.core.mod_historic import (
+                clear_historic_mod,
+                get_historic_mod,
+                write_historic_mod,
+            )
+            historic_value = get_historic_mod(str(category))
+            if isinstance(historic_value, list):
+                kept = [path for path in historic_value if not _same_path(path)]
+                if len(kept) != len(historic_value):
+                    if kept:
+                        write_historic_mod(str(category), kept)
+                    else:
+                        clear_historic_mod(str(category))
+            elif _same_path(historic_value):
+                clear_historic_mod(str(category))
+        except Exception as exc:
+            log.debug("[DeleteMod] Failed to clear category historic: %s", exc)
+
     def _handle_delete_category_mod(self, payload: dict) -> None:
         """Permanently delete an imported mod from a category folder."""
         category = payload.get("category")
@@ -1626,6 +1788,7 @@ class MessageHandler:
         try:
             deleted = self.mod_storage.delete_category_mod(category, mod_name)
             if deleted:
+                self._clear_category_selection_if_matches(category, mod_name)
                 log.info(
                     "[DeleteMod] Deleted category mod: category=%s, mod=%s",
                     category,
@@ -1644,6 +1807,134 @@ class MessageHandler:
             log.error("[DeleteMod] Failed to delete category mod: %s", exc)
             self._send_response(json.dumps({
                 "type": "category-mod-deleted",
+                "success": False,
+                "category": category,
+                "modName": mod_name,
+                "error": str(exc),
+            }))
+
+    def _sync_selected_custom_mod_display_name(
+        self,
+        champion_id: object,
+        relative_path: object,
+        mod_name: object,
+        display_name: str,
+    ) -> None:
+        """Keep the live selection/popup in sync after a display-name rename."""
+        selected = getattr(self.shared_state, "selected_custom_mod", None)
+        if not isinstance(selected, dict):
+            return
+
+        selected_rel = str(selected.get("relative_path") or "").replace("\\", "/")
+        target_rel = str(relative_path or "").replace("\\", "/")
+        same_path = bool(target_rel) and selected_rel == target_rel
+        try:
+            same_champion = (
+                champion_id is not None
+                and selected.get("champion_id") is not None
+                and int(selected.get("champion_id")) == int(champion_id)
+            )
+        except (TypeError, ValueError):
+            same_champion = False
+        same_name = bool(mod_name) and selected.get("mod_name") == mod_name
+        if not (same_path or (same_champion and same_name)):
+            return
+
+        selected["display_name"] = display_name
+        try:
+            if hasattr(self.shared_state, "ui_skin_thread") and self.shared_state.ui_skin_thread:
+                self.shared_state.ui_skin_thread._broadcast_custom_mod_state()
+        except Exception as exc:
+            log.debug("[RenameMod] Failed to broadcast custom mod state: %s", exc)
+
+    def _handle_rename_champion_mod(self, payload: dict) -> None:
+        """Set a display alias for an imported skin mod (folder is untouched)."""
+        champion_id = payload.get("championId")
+        mod_name = payload.get("modName")
+        relative_path = payload.get("relativePath")
+        new_name = payload.get("newName")
+        if not self.mod_storage:
+            self._send_response(json.dumps({
+                "type": "champion-mod-renamed",
+                "success": False,
+                "championId": champion_id,
+                "modName": mod_name,
+                "error": "Mod storage is not available",
+            }))
+            return
+        try:
+            display_name = self.mod_storage.set_champion_mod_display_name(
+                champion_id,
+                new_name,
+                mod_name=mod_name,
+                relative_path=relative_path,
+            )
+            self._sync_selected_custom_mod_display_name(
+                champion_id,
+                relative_path,
+                mod_name,
+                display_name,
+            )
+            log.info(
+                "[RenameMod] Renamed champion mod: champion=%s, mod=%s -> %s",
+                champion_id,
+                mod_name,
+                display_name,
+            )
+            self._send_response(json.dumps({
+                "type": "champion-mod-renamed",
+                "success": True,
+                "championId": champion_id,
+                "modName": mod_name,
+                "displayName": display_name,
+            }))
+        except Exception as exc:
+            log.error("[RenameMod] Failed to rename champion mod: %s", exc)
+            self._send_response(json.dumps({
+                "type": "champion-mod-renamed",
+                "success": False,
+                "championId": champion_id,
+                "modName": mod_name,
+                "error": str(exc),
+            }))
+
+    def _handle_rename_category_mod(self, payload: dict) -> None:
+        """Set a display alias for a category mod (folder is untouched)."""
+        category = payload.get("category")
+        mod_name = payload.get("modName")
+        new_name = payload.get("newName")
+        if not self.mod_storage:
+            self._send_response(json.dumps({
+                "type": "category-mod-renamed",
+                "success": False,
+                "category": category,
+                "modName": mod_name,
+                "error": "Mod storage is not available",
+            }))
+            return
+        try:
+            display_name = self.mod_storage.set_category_mod_display_name(
+                category,
+                mod_name,
+                new_name,
+            )
+            log.info(
+                "[RenameMod] Renamed category mod: category=%s, mod=%s -> %s",
+                category,
+                mod_name,
+                display_name,
+            )
+            self._send_response(json.dumps({
+                "type": "category-mod-renamed",
+                "success": True,
+                "category": category,
+                "modName": mod_name,
+                "displayName": display_name,
+            }))
+        except Exception as exc:
+            log.error("[RenameMod] Failed to rename category mod: %s", exc)
+            self._send_response(json.dumps({
+                "type": "category-mod-renamed",
                 "success": False,
                 "category": category,
                 "modName": mod_name,

--- a/pengu/communication/message_handler.py
+++ b/pengu/communication/message_handler.py
@@ -230,6 +230,10 @@ class MessageHandler:
             self._handle_find_match_hover(payload)
         elif payload_type == "dismiss-custom-mod":
             self._handle_dismiss_custom_mod(payload)
+        elif payload_type == "delete-champion-mod":
+            self._handle_delete_champion_mod(payload)
+        elif payload_type == "delete-category-mod":
+            self._handle_delete_category_mod(payload)
         elif payload_type == "dismiss-historic":
             self._handle_dismiss_historic(payload)
         # Party mode messages
@@ -1526,6 +1530,126 @@ class MessageHandler:
         except Exception as exc:
             log.debug("[Dismiss] Failed to broadcast custom mod state: %s", exc)
 
+    def _clear_active_selection_if_matches(self, champion_id: object, relative_path: object) -> None:
+        """Clear the active/historic custom mod selection if it points at the deleted mod."""
+        if not relative_path:
+            return
+        normalized_target = str(relative_path).replace("\\", "/")
+
+        selected = getattr(self.shared_state, "selected_custom_mod", None)
+        if selected:
+            selected_rel = selected.get("relative_path")
+            if selected_rel and str(selected_rel).replace("\\", "/") == normalized_target:
+                self.shared_state.selected_custom_mod = None
+                try:
+                    if hasattr(self.shared_state, "ui_skin_thread") and self.shared_state.ui_skin_thread:
+                        self.shared_state.ui_skin_thread._broadcast_custom_mod_state()
+                except Exception as exc:
+                    log.debug("[DeleteMod] Failed to broadcast custom mod state: %s", exc)
+
+        try:
+            from utils.core.historic import (
+                clear_historic_entry,
+                get_historic_skin_for_champion,
+                is_custom_mod_path,
+                get_custom_mod_path,
+            )
+            if champion_id:
+                historic_value = get_historic_skin_for_champion(int(champion_id))
+                if historic_value is not None and is_custom_mod_path(historic_value):
+                    historic_path = get_custom_mod_path(historic_value)
+                    if historic_path and historic_path.replace("\\", "/") == normalized_target:
+                        clear_historic_entry(int(champion_id))
+                        log.info("[DeleteMod] Cleared historic entry for champion %s", champion_id)
+        except Exception as exc:
+            log.debug("[DeleteMod] Failed to clear historic entry: %s", exc)
+
+    def _handle_delete_champion_mod(self, payload: dict) -> None:
+        """Permanently delete an imported skin mod from a champion's mod folder."""
+        champion_id = payload.get("championId")
+        mod_name = payload.get("modName")
+        relative_path = payload.get("relativePath")
+        if not self.mod_storage:
+            self._send_response(json.dumps({
+                "type": "champion-mod-deleted",
+                "success": False,
+                "championId": champion_id,
+                "modName": mod_name,
+                "error": "Mod storage is not available",
+            }))
+            return
+        try:
+            deleted = self.mod_storage.delete_champion_mod(
+                champion_id,
+                mod_name=mod_name,
+                relative_path=relative_path,
+            )
+            if deleted:
+                self._clear_active_selection_if_matches(champion_id, relative_path)
+                log.info(
+                    "[DeleteMod] Deleted champion mod: champion=%s, mod=%s",
+                    champion_id,
+                    mod_name,
+                )
+            response_payload = {
+                "type": "champion-mod-deleted",
+                "success": deleted,
+                "championId": champion_id,
+                "modName": mod_name,
+            }
+            if not deleted:
+                response_payload["error"] = "Mod not found"
+            self._send_response(json.dumps(response_payload))
+        except Exception as exc:
+            log.error("[DeleteMod] Failed to delete champion mod: %s", exc)
+            self._send_response(json.dumps({
+                "type": "champion-mod-deleted",
+                "success": False,
+                "championId": champion_id,
+                "modName": mod_name,
+                "error": str(exc),
+            }))
+
+    def _handle_delete_category_mod(self, payload: dict) -> None:
+        """Permanently delete an imported mod from a category folder."""
+        category = payload.get("category")
+        mod_name = payload.get("modName")
+        if not self.mod_storage:
+            self._send_response(json.dumps({
+                "type": "category-mod-deleted",
+                "success": False,
+                "category": category,
+                "modName": mod_name,
+                "error": "Mod storage is not available",
+            }))
+            return
+        try:
+            deleted = self.mod_storage.delete_category_mod(category, mod_name)
+            if deleted:
+                log.info(
+                    "[DeleteMod] Deleted category mod: category=%s, mod=%s",
+                    category,
+                    mod_name,
+                )
+            response_payload = {
+                "type": "category-mod-deleted",
+                "success": deleted,
+                "category": category,
+                "modName": mod_name,
+            }
+            if not deleted:
+                response_payload["error"] = "Mod not found"
+            self._send_response(json.dumps(response_payload))
+        except Exception as exc:
+            log.error("[DeleteMod] Failed to delete category mod: %s", exc)
+            self._send_response(json.dumps({
+                "type": "category-mod-deleted",
+                "success": False,
+                "category": category,
+                "modName": mod_name,
+                "error": str(exc),
+            }))
+
     def _handle_dismiss_historic(self, payload: dict) -> None:
         """Dismiss historic mode (close-button on popup)"""
         try:
@@ -2021,14 +2145,7 @@ class MessageHandler:
             return
 
         category = payload.get("category")
-        if category not in {
-            self.mod_storage.CATEGORY_UI,
-            self.mod_storage.CATEGORY_VOICEOVER,
-            self.mod_storage.CATEGORY_LOADING_SCREEN,
-            self.mod_storage.CATEGORY_VFX,
-            self.mod_storage.CATEGORY_SFX,
-            self.mod_storage.CATEGORY_OTHERS,
-        }:
+        if category not in self.mod_storage.MOD_CATEGORIES:
             log.warning(f"[SkinMonitor] Invalid category for request-category-mods: {category}")
             return
 

--- a/threads/handlers/injection_trigger.py
+++ b/threads/handlers/injection_trigger.py
@@ -347,6 +347,7 @@ class InjectionTrigger:
                                 "target_skin_ids": sorted(target_skin_ids),
                                 "champion_id": champion_id,
                                 "mod_name": selected_mod_entry.mod_name,
+                                "display_name": selected_mod_entry.display_name,
                                 "mod_path": str(selected_mod_entry.path),
                                 "mod_folder_name": mod_folder_name,
                                 "relative_path": historic_custom_mod_path,


### PR DESCRIPTION
## The problem
Currently in Rose it is not possible to delete a custom mod from the UI. Users have to open the mods folder and delete it manually. The same applies to renaming a custom mod. This feature lets users manage their custom mods (delete and rename) inside Rose.

## Summary
Adds **Manage custom mods** in Settings Panel: list imported mods by champion or category, delete them, and set a display alias  (`displayName`) without renaming the folder on disk.
The alias shows up in Custom Skin Selector, Custom Wheel, and the historic popup. Folder path stays the stable id (historic, 
injection, selection).

## Feature Preview

https://github.com/user-attachments/assets/0283b82c-9d00-40c0-a742-1b1fcf6b3e2f

## How to test?

  - [ ] Manage -> Skins -> pick a champion -> rename a mod -> name updates in manage list, Custom Skin Selector, and Custom Wheel
  - [ ] Delete a skin mod and a category mod
  - [ ] Historic / selected mod still works after rename (folder was not renamed)